### PR TITLE
Improvements to handling of chapter headings in HTML version

### DIFF
--- a/headerdefault.txt
+++ b/headerdefault.txt
@@ -44,6 +44,9 @@ hr.full {width: 95%; margin-left: 2.5%; margin-right: 2.5%;}
 
 hr.r5  {width: 5%; margin-top: 1em; margin-bottom: 1em; margin-left: 47.5%; margin-right: 47.5%;}
 hr.r65 {width: 65%; margin-top: 3em; margin-bottom: 3em; margin-left: 17.5%; margin-right: 17.5%;}
+ 
+div.chapter {page-break-before: always;}
+h2.nobreak  {page-break-before: avoid;}
 
 ul.index { list-style-type: none; }
 li.ifrst { margin-top: 1em; }

--- a/lib/Guiguts/HTMLConvert.pm
+++ b/lib/Guiguts/HTMLConvert.pm
@@ -1154,6 +1154,11 @@ sub html_convert_chapterdivs {
 		}
 		$searchstart = $h2blockend . '+4l'; # ensure we don't find the same </h2 again
 	}
+	#remove excess blank lines between pagenum and h2 elements - leave 1 blank
+	my $selection = $textwindow->get( '1.0', 'end' );
+	$selection =~ s/\n+<h2/\n\n<h2/g;
+	$textwindow->ntdelete( '1.0', 'end' );
+	$textwindow->ntinsert( '1.0', $selection );
 }
 
 sub html_convert_underscoresmallcaps {


### PR DESCRIPTION
Ebookmaker uses div with a class of "chapter" to flag the start of a new chunk of the epub file, and default PP practice is to use this to surround each chapter heading. This reduces the chance of a chunk becoming too full at an inconvenient moment in the epub generation, which would cause an unwanted pagebreak at a random point in the book. These edits surround each h2 element with a chapter class div, also including the preceding page number if appropriate.