### PR TITLE
Surround h2 headings with chapter divs

### DIFF
--- a/headerdefault.txt
+++ b/headerdefault.txt
@@ -44,6 +44,9 @@ hr.full {width: 95%; margin-left: 2.5%; margin-right: 2.5%;}
 
 hr.r5  {width: 5%; margin-top: 1em; margin-bottom: 1em; margin-left: 47.5%; margin-right: 47.5%;}
 hr.r65 {width: 65%; margin-top: 3em; margin-bottom: 3em; margin-left: 17.5%; margin-right: 17.5%;}
+ 
+div.chapter {page-break-before: always;}
+h2.nobreak  {page-break-before: avoid;}
 
 ul.index { list-style-type: none; }
 li.ifrst { margin-top: 1em; }

--- a/lib/Guiguts/HTMLConvert.pm
+++ b/lib/Guiguts/HTMLConvert.pm
@@ -1032,6 +1032,10 @@ sub html_convert_body {
 			if ( not $selection =~ /<[ph]/ ) {
 				$textwindow->ntinsert( "$step.0",
 					"<h2 class=\"nobreak\" id=\"" . $aname . "\">" );
+				# remove surplus blank lines prior to h2
+				$textwindow->ntdelete( "$step.0-3l", "$step.0" );
+				$step -= 3;
+				
 				my $linesinheader=1;
 				while (1) {
 					$step++;
@@ -1066,12 +1070,12 @@ sub html_convert_body {
 				  . $completeheader
 				  . "</a><br />\n";
 			}
-			$selection .= '<h2>';
+			$selection .= '<h2';
 			$textwindow->see("$step.0");
 			$textwindow->update;
 
 			#open subheading with <p>
-		} elsif ( ( $last5[2] =~ /<h2>/ ) && ($selection) ) {
+		} elsif ( ( $last5[2] =~ /<h2/ ) && ($selection) ) {
 			$textwindow->ntinsert( "$step.0", '<p>' )
 			  unless ( ( $selection =~ /<[pd]/ )
 				|| ( $selection =~ /<[hb]r>/ )


### PR DESCRIPTION
A div with class "chapter" causes ebookmaker to create a new chunk in the epub file. Using them around every h2 is best practice, and helps to avoid mid-chapter pagebreaks occurring due to epub chunk size overflow.