### PR TITLE
All-small-caps, default flag and title settings changed for HTML generation

### DIFF
--- a/headerdefault.txt
+++ b/headerdefault.txt
@@ -70,7 +70,7 @@ table {
     left: 92%;
     font-size: smaller;
     text-align: right;
-    font-style:normal;
+    font-style: normal;
     font-weight: normal;
     font-variant: normal;
 } /* page numbers */
@@ -114,9 +114,11 @@ table {
 
 .center   {text-align: center;}
 
-.right   {text-align: right;}
+.right    {text-align: right;}
 
 .smcap    {font-variant: small-caps;}
+
+.allsmcap {font-variant: small-caps; text-transform: lowercase;}
 
 .u        {text-decoration: underline;}
 

--- a/headerdefault.txt
+++ b/headerdefault.txt
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html;charset=BOOKCHARSET" />
     <meta http-equiv="Content-Style-Type" content="text/css" />
     <title>
-      The Project Gutenberg eBook of TITLE, by AUTHOR.
+      TITLE, by AUTHOR&mdash;A Project Gutenberg eBook
     </title>
     <style type="text/css">
 

--- a/lib/Guiguts/HTMLConvert.pm
+++ b/lib/Guiguts/HTMLConvert.pm
@@ -1174,7 +1174,16 @@ sub html_convert_underscoresmallcaps {
 		$textwindow->search( '-exact', '--', '<sc>', '1.0', 'end' ) )
 	{
 		$textwindow->ntdelete( $thisblockstart, "$thisblockstart+4c" );
-		$textwindow->ntinsert( $thisblockstart, '<span class="smcap">' );
+		
+		# If text from here to next closing </sc> does not contain
+		# any Unicode lowercase letters, use allsmcap class.
+		my $thisblockend = '1.0';
+		if ( $thisblockend = $textwindow->search( '-exact', '--', '</sc>', $thisblockstart, 'end' ) and
+		     $textwindow->get( "$thisblockstart+1c", $thisblockend ) !~ /\p{Lowercase_Letter}/ ) {
+			$textwindow->ntinsert( $thisblockstart, '<span class="allsmcap">' );
+		} else {
+			$textwindow->ntinsert( $thisblockstart, '<span class="smcap">' );
+		}
 	}
 	while ( $thisblockstart =
 		$textwindow->search( '-exact', '--', '</sc>', '1.0', 'end' ) )

--- a/lib/Guiguts/HTMLConvert.pm
+++ b/lib/Guiguts/HTMLConvert.pm
@@ -2168,6 +2168,9 @@ sub htmlgenpopup {
 			-pady   => 2,
 			-sticky => 'w'
 		  );
+		# Preserve utf-8 characters by default, rather than converting to HTML named/numbered entities
+		$utfconvert->select;
+		
 		my $latin1_convert = $f0->Checkbutton(
 			-variable    => \$::lglobal{keep_latin1},
 			-selectcolor => $::lglobal{checkcolor},
@@ -2210,13 +2213,6 @@ sub htmlgenpopup {
 		$blockmarkup = $f0->Checkbutton(
 			-variable    => \$::lglobal{cssblockmarkup},
 			-selectcolor => $::lglobal{checkcolor},
-			-command     => sub {
-				if ( $::lglobal{cssblockmarkup} ) {
-					$blockmarkup->configure( '-text' => 'CSS blockquote' );
-				} else {
-					$blockmarkup->configure( '-text' => 'Std. <blockquote>' );
-				}
-			},
 			-text   => 'CSS blockquote',
 			-anchor => 'w',
 		  )->grid(
@@ -2226,6 +2222,8 @@ sub htmlgenpopup {
 			-pady   => 2,
 			-sticky => 'w'
 		  );
+		# By default, use <div> with CSS class rather than HTML <blockquote> element
+		$blockmarkup->select;
 
 		my $f7 =
 		  $::lglobal{htmlgenpop}->Frame->pack( -side => 'top', -anchor => 'n' );


### PR DESCRIPTION
Implemented all-small-caps when text in small caps has no lowercase letters.
Keep utf8 characters in HTML by default
Use div with CSS rather than HTML blockquote elements 