### PR TITLE
Self-closing anchor fails on some platforms

### DIFF
--- a/lib/Guiguts/HTMLConvert.pm
+++ b/lib/Guiguts/HTMLConvert.pm
@@ -1366,7 +1366,7 @@ sub html_convert_pageanchors {
 							$br = '';    # No page break for exportwithmarkup
 						} else {
 							$pagereference .= "$br"
-							  . "<a id=\"$::htmllabels{pglabel}$_\" />$::htmllabels{pgnumbefore}$_$::htmllabels{pgnumafter}";
+							  . "<a id=\"$::htmllabels{pglabel}$_\"></a>$::htmllabels{pgnumbefore}$_$::htmllabels{pgnumafter}";
 							$br = "<br />";
 						}
 					}
@@ -1378,7 +1378,7 @@ sub html_convert_pageanchors {
 						$pagereference = "<$mark>";
 					} else {
 						$pagereference =
-							"<a id=\"$::htmllabels{pglabel}$num\" />$::htmllabels{pgnumbefore}$num$::htmllabels{pgnumafter}";
+							"<a id=\"$::htmllabels{pglabel}$num\"></a>$::htmllabels{pgnumbefore}$num$::htmllabels{pgnumafter}";
 					}
 				}
 			}


### PR DESCRIPTION
Replace self-closing anchor with empty anchor element