### PR TITLE
fix for '.' not in path

### DIFF
--- a/guiguts.pl
+++ b/guiguts.pl
@@ -15,6 +15,8 @@
 use strict;
 use warnings;
 
+use lib '.';
+
 #use criticism 'gentle';
 our $VERSION = '1.0.25';
 
@@ -343,7 +345,7 @@ unless ( -e 'header.txt' ) {
 ::checkforupdatesmonthly();
 
 sub dofile {
-	my $filename = "./" . shift;
+	my $filename = shift;
 	return do $filename;
 }
 

--- a/guiguts.pl
+++ b/guiguts.pl
@@ -343,7 +343,7 @@ unless ( -e 'header.txt' ) {
 ::checkforupdatesmonthly();
 
 sub dofile {
-	my $filename = shift;
+	my $filename = "./" . shift;
 	return do $filename;
 }
 


### PR DESCRIPTION
Settings were not persisted and other files not found because `'.'` is apparently no longer in the `@INC` path in more recent versions of perl.

I know nothing about perl so not sure if this fix is 'correct', but it seems to make things work again :wink: 