### PR TITLE
Allow checkfile from external tool to be viewed

### DIFF
--- a/lib/Guiguts/MenuStructure.pm
+++ b/lib/Guiguts/MenuStructure.pm
@@ -924,6 +924,11 @@ sub menubuildold {
 					unlink 'null' if ( -e 'null' );
 				},
 			],
+			[	Button => 'Load Chec~kfile...',
+				-command => sub {
+					::errorcheckpop_up( $textwindow, $top, 'Load Checkfile' );
+				}
+			],
 			[ 'separator', '' ],
 			[
 				Button   => 'Remove ~End-of-line Spaces',
@@ -1388,6 +1393,11 @@ sub menubuilddefault {
 			],
 			[	Button   => '~Jeebies...',
 				-command => \&::jeebiespop_up
+			],
+			[	Button => 'Load Chec~kfile...',
+				-command => sub {
+					::errorcheckpop_up( $textwindow, $top, 'Load Checkfile' );
+				}
 			],
 			[ 'separator', '' ],
 			[	Button => '~Footnote Fixup...',


### PR DESCRIPTION
When tools like gutcheck or pptxt are run, the results are displayed and the user can click the error to jump to the correct line. Add the option to "Load Checkfile" that has been created externally, in particular using the ppwb suite of tools. Also add feature (same as in gutcheck window) so that when user right-clicks to hide an error, the next error location is automatically displayed - this will now apply to other checks such as HTML validate, Tidy, etc.