### PR TITLE
Improvements to poetry, list, block markup

### DIFF
--- a/headerdefault.txt
+++ b/headerdefault.txt
@@ -79,6 +79,9 @@ table {
     position: absolute;
     top: auto;
     left: 4%;
+    font-style: normal;
+    font-weight: normal;
+    font-variant: normal;
 } /* poetry number */
 
 .blockquot {


### PR DESCRIPTION
1) User can manually select part of file and convert to poetry markup. This now uses same best practice markup as main conversion routine.
2) Code to convert italic markup across line breaks into separate markup on each line improved. There were several pieces of code, all different, at least some of which failed to cope with some cases, notably if italic started at beginning of line. Now all use new, improved sub.
3) Commonised code used to detect if poetry is already indented by 4 characters across two poetry creation routines. Code now in a sub.
4) Minor correction to counter adjustments from previous poetry work - would probably never have triggered, but more correct now.