### PR TITLE
Character Counts search fails on backslash

### DIFF
--- a/lib/Guiguts/WordFrequency.pm
+++ b/lib/Guiguts/WordFrequency.pm
@@ -364,6 +364,7 @@ sub wordfrequency {
 				}
 				$sword =~ s/(\d+)\s+(\S)/$2/;
 				my $snum = $1;
+				$sword = '\\\\' if ( $sword eq '\\' ); # special case of backslash in character count
 				$sword =~ s/\s+\*\*\*\*$//;
 				if ( $sword =~ /\W/ ) {
 					$sword =~ s/\*nbsp\*/\x{A0}/;


### PR DESCRIPTION
Word Frequency, Character Counts finds all characters used in the file. If a backslash is present, then clicking on it in the list to find where it is in the file failed with an Invalid Regex popup.  Fixed by doubling backslashes :)