### PR TITLE
Fix rewrap bug losing y-umlaut character (Tony Browne)

### DIFF
--- a/lib/Guiguts/ReflowGG.pm
+++ b/lib/Guiguts/ReflowGG.pm
@@ -458,9 +458,9 @@ sub process($) {
   # current line is non-poetry
   # remove spaces around dashes:
   $line =~ s/([^-])[ \t]*--[ \t]*([^-])/$1--$2/g unless $gg;
-  # protect ". . ." ellipses:
-  $line =~ s/ \. \. \./\377\.\377\.\377\./g;
-  $line =~ s/\. \. \./\.\377\.\377\./g;
+  # protect ". . ." ellipses by replacing space with unused byte \x9f
+  $line =~ s/ \. \. \./\x9f\.\x9f\.\x9f\./g;
+  $line =~ s/\. \. \./\.\x9f\.\x9f\./g;
   @linewords = split(/\s+/, $line);
   shift(@linewords) if (@linewords && ($linewords[0] eq ""));
   # If last word of previous line ends in a single hyphen,
@@ -521,7 +521,7 @@ sub reflow_para {
   @linkbreak = map { $_ > 0xF0000000 ? -((0xFFFFFFFF - $_) + 1) : $_ + 0 } @linkbreak;
   $lastbreak = shift(@linkbreak);
   compute_output();
-  grep (s/\377/ /g, @output);
+  grep (s/\x9f/ /g, @output);
   print_lines(@output);
   @words = ();
 }


### PR DESCRIPTION
To avoid spaced ellipses being split, rewrap code converted the spaces to y-umlaut character, then converted them back to spaces at the end, hence losing any actual y-umlauts from text. Now using \x9f instead, which is not a legal character in the text, since not valid in ISO8859-1 nor utf-8.
Tony Browne made the fix but accidentally omitted it from his latest patch file which was merged previously.