### PR TITLE
Improvements to /i...i/ index conversion

### DIFF
--- a/guiguts.pl
+++ b/guiguts.pl
@@ -90,6 +90,7 @@ use Guiguts::CharacterTools;
 use Guiguts::Utilities;
 use Guiguts::WordFrequency;
 ### Constants
+our $allblocktypes = quotemeta '#$*FfIiLlPpXx';
 our $url_no_proofer  = 'http://www.pgdp.net/phpBB2/privmsg.php?mode=post';
 our $url_yes_proofer = 'http://www.pgdp.net/c/stats/members/mbr_list.php?uname=';
 our $urlprojectpage  = 'http://www.pgdp.net/c/project.php?id=';

--- a/lib/Guiguts/TextProcessingMenu.pm
+++ b/lib/Guiguts/TextProcessingMenu.pm
@@ -537,14 +537,14 @@ sub cleanup {
 	while (1) {
 		$::searchstartindex =
 		  $textwindow->search( '-regexp', '--',
-							   '^\/[\*\$#pPfFLlXx]|^[Pp\*\$#fFLlXx]\/',
+							   "^\/[$::allblocktypes]|^[$::allblocktypes]\/",
 							   $::searchstartindex, 'end' );
 		last unless $::searchstartindex;
 		# if a start rewrap block marker is followed by a start rewrap block marker,
 		# also delete the blank line between the two
 		if ( $textwindow->get($::searchstartindex, "$::searchstartindex +1c") eq '/'
 		     && $textwindow->get("$::searchstartindex +3c", "$::searchstartindex +6c")
-		          =~ /\n\/[\*\$#pPfFlLxX]/ ) {
+		          =~ /\n\/[$::allblocktypes]/ ) {
 			$textwindow->delete( "$::searchstartindex -1c",
 							 "$::searchstartindex +5c lineend" );
 		} else {


### PR DESCRIPTION
Improve placement of pagenum spans within lists, e.g. index, during HTML conversion. Should now be valid HTML.
Add blockquote-style rewrap margins feature to /i...i/ markup, e.g. /i[8.2.60] means index is indented by 2, continuation lines indented by 8, right margin is 60. Later numbers can be omitted.
Commonised list of block markup types - some types were omitted from some places.