### PR TITLE
Improve dialog position persistence

### DIFF
--- a/guiguts.pl
+++ b/guiguts.pl
@@ -118,7 +118,6 @@ our $failedsearch  = 0;
 our $fontname      = 'Courier New';
 our $fontsize      = 10;
 our $fontweight    = q{};
-our $geometry2     = q{};
 our $geometry;
 our $globalaspellmode   = 'normal';
 our $globalbrowserstart = $ENV{BROWSER};

--- a/lib/Guiguts/CharacterTools.pm
+++ b/lib/Guiguts/CharacterTools.pm
@@ -586,8 +586,6 @@ sub utfcharentrypopup {
 				undef $::lglobal{utfentrypop};
 			},
 		)->grid( -row => 1, -column => 2 );
-		$::lglobal{ordpop}->resizable( 'yes', 'no' );
-		::initialize_popup_with_deletebinding('ordpop');
 		$inentry->Tk::bind(
 			'<Return>',
 			sub {

--- a/lib/Guiguts/ErrorCheck.pm
+++ b/lib/Guiguts/ErrorCheck.pm
@@ -703,10 +703,6 @@ sub gutcheckview {
 							 $::gc{$line} . " lineend" );
 		::update_indicators();
 	}
-
-	#don't focus    $textwindow->focus;
-	#leave main text on top    $::lglobal{gcpop}->raise;
-	$::geometry2 = $::lglobal{gcpop}->geometry;
 }
 
 # Equivalent to gutcheckview for the general errors window
@@ -976,7 +972,7 @@ sub gcheckpop_up {
 	} else {
 		$::lglobal{gcpop} = $top->Toplevel;
 		$::lglobal{gcpop}->title('Bookloupe/Gutcheck');
-		$::lglobal{gcpop}->geometry($::geometry2) if $::geometry2;
+		$::lglobal{gcpop}->geometry($::geometryhash{gcpop});
 		$::lglobal{gcpop}->transient($top)        if $::stayontop;
 		my $ptopframe = $::lglobal{gcpop}->Frame->pack;
 		my $opsbutton =
@@ -1050,7 +1046,7 @@ sub gcheckpop_up {
 		$::lglobal{gcpop}->bind(
 			'<Configure>' => sub {
 				$::lglobal{gcpop}->XEvent;
-				$::geometry2 = $::lglobal{gcpop}->geometry;
+				$::geometryhash{gcpop} = $::lglobal{gcpop}->geometry;
 				$::lglobal{geometryupdate} = 1;
 			}
 		);
@@ -1350,7 +1346,7 @@ sub gutcheck {
 	my $textwindow = $::textwindow;
 	my $top        = $::top;
 	no warnings;
-	::operationadd('Gutcheck' );
+	::operationadd('Bookloupe/Gutcheck' );
 	::hidepagenums();
 	my ( $name, $path, $extension, @path );
 	$textwindow->focus;

--- a/lib/Guiguts/FileMenu.pm
+++ b/lib/Guiguts/FileMenu.pm
@@ -982,7 +982,7 @@ EOM
 			qw/alpha_sort activecolor auto_page_marks auto_show_images autobackup autosave autosaveinterval bkgcolor
 			blocklmargin blockrmargin bold_char defaultindent donotcenterpagemarkers extops_size failedsearch
 			font_char fontname fontsize fontweight geometry
-			geometry2 gesperrt_char globalaspellmode highlightcolor history_size hotkeybookmarks
+			gesperrt_char globalaspellmode highlightcolor history_size hotkeybookmarks
 			htmldiventry htmlspanentry ignoreversionnumber
 			intelligentWF ignoreversions italic_char jeebiesmode lastversioncheck lastversionrun lmargin	
 			multisearchsize multiterm nobell nohighlights projectfileslocation notoolbar oldspellchecklayout poetrylmargin projectfileslocation

--- a/lib/Guiguts/HTMLConvert.pm
+++ b/lib/Guiguts/HTMLConvert.pm
@@ -2859,7 +2859,7 @@ sub markup {
 				return unless length($selection);
 				$::lglobal{linkpop} = $top->Toplevel;
 				$::lglobal{linkpop}->title('Internal Links');
-				$::lglobal{linkpop}->geometry($::geometry2) if $::geometry2;
+				$::lglobal{linkpop}->geometry($::geometryhash{linkpop});
 				$::lglobal{linkpop}->transient($top)        if $::stayontop;
 				$::lglobal{fnlinks} = 1;
 				my $tframe = $::lglobal{linkpop}->Frame->pack;
@@ -2925,6 +2925,7 @@ sub markup {
 				::drag($linklistbox);
 				$::lglobal{linkpop}->protocol(
 					'WM_DELETE_WINDOW' => sub {
+						$::geometryhash{linkpop} = $::lglobal{linkpop}->geometry;
 						$::lglobal{linkpop}->destroy;
 						undef $::lglobal{linkpop};
 					}
@@ -2936,7 +2937,7 @@ sub markup {
 					'<<trans>>',
 					sub {
 						$name        = $linklistbox->get('active');
-						$::geometry2 = $::lglobal{linkpop}->geometry;
+						$::geometryhash{linkpop} = $::lglobal{linkpop}->geometry;
 						$done        = '</a>';
 						$textwindow->insert( $thisblockend, $done );
 						$done = "<a href=\"" . $name . "\">";

--- a/lib/Guiguts/Utilities.pm
+++ b/lib/Guiguts/Utilities.pm
@@ -669,7 +669,7 @@ sub initialize {
 		$::positionhash{fontpop}       = '+10+10';
 		$::geometryhash{footcheckpop}  = '+22+12';
 		$::positionhash{footpop}       = '+255+157';
-		$::geometryhash{gcpop}         = '1000x800+224+72';
+		$::geometryhash{gcpop}         = '800x600+224+72';
 		$::geometryhash{gcrunoptspop}  = '+244+72';
 		$::geometryhash{gcviewoptspop} = '+264+72';
 		$::positionhash{grpop}         = '+144+153';

--- a/lib/Guiguts/Utilities.pm
+++ b/lib/Guiguts/Utilities.pm
@@ -653,10 +653,6 @@ sub initialize {
 		chdir $dir if length $dir;
 	}
 
-	# For backward compatibility, carry over old geometry settings
-	unless ($::geometry2) {
-		$::geometry2 = '462x583+684+72';
-	}
 	unless ( $::geometryhash{wfpop} ) {
 		# positionhash stores user's window position
 		# geometryhash stores user's window position and size
@@ -664,38 +660,50 @@ sub initialize {
 		$::geometryhash{alignpop}      = '+338+83';
 		$::geometryhash{asciiboxpop}   = '+358+187';
 		$::positionhash{brkpop}        = '+482+131';
+		$::positionhash{defurlspop}    = '+150+150';
 		$::geometryhash{errorcheckpop} = '+484+72';
+		$::geometryhash{extpop}        = '+120+38';
 		$::positionhash{filepathspop}  = '+55+7';
 		$::positionhash{fixpop}        = '+34+22';
+		$::positionhash{floodpop}      = '+150+150';
 		$::positionhash{fontpop}       = '+10+10';
 		$::geometryhash{footcheckpop}  = '+22+12';
 		$::positionhash{footpop}       = '+255+157';
-		$::geometryhash{gcpop}         = '+224+72';
+		$::geometryhash{gcpop}         = '1000x800+224+72';
 		$::geometryhash{gcrunoptspop}  = '+244+72';
 		$::geometryhash{gcviewoptspop} = '+264+72';
 		$::positionhash{grpop}         = '+144+153';
 		$::positionhash{guesspgmarkerpop}='+10+10';
 		$::geometryhash{hotkeyspop}    = '+144+119';
+		$::positionhash{hilitepop}     = '+150+150';
+		$::positionhash{hintpop}       = '+150+150';
 		$::geometryhash{hpopup}        = '300x400+584+211';
 		$::positionhash{htmlgenpop}    = '+145+37';
 		$::positionhash{htmlimpop}     = '+45+37';
 		$::geometryhash{jeepop}        = '+284+72';
 		$::positionhash{latinpop}      = '+10+10';
+		$::geometryhash{linkpop}       = '+224+72';
 		$::positionhash{marginspop}    = '+145+137';
+		$::positionhash{markpop}       = '+140+93';
+		$::geometryhash{oppop}         = '600x400+50+50';
 		$::geometryhash{pagelabelpop}  = '375x500+20+20';
 		$::positionhash{pagemarkerpop} = '+302+97';
 		$::geometryhash{pagesephelppop}= '+191+132';
 		$::positionhash{pageseppop}    = '+334+176';
+		$::geometryhash{prooferpop}    = '600x400+100+70';
 		$::geometryhash{regexrefpop}   = '+106+72';
 		$::positionhash{searchpop}     = '+10+10';
-		$::positionhash{srchhistsizepop}='+152+97';
+		$::positionhash{selectionpop}  = '+10+10';
 		$::positionhash{spellpopup}    = '+152+97';
+		$::positionhash{srchhistsizepop}='+152+97';
+		$::positionhash{stoppop}       = '+10+10';
+		$::positionhash{surpop}        = '+150+150';
+		$::positionhash{tblfxpop}      = '+120+120';
 		$::positionhash{txtconvpop}    = '+82+131';
 		$::positionhash{utfentrypop}   = '+191+132';
 		$::geometryhash{utfpop}        = '+46+46';
 		$::geometryhash{utfsearchpop}  = '550x450+53+87';
 		$::geometryhash{wfpop}         = '+365+63';
-		$::geometryhash{extpop}        = '+120+38';
 	}
 
 	::readsettings();
@@ -1328,7 +1336,8 @@ sub initialize_popup_without_deletebinding {
 		$::lglobal{$popupname}->bind(
 			'<Configure>' => sub {
 				my $pos = $::lglobal{$popupname}->geometry;
-				$pos =~ s/^[0-9x]*(\+\d+\+\d+)$/$1/;
+				# Extract position coordinates - note negative coords are of form +-nnn
+				$pos =~ s/^[0-9x]*(\+-*\d+\+-*\d+)$/$1/;
 				$::positionhash{$popupname} = $pos; # don't try using ->x and ->y, ->y has a wrong value (at least on mac)
 				$::lglobal{geometryupdate} = 1;
 			}


### PR DESCRIPTION
Some dialogs' positions were persistent, i.e. if the user moved them,
then next time they popup in the new position, even on a new run.
All specific dialogs now have persistent positions.

If a dialog was positioned with negative coordinates, it could
cause the dialog height to be broken, only fixable by editing the
setting.rc file. Negative position coordinates, e.g. "+-123+-37"
now handled correctly.

Two pieces of history relating to dialog positions (geometry2
and ordpop) have been removed. No expected effects.