### PR TITLE
Use em measure for image div widths

### DIFF
--- a/headerdefault.txt
+++ b/headerdefault.txt
@@ -142,7 +142,13 @@ em.gesperrt
 .caption  {font-weight: bold;}
 
 /* Images */
-.figcenter   {
+
+img {
+    max-width: 100%;
+    height: auto;
+}
+
+.figcenter {
     margin: auto;
     text-align: center;
 }
@@ -162,8 +168,7 @@ em.gesperrt
     float: right;
     clear: right;
     margin-left: 1em;
-    margin-bottom:
-    1em;
+    margin-bottom: 1em;
     margin-top: 1em;
     margin-right: 0;
     padding: 0;

--- a/lib/Guiguts/HTMLConvert.pm
+++ b/lib/Guiguts/HTMLConvert.pm
@@ -1807,7 +1807,9 @@ sub htmlimage {
 					# Write class into CSS block (sorted in width order) - first find end of CSS
 					my $insertpoint = $textwindow->search( '--', '</style', '1.0', 'end' );
 					if ($insertpoint) {
-						my $cssdef = ".$classname {width: " . $width . "px;}";
+						# Max-width in em - assumed to be 16px
+						# Necessary because eBookMaker removes declarations ending in "px" 
+						my $cssdef = ".$classname {max-width: " . ($width/16.0) . "em;}";
 						# Unless this class has been added already ...
 						unless ($textwindow->search( '-backwards', '--', $cssdef, $insertpoint, '10.0' )) {
 							# Find end of last class definition in CSS


### PR DESCRIPTION
Because eBookMaker removes CSS declarations that end in px,
change to use em for the autogenerated width classes used by
Auto-Illus. Assumes 1em=16px, but if it isn't nothing too bad
will happen, just the caption wrapping a bit wider/narrower.
Also swapped from width to max-width as more flexible for
different screen widths.