### PR TITLE
Fix column copy/cut inconsistency

### DIFF
--- a/lib/Guiguts/MenuStructure.pm
+++ b/lib/Guiguts/MenuStructure.pm
@@ -592,13 +592,13 @@ sub menubuildold {
 				'command',
 				'Column Cut',
 				-command => sub { ::colcut($textwindow); },
-				-accelerator => 'F1'
+				-accelerator => 'F2'
 			],
 			[
 				'command',
 				'Column Copy',
 				-command => sub { ::colcopy($textwindow); },
-				-accelerator => 'F2'
+				-accelerator => 'F1'
 			],
 			[
 				'command',
@@ -1182,11 +1182,11 @@ sub menubuilddefault {
 			],
 			[ 'separator', '' ],
 			[	'command', 'Column Cut',
-				-accelerator => 'F1',
+				-accelerator => 'F2',
 				-command => sub { ::colcut($textwindow); },
 			],
 			[	'command', 'Column Copy',
-				-accelerator => 'F2',
+				-accelerator => 'F1',
 				-command => sub { ::colcopy($textwindow); },
 			],
 			[	'command', 'Column Paste',

--- a/lib/Guiguts/Utilities.pm
+++ b/lib/Guiguts/Utilities.pm
@@ -1521,7 +1521,7 @@ sub colcut {
 	my $textwindow = shift;
 	columnizeselection($textwindow);
 	$textwindow->addGlobStart;
-	::textcopy();
+	::cut();
 	$textwindow->addGlobEnd;
 }
 
@@ -1529,7 +1529,7 @@ sub colcopy {
 	my $textwindow = shift;
 	columnizeselection($textwindow);
 	$textwindow->addGlobStart;
-	::cut();
+	::textcopy();
 	$textwindow->addGlobEnd;
 }
 


### PR DESCRIPTION
Since it's inception, there has been an mixup between column
copy and column cut. The two functions did the wrong operation,
and the accelerator text on the menu buttons was swapped. So
clicking "Column Cut (F1)" had a different effect to pressing the
F1 button, also not matching the hotkeys help text nor the
Guiguts manual. Similar swap for "Column Copy (F2)"