### PR TITLE
Increase image size limits in ppvimage tool

### DIFF
--- a/tools/ppvimage/ppvimage.pl
+++ b/tools/ppvimage/ppvimage.pl
@@ -887,7 +887,7 @@ sub checkepubcover {
   else {
     print LOGFILE ("\n\n");
     logprint("NOTE: epub cover will be $imgcover",$imgcoverline,"INFO","\n"," (line $imgcoverline)");
-    # warn if not jpg or smaller than 625x1000
+    # warn if not jpg or smaller than minimum width & height
     if (not ($imgcover =~ m/\.jpe?g$/)) {
       logprint("WARNING: epub cover should be jpg",$imgcoverline,"KEY","","");
       }


### PR DESCRIPTION
The size limits on images included with the HTML version are
being increased. Change the limits within the ppvimage checking
tool, and make the magic numbers constants rather than
hard-coded.