### PR TITLE
Improve operation of hotkeys

### DIFF
--- a/guiguts.pl
+++ b/guiguts.pl
@@ -138,7 +138,6 @@ our $htmldiventry   = ' class="i2"';
 our $htmlspanentry  = ' class="i2"';
 our $highlightcolor = '#a08dfc';
 our $history_size   = 20;
-our $hotkeybookmarks = 0;
 our $ignoreversions =
   "revision";    #ignore revisions by default but not major or minor versions
 our $ignoreversionnumber    = "";         #ignore a specific version

--- a/hotkeys.txt
+++ b/hotkeys.txt
@@ -4,7 +4,11 @@ MAIN WINDOW
 <ctrl>+c -- copy or column copy
 <ctrl>+v -- paste
 <ctrl>+a -- select all
+<ctrl>+o -- open file
 <ctrl>+s -- save file
+<ctrl>+<shift>+s -- save as
+<ctrl>+<alt>+r -- open regex quick reference
+<ctrl>+<alt>+s -- open scratchpad.txt
 
 <shift>+mouse drag -- column select
 F1 -- column copy
@@ -17,7 +21,7 @@ F7 -- spell check selection (or document, if no selection made)
 F8 -- open Stealth Scannos search
 
 <ctrl>+z -- undo
-<ctrl>+y -- redo
+<ctrl>+y, <ctrl>+<shift>+z -- redo
 
 <ctrl>+u -- Convert case of selection to upper case
 <ctrl>+l -- Convert case of selection to lower case
@@ -34,9 +38,17 @@ F8 -- open Stealth Scannos search
 <ctrl>+<shift>+g -- continue search in opposite direction
 
 <ctrl>+i -- view current image (as See Img button)
+<ctrl>+j -- go to line
 <ctrl>+p -- go to page
-<ctrl>+P -- go to page label
-<ctrl>+o -- flood fill (if popup is open, otherwise open it)
+<ctrl>+<shift>+p -- go to page label
+
+<ctrl>+w -- rewrap selection
+<ctrl>+<shift>+w -- block rewrap selection
+<ctrl>+m -- indent +1 / move column selection right
+<ctrl>+<shift>+m -- indent -1 / move column selection left
+<ctrl>+<alt>+m -- indent +4
+<ctrl>+<alt>+<shift>+m -- indent -4
+<ctrl>+e -- flood fill (if popup is open, otherwise open it)
 <ctrl>+r -- surround text (if popup is open, otherwise open it)
 
 <ctrl>+Home -- move cursor to the start of the text
@@ -62,9 +74,13 @@ F8 -- open Stealth Scannos search
 <shift>+<ctrl>+up arrow -- adjust selection to the start of the current paragraph
 <shift>+<ctrl>+down arrow -- adjust selection to the start of the next paragraph
 
-<ctrl>+, -- highlight all apostrophes in selection.
-<ctrl>+. -- highlight all double quotes in selection.
-<ctrl>+0 -- remove all highlights.
+<ctrl>+, -- highlight all apostrophes in selection
+<ctrl>+. -- highlight all double quotes in selection
+<ctrl>+<alt>+h -- highlight arbitrary characters in selection
+<ctrl>+0 -- remove all highlights
+
+<ctrl>+1,2,3,4,5 -- go to bookmark 1,2,3,4,5
+<ctrl>+<shift>+1,2,3,4,5 -- set bookmark 1,2,3,4,5
 
 <Insert> -- Toggle insert / overstrike mode
 
@@ -77,6 +93,7 @@ Triple-click left mouse button -- select line
 
 Single click right mouse button -- pop up shortcut to menu bar
 
+<command>+q - quit Guiguts (Mac only)
 
 MENUS (non-Mac)
 
@@ -93,17 +110,17 @@ SEARCH POPUP
 
 PAGE SEPARATOR POPUP
 
-j -- Join Lines - join lines, remove all blank lines, spaces, asterisks and hyphens.
-k -- Join, Keep Hyphen - join lines, remove all blank lines, spaces and asterisks, keep hyphen.
-l -- Blank Line - leave one blank line. Close up any other whitespace. (Paragraph Break)
-t -- New Section - leave two blank lines. Close up any other whitespace. (Section Break)
-h -- New Chapter - leave four blank lines. Close up any other whitespace. (Chapter Break)
-r -- Refresh - search for, highlight and re-center the next page separator.
-u -- Undo - undo the last edit.
-d -- Delete - delete the page separator. Make no other edits.
-v -- View the current page in the image viewer.
-a -- Cycle Automatic modes.
-? -- View hotkey help popup.
+j -- Join Lines - join lines, remove all blank lines, spaces, asterisks and hyphens
+k -- Join, Keep Hyphen - join lines, remove all blank lines, spaces and asterisks, keep hyphen
+l -- Blank Line - leave one blank line. Close up any other whitespace (paragraph break)
+t -- New Section - leave two blank lines. Close up any other whitespace (section break)
+h -- New Chapter - leave four blank lines. Close up any other whitespace (chapter break)
+r -- Refresh - search for, highlight and re-center the next page separator
+u -- Undo - undo the last edit
+d -- Delete - delete the page separator. Make no other edits
+v -- View the current page in the image viewer
+a -- Cycle Automatic modes
+? -- View hotkey help popup
 
 
 SPELL CHECK POPUP
@@ -116,6 +133,6 @@ SPELL CHECK POPUP
 
 ADJUST PAGE MARKERS POPUP
 
-PgDn/PgUp -- move to next/previous page marker.
-Up/Down/Left/Right arrows -- move current page marker up/down/left/right.
+PgDn/PgUp -- move to next/previous page marker
+Up/Down/Left/Right arrows -- move current page marker up/down/left/right
 

--- a/lib/Guiguts/FileMenu.pm
+++ b/lib/Guiguts/FileMenu.pm
@@ -982,7 +982,7 @@ EOM
 			qw/alpha_sort activecolor auto_page_marks auto_show_images autobackup autosave autosaveinterval bkgcolor
 			blocklmargin blockrmargin bold_char defaultindent donotcenterpagemarkers extops_size failedsearch
 			font_char fontname fontsize fontweight geometry
-			gesperrt_char globalaspellmode highlightcolor history_size hotkeybookmarks
+			gesperrt_char globalaspellmode highlightcolor history_size
 			htmldiventry htmlspanentry ignoreversionnumber
 			intelligentWF ignoreversions italic_char jeebiesmode lastversioncheck lastversionrun lmargin	
 			multisearchsize multiterm nobell nohighlights projectfileslocation notoolbar oldspellchecklayout poetrylmargin projectfileslocation

--- a/lib/Guiguts/KeyBindings.pm
+++ b/lib/Guiguts/KeyBindings.pm
@@ -166,6 +166,7 @@ sub keybindings {
 				  or warn "Could not create file $!";
 			}
 			::runner('start scratchpad.txt') if $::OS_WIN;
+			::runner('open scratchpad.txt') if $::OS_MAC;
 		} );
 # Help
 	keybind( '<Control-Alt-r>',     sub { ::regexref(); } );
@@ -180,7 +181,18 @@ sub keybindings {
 			$::menubar->Popup( -popover => 'cursor' ) if ($::OS_WIN);
 		} );
 # Extra bindings for Mac
-	keybind( '<Meta-q>',            sub { ::_exit(); } ) if $::OS_MAC;
+	if ( $::OS_MAC ) {
+		keybind( '<Meta-q>',        sub { ::_exit(); } );
+		keybind( '<Meta-s>',        sub { ::savefile(); } );
+		keybind( '<Meta-a>',        sub { $textwindow->selectAll; } );
+		keybind( '<Meta-c>',        sub { ::textcopy(); } );
+		keybind( '<Meta-x>',        sub { ::cut(); } );
+		keybind( '<Meta-v>',        sub { ::paste(); } );
+		keybind( '<Meta-f>',        sub { ::searchpopup(); } );
+		keybind( '<Meta-z>',        undef, '<<Undo>>' );
+		keybind( '<Meta-y>',        undef, '<<Redo>>' );
+	}
+
 # Bookmarks - multiple key-combinations to allow for keyboard differences
 	keybind( '<Control-Shift-exclam>',         sub { ::setbookmark('1'); },	'<<SetBkmk1>>' );
 	keybind( '<Control-Shift-at>',             sub { ::setbookmark('2'); },	'<<SetBkmk2>>' );
@@ -204,7 +216,6 @@ sub keybindings {
 # with <Control-k> bound, so bind <Control-K> to the same event.
 # If key-combination does not end in "-k>" where k is in [a-z], no
 # uppercase binding is added.
-# If on Mac, also add <Meta-k> as alternative to <Control-k>
 #
 # If optional event argument given, link key and event, and bind sub to event.
 #
@@ -219,20 +230,16 @@ sub keybind {
 	my $subr = shift;				# Subroutine to bind to key/event
 	my $event = shift;				# Optional event argument
 	
-	
-	my $mkey = my $ukey = $lkey;
-	$ukey =~ s/-([a-z])>/-\u$1>/;			# Create uppercase version
-	$mkey =~ s/Control/Meta/ if $::OS_MAC;	# Create Mac alternative to Control key
+	my $ukey = $lkey;
+	$ukey =~ s/-([a-z])>/-\u$1>/;	# Create uppercase version
 
 	if ( defined $event ) {
 		$textwindow->eventAdd( $event => $lkey );
 		$textwindow->eventAdd( $event => $ukey ) if $ukey ne $lkey;
-		$textwindow->eventAdd( $event => $mkey ) if $mkey ne $lkey;
 		$textwindow->bind( 'TextUnicode', $event => $subr ) if defined $subr;
 	} elsif ( defined $subr ) {
 		$textwindow->bind( 'TextUnicode', $lkey => $subr );
 		$textwindow->bind( 'TextUnicode', $ukey => $subr ) if $ukey ne $lkey;
-		$textwindow->bind( 'TextUnicode', $mkey => $subr ) if $mkey ne $lkey;
 	} else {
 		print "Undefined arguments to keybind\n";
 	}

--- a/lib/Guiguts/MenuStructure.pm
+++ b/lib/Guiguts/MenuStructure.pm
@@ -14,6 +14,7 @@ sub menu_file {
 	my ( $textwindow, $top ) = ( $::textwindow, $::top );
 	[
 		[	'command', '~Open...',
+			-accelerator => 'Ctrl+o',
 			-command => sub { ::file_open($textwindow) }
 		],
 		[ 'separator', '' ],
@@ -28,6 +29,7 @@ sub menu_file {
 			-command     => \&::savefile
 		],
 		[	'command', 'Save ~As...',
+			-accelerator => 'Ctrl+Shift+s',
 			-command => sub { ::file_saveas($textwindow) }
 		],
 		[	'command', 'Sa~ve a Copy As...',
@@ -314,13 +316,6 @@ sub menu_preferences {
 					-offvalue   => 0
 				],
 				[
-					Checkbutton => 'Enable Shortcuts for Set Bookmark (beta)',
-					-variable   => \$::hotkeybookmarks,
-					-onvalue    => 1,
-					-offvalue   => 0,
-					-command    => sub { ::keybindings(); ::menurebuild(); ::savesettings(); },
-				],
-				[
 					Checkbutton => 'Use Old Spellcheck Layout',
 					-variable   => \$::oldspellchecklayout,
 					-onvalue    => 1,
@@ -521,7 +516,7 @@ sub menu_bookmarks {
 		map ( [
 				Button       => "Set Bookmark $_",
 				-command     => [ \&::setbookmark, "$_" ],
-				-accelerator => ( $::hotkeybookmarks ? "Ctrl+Shift+$_" : '' ),
+				-accelerator => "Ctrl+Shift+$_"
 			],
 			( 1 .. 5 ) ),
 		[ 'separator', '' ],
@@ -648,6 +643,7 @@ sub menubuildold {
 			[
 				'command',
 				'Goto ~Line...',
+				-accelerator => 'Ctrl+j',
 				-command => sub {
 					::gotoline();
 					::update_indicators();
@@ -813,36 +809,37 @@ sub menubuildold {
 			],
 			[
 				Button   => '~Flood Fill Selection With...',
-				-accelerator => 'Ctrl+o',
+				-accelerator => 'Ctrl+e',
 				-command => sub { ::flood() }
 			],
 			[ 'separator', '' ],
 			[
 				Button   => 'Indent Selection 1',
 				-command => sub {
+				-accelerator => 'Ctrl+m',
 					::indent( $textwindow, 'in' );
 				  }
 			],
 			[
 				Button   => 'Indent Selection 4',
+				-accelerator => 'Ctrl+Alt+m',
 				-command => sub {
 					$textwindow->addGlobStart;
-					::indent( $textwindow, 'in' );
-					::indent( $textwindow, 'in' );
-					::indent( $textwindow, 'in' );
-					::indent( $textwindow, 'in' );
+					::indent( $textwindow, 'in' ) for ( 1 .. 4 );
 					$textwindow->addGlobEnd;
 				  }
 			],
 			[
 				Button   => 'Indent Selection -1',
+				-accelerator => 'Ctrl+Shift+m',
 				-command => sub {
-					::indent( $textwindow, 'out', $::operationinterrupt );
+					::indent( $textwindow, 'out' );
 				  }
 			],
 			[ 'separator', '' ],
 			[
 				Button   => '~Rewrap Selection',
+				-accelerator => 'Ctrl+w',
 				-command => sub {
 					$textwindow->addGlobStart;
 					::selectrewrap( $textwindow, $::lglobal{seepagenums},
@@ -852,6 +849,7 @@ sub menubuildold {
 			],
 			[
 				Button   => '~Block Rewrap Selection',
+				-accelerator => 'Ctrl+Shift+w',
 				-command => sub {
 					$textwindow->addGlobStart;
 					::blockrewrap();
@@ -1227,7 +1225,7 @@ sub menubuilddefault {
 				-command => \&::surround
 			],
 			[	Button   => 'Fl~ood Fill Selection With...',
-				-accelerator => 'Ctrl+o',
+				-accelerator => 'Ctrl+e',
 				-command => sub { ::flood() }
 			],
 		]
@@ -1250,13 +1248,14 @@ sub menubuilddefault {
 				  }
 			],
 			[	'command', 'Goto Page La~bel...',
-				-accelerator => 'Ctrl+P',
+				-accelerator => 'Ctrl+Shift+p',
 				-command => sub {
 					::gotolabel();
 					::update_indicators();
 				  }
 			],
 			[	'command', 'Goto ~Line...',
+				-accelerator => 'Ctrl+j',
 				-command => sub {
 					::gotoline();
 					::update_indicators();
@@ -1439,6 +1438,7 @@ sub menubuilddefault {
 				  }
 			],
 			[	Button   => '~Rewrap Selection',
+				-accelerator => 'Ctrl+w',
 				-command => sub {
 					$textwindow->addGlobStart;
 					::selectrewrap( $textwindow, $::lglobal{seepagenums},
@@ -1447,6 +1447,7 @@ sub menubuilddefault {
 				  }
 			],
 			[	Button   => '~Block Rewrap Selection',
+				-accelerator => 'Ctrl+Shift+w',
 				-command => sub {
 					$textwindow->addGlobStart;
 					::blockrewrap();
@@ -1564,23 +1565,23 @@ sub menubuilddefault {
 			],
 			[ 'separator', '' ],
 			[	Button   => 'Indent Selection ~1',
+				-accelerator => 'Ctrl+m',
 				-command => sub {
 					::indent( $textwindow, 'in' );
 				  }
 			],
 			[	Button   => 'Indent Selection ~4',
+				-accelerator => 'Ctrl+Alt+m',
 				-command => sub {
 					$textwindow->addGlobStart;
-					::indent( $textwindow, 'in' );
-					::indent( $textwindow, 'in' );
-					::indent( $textwindow, 'in' );
-					::indent( $textwindow, 'in' );
+					::indent( $textwindow, 'in' ) for ( 1 .. 4 );
 					$textwindow->addGlobEnd;
 				  }
 			],
 			[	Button   => 'In~dent Selection -1',
+				-accelerator => 'Ctrl+Shift+m',
 				-command => sub {
-					::indent( $textwindow, 'out', $::operationinterrupt );
+					::indent( $textwindow, 'out' );
 				  }
 			],
 			[ 'separator', '' ],

--- a/lib/Guiguts/PageNumbers.pm
+++ b/lib/Guiguts/PageNumbers.pm
@@ -7,7 +7,7 @@ BEGIN {
 	our ( @ISA, @EXPORT );
 	@ISA = qw(Exporter);
 	@EXPORT =
-	  qw( &hidepagenums &displaypagenums &togglepagenums &gotolabel
+	  qw( &hidepagenums &displaypagenums &togglepagenums
 	  &pnumadjust &pgnext &pgprevious &pgrenum &pmovedown
 	  &pmoveup &pmoveleft &pmoveright &pageadd &pageremove	);
 }
@@ -59,69 +59,6 @@ sub togglepagenums {
 			}
 		}
 		::pnumadjust();
-	}
-}
-
-## Pop up a window which will allow jumping directly to a specified page
-sub gotolabel {
-	my $textwindow = $::textwindow;
-	my $top        = $::top;
-	unless ( defined( $::lglobal{gotolabpop} ) ) {
-		return unless %::pagenumbers;
-		for ( keys(%::pagenumbers) ) {
-			$::lglobal{pagedigits} = ( length($_) - 2 );
-			last;
-		}
-		$::lglobal{gotolabpop} = $top->DialogBox(
-			-buttons => [qw[Ok Cancel]],
-			-title   => 'Goto Page Label',
-			-popover => $top,
-			-command => sub {
-				if ( $_[0] && $_[0] eq 'Ok' ) {
-					my $mark;
-					for ( keys %::pagenumbers ) {
-						if (    $::pagenumbers{$_}{label}
-							 && $::pagenumbers{$_}{label} eq
-							 $::lglobal{lastlabel} )
-						{
-							$mark = $_;
-							last;
-						}
-					}
-					unless ($mark) {
-						$::lglobal{gotolabpop}->bell;
-						$::lglobal{gotolabpop}->destroy;
-						undef $::lglobal{gotolabpop};
-						return;
-					}
-					my $index = $textwindow->index($mark);
-					$textwindow->markSet( 'insert', "$index +1l linestart" );
-					::seeindex('insert -2l', 1);
-					$textwindow->focus;
-					::update_indicators();
-					$::lglobal{gotolabpop}->destroy;
-					undef $::lglobal{gotolabpop};
-				} else {
-					$::lglobal{gotolabpop}->destroy;
-					undef $::lglobal{gotolabpop};
-				}
-			}
-		);
-		$::lglobal{gotolabpop}->resizable( 'no', 'no' );
-		my $frame = $::lglobal{gotolabpop}->Frame->pack( -fill => 'x' );
-		$frame->Label( -text => 'Enter Label: ' )->pack( -side => 'left' );
-		$::lglobal{lastlabel} = 'Pg ' unless $::lglobal{lastlabel};
-		my $entry = $frame->Entry(
-								   -background   => $::bkgcolor,
-								   -width        => 25,
-								   -textvariable => \$::lglobal{lastlabel}
-		)->pack( -side => 'left', -fill => 'x' );
-		$::lglobal{gotolabpop}->Advertise( entry => $entry );
-		$::lglobal{gotolabpop}->Popup;
-		$::lglobal{gotolabpop}->Subwidget('entry')->focus;
-		$::lglobal{gotolabpop}->Subwidget('entry')->selectionRange( 3, 'end' );
-		$::lglobal{gotolabpop}->Subwidget('entry')->icursor( 3 );
-		$::lglobal{gotolabpop}->Wait;
 	}
 }
 


### PR DESCRIPTION
If caps lock on, hotkeys failed, e.g. pressing Ctrl-x  did not do
"cut", because program was receiving Ctrl-X. Now all hotkeys
work as expected, depending on keys pressed, rather than
state of caps lock. Note that Ctrl-Shift-w can still be bound to
a different action from Ctrl-w. Attempt also made to enable
more hotkeys on Macs.

Goto Line, Goto Page and Goto Page Label dialog code has
been commonised. They can now also be dismissed with
Escape key or Window Manager close button.

Several new hotkeys added, accelerator text added to menus,
and hotkeys.txt documentation updated.

Shortcut keys for setting bookmarks was a "beta" feature from
many years ago, with a setting to enable/disable it. Now made
a permanently enabled feature.