### PR TITLE
Add Count button to S&R dialog

### DIFF
--- a/hotkeys.txt
+++ b/hotkeys.txt
@@ -35,6 +35,7 @@ F8 -- open Stealth Scannos search
 
 <ctrl>+f -- open Search & Replace popup
 <ctrl>+g -- continue search
+<ctrl>+n -- count number of matches
 <ctrl>+<shift>+g -- continue search in opposite direction
 
 <ctrl>+i -- view current image (as See Img button)

--- a/lib/Guiguts/KeyBindings.pm
+++ b/lib/Guiguts/KeyBindings.pm
@@ -108,6 +108,12 @@ sub keybindings {
 				::searchpopup();
 			}
 		}, '<<FindNextReverse>>' );
+	keybind( '<Control-n>',         sub {
+			if ( $::lglobal{searchpop} ) {
+				my $searchterm = $::lglobal{searchentry}->get( '1.0', '1.end' );
+				::countmatches($searchterm);
+			}		
+		} );
 # Navigation
 	keybind( '<Control-i>',         sub { ::seecurrentimage(); } );
 	keybind( '<Control-j>',         sub { ::gotoline(); } );

--- a/lib/Guiguts/SearchReplaceMenu.pm
+++ b/lib/Guiguts/SearchReplaceMenu.pm
@@ -329,7 +329,7 @@ sub countmatches {
 	$::lglobal{selectionsearch} = $saveselectionsearch;
 }
 
-{
+BEGIN { # restrict scope of $countlastterm
 	# remember last term counted / searched
 	my $countlastterm = '';
 	# only need to clear counted label if current term is different


### PR DESCRIPTION
Add new button to count how many times current search would
find a match (including regex, whole word & case flags). Uses
same label as current part-solution which relies on a list of
"seen words" and only works for whole word searches. Also
added shortcut key Ctrl-n to both main window and S&R
dialog. Fixed Ctrl-g/Ctrl-Shift-g issue on dialog to match fix
made to main window hotkeys (MR #37)