### PR TITLE
Fix pgdp.net URLs

### DIFF
--- a/ggmanual.html
+++ b/ggmanual.html
@@ -11,9 +11,9 @@
 
 <h1>Guiguts User Manual</h1>
 
-<p><a href="http://www.pgdp.net/wiki/PPTools/Guiguts">Guiguts manual</a>
-is available on the <a href="http://www.pgdp.net/wiki">Distributed
-  Proofreaders Wiki</a>, which also has the latest version of the <a href="http://www.pgdp.net/wiki/Guiguts_PP_Process_Checklist">Guiguts PP checklist</a>. </p>
+<p><a href="https://www.pgdp.net/wiki/PPTools/Guiguts">Guiguts manual</a>
+is available on the <a href="https://www.pgdp.net/wiki">Distributed
+  Proofreaders Wiki</a>, which also has the latest version of the <a href="https://www.pgdp.net/wiki/Guiguts_PP_Process_Checklist">Guiguts PP checklist</a>. </p>
  
 </body>
 </html>

--- a/guiguts.pl
+++ b/guiguts.pl
@@ -91,10 +91,10 @@ use Guiguts::Utilities;
 use Guiguts::WordFrequency;
 ### Constants
 our $allblocktypes = quotemeta '#$*FfIiLlPpXx';
-our $url_no_proofer  = 'http://www.pgdp.net/phpBB2/privmsg.php?mode=post';
-our $url_yes_proofer = 'http://www.pgdp.net/c/stats/members/mbr_list.php?uname=';
-our $urlprojectpage  = 'http://www.pgdp.net/c/project.php?id=';
-our $urlprojectdiscussion = 'http://www.pgdp.net/c/tools/proofers/project_topic.php?project=';
+our $url_no_proofer  = 'https://www.pgdp.net/phpBB3/ucp.php?i=pm&mode=compose';
+our $url_yes_proofer = 'https://www.pgdp.net/c/stats/members/mbr_list.php?uname=';
+our $urlprojectpage  = 'https://www.pgdp.net/c/project.php?id=';
+our $urlprojectdiscussion = 'https://www.pgdp.net/c/tools/proofers/project_topic.php?project=';
 ### Application Globals
 our $OS_WIN = $^O =~ m{Win};
 our $OS_MAC = $^O =~ m{darwin};

--- a/lib/Guiguts/MenuStructure.pm
+++ b/lib/Guiguts/MenuStructure.pm
@@ -114,17 +114,17 @@ sub menu_help {
 	my $help_top = [
 		[ Button   => '~Manual [www]',
 			-command => sub {
-				::launchurl( "http://www.pgdp.net/wiki/PPTools/Guiguts" );
+				::launchurl( "https://www.pgdp.net/wiki/PPTools/Guiguts" );
 			  }
 		],
 		[ Button  => 'Guiguts ~Help on DP Forum [www]',
-		  -command => sub { ::launchurl('http://www.pgdp.net/phpBB2/viewtopic.php?t=30324'); }
+		  -command => sub { ::launchurl('https://www.pgdp.net/phpBB3/viewtopic.php?f=13&t=11466'); }
 		],
 		[ Button => '~Keyboard Shortcuts',    -command => \&::hotkeyshelp ],
 		[ Button => '~Regex Quick Reference', -command => \&::regexref ],
 		[ Button => 'Re~wrap Markers [www]',
 		  -command => sub {
-			::launchurl( 'http://www.pgdp.net/wiki/PPTools/Guiguts/Rewrapping#Rewrap_Markers' );
+			::launchurl( 'https://www.pgdp.net/wiki/PPTools/Guiguts/Rewrapping#Rewrap_Markers' );
 		  }
 		],
 	];
@@ -139,7 +139,7 @@ sub menu_help {
 		[ 'separator', '' ],
 		[ Button   => 'GG ~PP Process Checklist [www]',
 		  -command => sub {
-			::launchurl( "http://www.pgdp.net/wiki/Guiguts_PP_Process_Checklist" );
+			::launchurl( "https://www.pgdp.net/wiki/Guiguts_PP_Process_Checklist" );
 		  }
 		],
 		[ 'separator', '' ],

--- a/lib/Guiguts/SearchReplaceMenu.pm
+++ b/lib/Guiguts/SearchReplaceMenu.pm
@@ -772,7 +772,7 @@ sub replaceeval {
 	$replaceterm =~ s/\\\$/\$/g;
 
 # For an explanation see
-# http://www.pgdp.net/wiki/PPTools/Guiguts/Searching#Replacing_by_Modifying_Quoted_Text
+# https://www.pgdp.net/wiki/PPTools/Guiguts/Searching#Replacing_by_Modifying_Quoted_Text
 # \C indicates perl code to be run
 	if ($cfound) {
 		if ( $::lglobal{codewarn} ) {


### PR DESCRIPTION
Use HTTPS URLs for all pgpd.net links and fix broken links.

I took my best guess at what URL `$url_no_proofer` pointed to in phpBB2. That URL has been wrong for years now.