### PR TITLE
Package EBookMaker

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -185,6 +185,8 @@ brew install tidy-html5
 brew install open-sp
 ```
 
+See also the [EBookMaker installation instructions](tools/ebookmaker/README.md).
+
 ## Other
 
 For other platforms, you will need to install Perl and the necessary

--- a/tools/ebookmaker/README.md
+++ b/tools/ebookmaker/README.md
@@ -1,0 +1,84 @@
+# EBookMaker
+
+EBookMaker is the tool used to convert projects into EPUB and Kindle files
+for use with Project Gutenberg.
+
+https://github.com/gutenbergtools/ebookmaker
+
+## Windows
+
+We bundle a Windows binary of ebookmaker manually created by the 
+[ebm_builder](https://github.com/DistributedProofreaders/ebm_builder) tool.
+
+### Installing the python version manually
+
+_These instructions are for advanced users. You do not need these steps to use
+the `ebookmaker.exe` file._
+
+We ship a binary because while the tool is a simple python script, the build
+environment needed for the script's dependencies is very involved. However,
+if you want the latest version of ebookmaker without waiting for a new build
+here's how you can do it.
+
+1. Install all of the Windows build dependencies. This is covered in step 2 of the
+   [ebm_builder](https://github.com/DistributedProofreaders/ebm_builder/blob/master/README.md)
+   instructions.
+2. Install ebookmaker by starting a command line window and running:
+   ```
+   pip3 install --user ebookmaker
+   ```
+
+To run ebookmaker:
+```
+python "%APPDATA%\Python\Python38\Scripts\ebookmaker" --version
+```
+
+## MacOS
+
+EBookMaker installs easily on MacOS with the Python 3 and Cairo included with
+[Homebrew](https://brew.sh). After installing Homebrew:
+
+```
+brew install python3
+brew pin python3
+brew install cairo
+```
+
+Then install EBookMaker:
+
+```
+pip3 install --user ebookmaker
+```
+
+The script to start ebookmaker will be placed into your user's local Python
+package directory which will not be on your path. You can add it to path by
+updating your shell's profile. We've included a helpful script since the
+shell profile can change depending on your version of MacOS.
+
+```
+./add_ebookmaker_to_path.sh
+```
+
+After closing and reopening a terminal window, `ebookmaker` should be on your
+path and usable. You can confirm this with:
+
+```
+ebookmaker --version
+```
+
+To update ebookmaker to the latest version, use:
+
+```
+pip3 install --user --upgrade ebookmaker
+```
+
+### Notes and troubleshooting
+
+As of this writing, Homebrew installs Python 3.7. If Homebrew installs a later
+version (eg: 3.8) you will need to adjust the path above to point to the
+correct location. Use `python3 --version` to see what version of python has
+been installed.
+
+EBookMaker requires Python 3.6 or later. If you have earlier versions of
+Python installed via Homebrew, you may get errors unless you uninstall them
+first.

--- a/tools/ebookmaker/add_ebookmaker_to_path.sh
+++ b/tools/ebookmaker/add_ebookmaker_to_path.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+PYTHON_PATH=~/Library/Python/3.7/bin
+
+# Check to see if the path has already been updated. This only checks if the
+# current env variable is correct, but it's something.
+if [[ $(echo $PATH | grep -c $PYTHON_PATH) -ge 1 ]]; then
+    echo "PATH appears to have been updated already"
+    exit 1
+fi
+
+# Find the right shell
+if [[ $SHELL == "/bin/zsh" ]]; then
+    PROFILE=~/.zprofile
+elif [[ $SHELL == "/bin/bash" ]]; then
+    if [[ -e ~/.profile ]]; then
+        PROFILE=~/.profile
+    else
+        PROFILE=~/.bash_profile
+    fi
+else
+    echo "Unable to determine your profile location based on your shell"
+    exit 1
+fi
+
+# Do the update
+echo "Updating $PROFILE with PATH $PYTHON_PATH"
+echo "export PATH=\$PATH:$PYTHON_PATH" >> $PROFILE
+
+echo "Close this terminal and open a new one to pick up the updated path"

--- a/tools/ebookmaker/package.sh
+++ b/tools/ebookmaker/package.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+OS=$1
+DEST=$2
+
+# Exit on any failure
+set -e
+
+DEST=$DEST/ebookmaker
+mkdir $DEST
+cp README.md $DEST
+
+if [[ $OS == "win" ]]; then
+    VERSION=0.9.1
+    URL=https://github.com/DistributedProofreaders/ebm_builder/releases/download/v$VERSION/ebookmaker-$VERSION.zip
+    curl -L -o ebookmaker.zip $URL
+    unzip ebookmaker.zip -d $DEST
+    rm -rf ebookmaker.zip
+elif [[ $OS == "mac" ]]; then
+    cp add_ebookmaker_to_path.sh $DEST
+fi


### PR DESCRIPTION
[MR revamped]

This MR now handles packaging the ebookmaker Windows binary created from the [ebm_builder](https://github.com/DistributedProofreaders/ebm_builder) repo. It also includes instructions for Mac users (the original purpose of this MR) but in a slightly different directory. The Mac build also includes a helper script to add the python module directory to the path based on their shell.

I have confirmed that the 18MB(!) `ebookmaker.exe` Windows binary returns a usage statement, but I haven't actually used it to make an ebook.

New packages with this code:
* [guiguts-mac-1.1.0-alpha4.zip](http://www.pgdp.org/~cpeel/forumPosts/guiguts-mac-1.1.0-alpha4.zip) - 21MB
* [guiguts-win-1.1.0-alpha4.zip](http://www.pgdp.org/~cpeel/forumPosts/guiguts-win-1.1.0-alpha4.zip) - 33MB