### PR TITLE
Fix Word Frequency search error

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -337,7 +337,7 @@ BEGIN { # restrict scope of $countlastterm
 		my $newterm = shift;
 		if ( $newterm ne $countlastterm ) {
 			$countlastterm = $newterm;
-			$::lglobal{searchnumlabel}->configure( -text => "" );
+			$::lglobal{searchnumlabel}->configure( -text => "" ) if defined $::lglobal{searchpop};
 		}
 	}
 }


### PR DESCRIPTION
Sometimes double clicking a word in Word frequency would
give an error. Now only update the search & dialog if it is
popped.