### PR TITLE
Allow run_guiguts to be run from other folders

### DIFF
--- a/src/run_guiguts.bat
+++ b/src/run_guiguts.bat
@@ -1,5 +1,10 @@
 @echo off
 
+REM Get the Guiguts install directory as the directory containing this batch file
+set GG_DIR=%~dp0
+REM Get full pathname of edit file from first argument to batch file
+set ED_FILE=%~f1
+
 REM Save original path to restore later. This prevents the path from being
 REM updated at every run.
 set OLDPATH=%PATH%
@@ -9,14 +14,14 @@ set PATH=C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;
 
 REM Add older bundled perl directory to the path at the end as a fall-back
 REM for users who want to try and use it instead of Strawberry Perl.
-set PATH=%PATH%;%~dp0perl;%~dp0perl\lib
+set PATH=%PATH%;%GG_DIR%perl;%GG_DIR%perl\lib
 
 REM Prefix tooling directories
-set PATH=%~dp0tools\kindlegen;%~dp0tools\tidy;%PATH%
+set PATH=%GG_DIR%tools\kindlegen;%GG_DIR%tools\tidy;%PATH%
 
 REM Find guiguts.pl in same folder as this batch file
 REM Use full pathname of file to be edited
-perl %~dp0guiguts.pl %~f1
+perl %GG_DIR%guiguts.pl %ED_FILE%
 
 REM Restore original path
 set PATH=%OLDPATH%

--- a/src/run_guiguts.bat
+++ b/src/run_guiguts.bat
@@ -1,6 +1,7 @@
 @echo off
 
 REM Get the Guiguts install directory as the directory containing this batch file
+REM using arcane Windows batch file magic.
 set GG_DIR=%~dp0
 REM Get full pathname of edit file from first argument to batch file
 set ED_FILE=%~f1
@@ -21,7 +22,7 @@ set PATH=%GG_DIR%tools\kindlegen;%GG_DIR%tools\tidy;%PATH%
 
 REM Find guiguts.pl in same folder as this batch file
 REM Use full pathname of file to be edited
-perl %GG_DIR%guiguts.pl %ED_FILE%
+perl "%GG_DIR%guiguts.pl" "%ED_FILE%"
 
 REM Restore original path
 set PATH=%OLDPATH%

--- a/src/run_guiguts.bat
+++ b/src/run_guiguts.bat
@@ -9,14 +9,14 @@ set PATH=C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;
 
 REM Add older bundled perl directory to the path at the end as a fall-back
 REM for users who want to try and use it instead of Strawberry Perl.
-set PATH=%PATH%;%cd%\perl;%cd%\perl\lib
+set PATH=%PATH%;%~dp0perl;%~dp0perl\lib
 
 REM Prefix tooling directories
-set PATH=%cd%\tools\kindlegen;%cd%\tools\tidy;%PATH%
+set PATH=%~dp0tools\kindlegen;%~dp0tools\tidy;%PATH%
 
-rem set ASPELL_CONF=conf-dir c:/guiguts/tools/aspell/bin
-
-perl guiguts.pl %1
+REM Find guiguts.pl in same folder as this batch file
+REM Use full pathname of file to be edited
+perl %~dp0guiguts.pl %~f1
 
 REM Restore original path
 set PATH=%OLDPATH%


### PR DESCRIPTION
Historically, run_guiguts.bat had a "cd" to move to the
folder where guiguts.pl resides before running it.
Recent edit removed the cd, which meant batch file would
only execute correctly if run from the correct folder. This
caused Windows' "Open with" right-click functionality to
break, since this always runs from a system folder, like C:\Windows\system32.

Use %~dp0 to get name of folder containing
run_guiguts.bat and %+f1 for full pathname of file to
be edited.

Also use %~dp0 instead of %cd% (current folder) when
adding tools folders to PATH.

This solution is better than historical use of cd to change
folder, since when run from a command window, that
caused the current folder in the shell to be changed
once the batch file had exited.