### PR TITLE
Update extops list and allow an arbitrary number of them

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -127,9 +127,6 @@ our $globalbrowserstart = $ENV{BROWSER};
 if ( !$globalbrowserstart ) { $globalbrowserstart = 'xdg-open'; }
 if ($OS_WIN)                { $globalbrowserstart = 'start'; }
 if ($OS_MAC)                { $globalbrowserstart = 'open'; }
-our $globalfirefoxstart = 'firefox';
-if ($OS_WIN) { $globalfirefoxstart = 'start firefox'; }
-if ($OS_MAC) { $globalfirefoxstart = 'open -a firefox'; }
 our $globalimagepath        = q{};
 our $globallastpath         = q{};
 our $globalspelldictopt     = q{};
@@ -243,20 +240,6 @@ our @extops = (
 		'command' => "$globalbrowserstart \"\$d\$f\$e\""
 	},
 	{
-		'label'   => 'Open current file in Firefox',
-		'command' => "$globalfirefoxstart \"\$d\$f\$e\""
-	},
-	{
-		'label' => "Websters 1913 (Specialist Online Dictionary)",
-		'command' =>
-"$globalbrowserstart http://www.specialist-online-dictionary.com/websters/headword_search.cgi?query=\$t"
-	},
-	{
-		'label' => "Websters 1828 American Dictionary",
-		'command' =>
-		  "$globalbrowserstart http://www.1828-dictionary.com/d/word/\$t"
-	},
-	{
 		'label'   => 'Onelook.com (several dictionaries)',
 		'command' => "$globalbrowserstart http://www.onelook.com/?w=\$t"
 	},
@@ -273,6 +256,15 @@ our @extops = (
 		'command' =>
 "$globalbrowserstart http://jigsaw.w3.org/css-validator/#validate_by_upload"
 	},
+	{
+		'label' => 'EBookMaker',
+		'command' => "$globalbrowserstart http://epubmaker.pglaf.org/"
+	},
+	{
+		'label' => 'Google Books Ngram Viewer',
+		'command' => "$globalbrowserstart https://books.google.com/ngrams/graph?content=\$t"
+	},
+	{ 'label' => q{}, 'command' => q{} },
 	{ 'label' => q{}, 'command' => q{} },
 	{ 'label' => q{}, 'command' => q{} },
 	{ 'label' => q{}, 'command' => q{} },

--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -240,28 +240,28 @@ our @extops = (
 	},
 	{
 		'label'   => 'Onelook.com (several dictionaries)',
-		'command' => "$globalbrowserstart http://www.onelook.com/?w=\$t"
-	},
-	{
-		'label'   => 'Shape Catcher (Unicode character finder)',
-		'command' => "$globalbrowserstart http://shapecatcher.com/"
-	},
-	{
-		'label'   => 'W3C Markup Validation Service',
-		'command' => "$globalbrowserstart http://validator.w3.org/"
-	},
-	{
-		'label' => 'W3C CSS Validation Service',
-		'command' =>
-"$globalbrowserstart http://jigsaw.w3.org/css-validator/#validate_by_upload"
-	},
-	{
-		'label' => 'EBookMaker',
-		'command' => "$globalbrowserstart http://epubmaker.pglaf.org/"
+		'command' => "$globalbrowserstart https://www.onelook.com/?w=\$t"
 	},
 	{
 		'label' => 'Google Books Ngram Viewer',
 		'command' => "$globalbrowserstart https://books.google.com/ngrams/graph?content=\$t"
+	},
+	{
+		'label'   => 'Shape Catcher (Unicode character finder)',
+		'command' => "$globalbrowserstart https://shapecatcher.com/"
+	},
+	{
+		'label'   => 'W3C HTML Validation Service',
+		'command' => "$globalbrowserstart https://validator.w3.org/#validate_by_upload+with_options"
+	},
+	{
+		'label' => 'W3C CSS Validation Service',
+		'command' =>
+"$globalbrowserstart https://jigsaw.w3.org/css-validator/#validate_by_upload+with_options"
+	},
+	{
+		'label' => 'EBookMaker Online',
+		'command' => "$globalbrowserstart http://epubmaker.pglaf.org/"
 	},
 );
 

--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -116,7 +116,6 @@ our $poetrylmargin    = 4;
 our $blockwrap;
 our $booklang      = 'en';
 our $defaultindent = 2;
-our $extops_size   = 10;
 our $failedsearch  = 0;
 our $fontname      = 'Courier New';
 our $fontsize      = 10;
@@ -264,10 +263,6 @@ our @extops = (
 		'label' => 'Google Books Ngram Viewer',
 		'command' => "$globalbrowserstart https://books.google.com/ngrams/graph?content=\$t"
 	},
-	{ 'label' => q{}, 'command' => q{} },
-	{ 'label' => q{}, 'command' => q{} },
-	{ 'label' => q{}, 'command' => q{} },
-	{ 'label' => q{}, 'command' => q{} },
 );
 
 # All local global variables contained in one global hash.

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -978,7 +978,7 @@ EOM
 		# otherwise we can't have a default value of 1 without overwriting the user's setting
 		for (
 			qw/alpha_sort activecolor auto_page_marks auto_show_images autobackup autosave autosaveinterval bkgcolor
-			blocklmargin blockrmargin bold_char defaultindent donotcenterpagemarkers extops_size failedsearch
+			blocklmargin blockrmargin bold_char defaultindent donotcenterpagemarkers failedsearch
 			font_char fontname fontsize fontweight geometry
 			gesperrt_char globalaspellmode highlightcolor history_size
 			htmldiventry htmlspanentry ignoreversionnumber
@@ -1012,8 +1012,8 @@ EOM
 		print $save_handle (");\n\n");
 		print $save_handle ("\@extops = (\n");
 		for my $index ( 0 .. $#::extops ) {
-			my $label   = ::escape_problems( $::extops[$index]{label} );
-			my $command = ::escape_problems( $::extops[$index]{command} );
+			my $label   = ::escape_problems( $::extops[$index]{label} ) || '';
+			my $command = ::escape_problems( $::extops[$index]{command} ) || '';
 			print $save_handle
 			  "\t{'label' => '$label', 'command' => '$command'},\n";
 		}

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -937,20 +937,18 @@ sub readsettings {
 		     || $::extops[0]{label} eq 'Pass open file to default handler') {
 			$::extops[0]{label} = 'View in browser';
 		}
-		if ( $::extops[0]{label} =~ m/browser/ ) {
-			$::extops[0]{label} = 'View in browser';
-		}
-		else {
-			if ( $::extops[$::extops_size-1]{label} || $::extops[$::extops_size-1]{command} ) {
-				$::extops_size++;
-			}
-			for ( my $i = $::extops_size-1; $i > 0; --$i ) {
-				$::extops[$i]{label}   = $::extops[$i-1]{label};
-				$::extops[$i]{command} = $::extops[$i-1]{command};
-			}
-			$::extops[0]{label}   = 'View in browser';
-			$::extops[0]{command} = $::globalbrowserstart . ' "$d$f$e"';
-		}
+	}
+
+	# Always force 'View in browser' to be the first entry as other parts
+	# of the code assume this
+	if ( $::extops[0]{label} =~ m/browser/ ) {
+		$::extops[0]{label} = 'View in browser';
+	}
+	else {
+		unshift(@::extops, {
+			'label' => 'View in browser',
+			'command' => $::globalbrowserstart . ' "$d$f$e"',
+		});
 	}
 }
 

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -512,7 +512,7 @@ sub menu_external {
 				Button   => ($_<9?'~':'').($_==9?'1~0':$_+1).": $::extops[$_]{label}",
 				-command => [ \&::xtops, $_ ]
 			],
-			( 0 .. $::extops_size-1 ) ),
+			( 0 .. $#::extops ) ),
 		[ 'separator', '' ],
 		[
 			Button   => 'Setup ~External Operations...',

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -662,7 +662,7 @@ sub initialize {
 		$::positionhash{brkpop}        = '+482+131';
 		$::positionhash{defurlspop}    = '+150+150';
 		$::geometryhash{errorcheckpop} = '+484+72';
-		$::geometryhash{extpop}        = '+120+38';
+		$::positionhash{extoptpop}     = '+120+38';
 		$::positionhash{filepathspop}  = '+55+7';
 		$::positionhash{fixpop}        = '+34+22';
 		$::positionhash{floodpop}      = '+150+150';
@@ -1919,14 +1919,14 @@ sub externalpopup {    # Set up the external commands menu
 	my $textwindow = $::textwindow;
 	my $top        = $::top;
 	my $menutempvar;
-	if ( $::lglobal{extpop} ) {
-		$::lglobal{extpop}->deiconify;
-		$::lglobal{extpop}->raise;
-		$::lglobal{extpop}->focus;
+	if ( $::lglobal{extoptpop} ) {
+		$::lglobal{extoptpop}->deiconify;
+		$::lglobal{extoptpop}->raise;
+		$::lglobal{extoptpop}->focus;
 	} else {
-		$::lglobal{extpop} = $top->Toplevel( -title => 'External programs', );
+		$::lglobal{extoptpop} = $top->Toplevel( -title => 'External programs', );
 		my $f0 =
-		  $::lglobal{extpop}->Frame->pack( -side => 'top', -anchor => 'n' );
+		  $::lglobal{extoptpop}->Frame->pack( -side => 'top', -anchor => 'n' );
 		$f0->Label( -text =>
 "You can set up external programs to be called from within guiguts here. Each line of entry boxes represent\n"
 			  . "a menu entry. The left box is the label that will show up under the menu. The right box is the calling parameters.\n"
@@ -1944,7 +1944,7 @@ sub externalpopup {    # Set up the external commands menu
 			  . "\$p = the number of the page that the cursor is currently in.\n"
 			  . "\$t = the currently highlighted text.\n" )->pack;
 		my $f1 =
-		  $::lglobal{extpop}->Frame->pack( -side => 'top', -anchor => 'n' );
+		  $::lglobal{extoptpop}->Frame->pack( -side => 'top', -anchor => 'n' );
 		for my $menutempvar ( 0 .. ($#::extops < 10 ? 10 : $#::extops) + 1 ) {
 			$f1->Entry(
 				-width        => 50,
@@ -1971,7 +1971,7 @@ sub externalpopup {    # Set up the external commands menu
 			  );
 		}
 		my $f2 =
-		  $::lglobal{extpop}->Frame->pack( -side => 'top', -anchor => 'n' );
+		  $::lglobal{extoptpop}->Frame->pack( -side => 'top', -anchor => 'n' );
 		my $gobut = $f2->Button(
 			-activebackground => $::activecolor,
 			-command          => sub {
@@ -1987,13 +1987,13 @@ sub externalpopup {    # Set up the external commands menu
 				# save the settings and rebuild the menu
 				::savesettings();
 				::menurebuild();
-				$::lglobal{extpop}->destroy;
-				undef $::lglobal{extpop};
+				$::lglobal{extoptpop}->destroy;
+				undef $::lglobal{extoptpop};
 			},
 			-text  => 'Close',
 			-width => 8
 		)->pack( -side => 'top', -padx => 2, -anchor => 'n' );
-		::initialize_popup_with_deletebinding('extpop');
+		::initialize_popup_with_deletebinding('extoptpop');
 	}
 }
 

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1945,7 +1945,7 @@ sub externalpopup {    # Set up the external commands menu
 			  . "\$t = the currently highlighted text.\n" )->pack;
 		my $f1 =
 		  $::lglobal{extpop}->Frame->pack( -side => 'top', -anchor => 'n' );
-		for my $menutempvar ( 0 .. $::extops_size-1 ) {
+		for my $menutempvar ( 0 .. ($#::extops < 10 ? 10 : $#::extops) + 1 ) {
 			$f1->Entry(
 				-width        => 50,
 				-background   => $::bkgcolor,
@@ -1975,6 +1975,16 @@ sub externalpopup {    # Set up the external commands menu
 		my $gobut = $f2->Button(
 			-activebackground => $::activecolor,
 			-command          => sub {
+				# remove any empty items in the list by building a fresh one
+				my @new_extops = qw();
+				for my $index ( 0 .. $#::extops ) {
+					if( $::extops[$index]{label} || $::extops[$index]{command} )
+					{
+						push(@new_extops, $::extops[$index]);
+					}
+				}
+				@::extops = @new_extops;
+				# save the settings and rebuild the menu
 				::savesettings();
 				::menurebuild();
 				$::lglobal{extpop}->destroy;


### PR DESCRIPTION
This removes deprecated extops entries and adds EBookMaker and Google Ngram (with the latter using the selected words as the search entry).

This also removes the limit on the number of entries in the extops list entirely.