### PR TITLE
Standardize dialog buttons & titles

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,0 +1,28 @@
+# Style Guide
+
+When adding or changing user interface elements in Guiguts, use this style
+guide as a reference. Guiguts was developed by numerous people over many years
+and this style guide is very recent, so not all parts adhere to this (yet).
+
+## Dialog buttons
+
+Most Guiguts users are on Windows, so we use the
+[Windows UX guide](https://docs.microsoft.com/en-us/windows/win32/uxguide/win-dialog-box)
+for dialog button styles.
+
+### Ordering
+
+Dialog buttons are in left-to-right order following the Windows convention:
+
+* OK / Cancel
+* Yes / No / Cancel
+
+Note that "OK" should be capitalized.
+
+### OK vs Close
+
+If a button closes a dialog and persists data within it, the button label
+should be OK (all uppercase).
+
+If a button closes a dialog but there is not data within it to persist, the
+button label should be Close.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -4,13 +4,27 @@ When adding or changing user interface elements in Guiguts, use this style
 guide as a reference. Guiguts was developed by numerous people over many years
 and this style guide is very recent, so not all parts adhere to this (yet).
 
-## Dialog buttons
+## Menus
+
+Menu items that open up a dialog should end with "...".
+
+## Dialogs
 
 Most Guiguts users are on Windows, so we use the
 [Windows UX guide](https://docs.microsoft.com/en-us/windows/win32/uxguide/win-dialog-box)
-for dialog button styles.
+for dialog styles.
 
-### Ordering
+### Title
+
+If a dialog is used solely to set values, the menu item or button that loads
+the dialog should start with a verb, eg: "Set File Paths..." and the dialog
+title should be a noun, eg: "File Paths". These dialog should have an "OK"
+button (and possibly a "Cancel" button). More on this below.
+
+Dialogs that present a tool palette for manipulating the page text should
+be accessed via the menu with the name of the dialog, eg: "Spell Check...".
+
+### Button ordering
 
 Dialog buttons are in left-to-right order following the Windows convention:
 
@@ -19,10 +33,13 @@ Dialog buttons are in left-to-right order following the Windows convention:
 
 Note that "OK" should be capitalized.
 
-### OK vs Close
+### OK vs Cancel vs Close buttons
 
 If a button closes a dialog and persists data within it, the button label
 should be OK (all uppercase).
+
+If a button closes a dialog with data but does not persist it, the button label
+should be Cancel.
 
 If a button closes a dialog but there is not data within it to persist, the
 button label should be Close.

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -1400,7 +1400,7 @@ sub gcrunopts {
 	my $textwindow = $::textwindow;
 	my $top        = $::top;
 	$::lglobal{gcrunoptspop} =
-	  $top->DialogBox( -title => 'Bookloupe/Gutcheck Run Options', -buttons => ['Close'] );
+	  $top->DialogBox( -title => 'Bookloupe/Gutcheck Run Options', -buttons => ['OK'] );
 	my $gcopt6 =
 	  $::lglobal{gcrunoptspop}->add(
 							   'Checkbutton',

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1755,7 +1755,7 @@ sub htmlimage {
 		my $f8 =
 		  $::lglobal{htmlimpop}->Frame->pack( -side => 'top', -anchor => 'n' );
 		$f8->Button(
-			-text    => 'Ok',
+			-text    => 'OK',
 			-width   => 10,
 			-command => sub {
 				my $name = $::lglobal{imgname}->get;
@@ -2763,7 +2763,7 @@ sub markup {
 				  ->Frame->pack( -side => 'top', -anchor => 'n' );
 				my $okbut = $linkf3->Button(
 					-activebackground => $::activecolor,
-					-text             => 'Ok',
+					-text             => 'OK',
 					-width            => 16,
 					-command          => sub {
 						$name = $::lglobal{linkentry}->get;

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -198,7 +198,7 @@ sub menu_preferences {
 			-tearoff => 1,
 			-menuitems =>
 			  [ # FIXME: sub this and generalize for all occurences in menu code.
-				[ Button => '~Font...', -command => \&::fontsize ],
+				[ Button => 'Set ~Font...', -command => \&::fontsize ],
 				[ 'separator', '' ],
 				[
 					Checkbutton => 'Keep Pop-ups On Top',
@@ -293,7 +293,7 @@ sub menu_preferences {
 					-offvalue   => 0
 				],
 				[
-					Checkbutton => 'Use Old Spellcheck Layout',
+					Checkbutton => 'Use Old Spell Check Layout',
 					-variable   => \$::oldspellchecklayout,
 					-onvalue    => 1,
 					-offvalue   => 0,
@@ -400,7 +400,7 @@ sub menu_preferences {
 					  }
 				],
 				[
-					Button   => 'Auto Save ~Interval...',
+					Button   => 'Set Auto Save ~Interval...',
 					-command => sub {
 						::saveinterval();
 						::savesettings();
@@ -454,7 +454,7 @@ sub menu_preferences {
 					-offvalue   => 0
 				],
 				[
-					Button   => 'Search History Size...',
+					Button   => 'Set Search History Size...',
 					-command => sub {
 						::searchsize();
 						::savesettings();
@@ -462,7 +462,7 @@ sub menu_preferences {
 				],
 				[ 'separator', '' ],
 				[
-					Button   => 'Spellcheck Dictionary Select...',
+					Button   => 'Set Spell Check Options...',
 					-command => sub { ::spelloptions() }
 				],
 				[ 'separator', '' ],
@@ -515,7 +515,7 @@ sub menu_external {
 			( 0 .. $#::extops ) ),
 		[ 'separator', '' ],
 		[
-			Button   => 'Setup ~External Operations...',
+			Button   => 'Set ~External Programs...',
 			-command => \&::externalpopup
 		],
 	];
@@ -1412,7 +1412,7 @@ sub menubuilddefault {
 					$textwindow->addGlobEnd;
 				  }
 			],
-			[	Button   => '~Auto-Conv. Italics, Bold and tb',
+			[	Button   => '~Auto-Convert Italics, Bold and tb',
 				-command => sub {
 					$textwindow->addGlobStart;
 					::text_convert_italic( $textwindow, $::italic_char );

--- a/src/lib/Guiguts/MultiLingual.pm
+++ b/src/lib/Guiguts/MultiLingual.pm
@@ -598,7 +598,7 @@ sub setmultiplelanguages {
 	$::multidicts[0] = $::globalspelldictopt;
 	my $dicts;
 	my $spellop = $top->DialogBox( -title   => 'Multiple language selection',
-								   -buttons => ['Close'] );
+								   -buttons => ['OK'] );
 	$spellop->Icon( -image => $::icon );
 	my $baselanglabel =
 	  $spellop->add( 'Label', -text => 'Base language' )->pack;

--- a/src/lib/Guiguts/PageSeparators.pm
+++ b/src/lib/Guiguts/PageSeparators.pm
@@ -33,7 +33,7 @@ EOM
 		$::lglobal{pagesephelppop}->focus;
 	} else {
 		$::lglobal{pagesephelppop} = $top->Toplevel;
-		$::lglobal{pagesephelppop}->title('Functions and Hotkeys for Page Separator Fixup');
+		$::lglobal{pagesephelppop}->title('Functions and Hotkeys for Fixup Page Separators');
 		::initialize_popup_with_deletebinding('pagesephelppop');
 		$::lglobal{pagesephelppop}->Label(
 			-justify => "left",
@@ -487,7 +487,7 @@ sub redojoin {
 sub separatorpopup {
 	my $textwindow = $::textwindow;
 	my $top        = $::top;
-	::operationadd('Begin Page Separators Fixup');
+	::operationadd('Begin Fixup Page Separators');
 	$::lglobal{pagesepauto} = 1 if !defined $::lglobal{pagesepauto} || $::lglobal{pagesepauto} >= 2;
 	if ( defined( $::lglobal{pageseppop} ) ) {
 		$::lglobal{pageseppop}->deiconify;
@@ -495,7 +495,7 @@ sub separatorpopup {
 		$::lglobal{pageseppop}->focus;
 	} else {
 		$::lglobal{pageseppop} = $top->Toplevel;
-		$::lglobal{pageseppop}->title('Page Separator Fixup');
+		$::lglobal{pageseppop}->title('Fixup Page Separators');
 		my $sf1 =
 		  $::lglobal{pageseppop}->Frame->pack( -side => 'top', -anchor => 'n' );
 		my $joinbutton = $sf1->Button(

--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -246,7 +246,7 @@ sub fontsize {
 		)->grid( -row => 2, -column => 2, -pady => 5 );
 		my $button_ok = $mframe->Button(
 			-activebackground => $::activecolor,
-			-text             => 'Close',
+			-text             => 'OK',
 			-command          => sub {
 				$::lglobal{fontpop}->destroy;
 				undef $::lglobal{fontpop};
@@ -555,7 +555,7 @@ sub filePathsPopup {
 		    )->pack( -expand => 'y', -fill   => 'x' );
 		$::lglobal{filepathspop}->Button(
 			-activebackground => $::activecolor,
-			-text             => 'Close',
+			-text             => 'OK',
 			-command          => sub {
 				$::lglobal{filepathspop}->destroy;
 				undef $::lglobal{filepathspop};
@@ -614,7 +614,7 @@ sub setDPurls {
 		    )->grid( -row => 4, -column => 1, -pady => 2 );
 		$f0->Button(
 			-activebackground => $::activecolor,
-			-text             => 'Close',
+			-text             => 'OK',
 			-command          => sub {
 				$::lglobal{defurlspop}->destroy;
 				undef $::lglobal{defurlspop};

--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -51,7 +51,7 @@ sub setmargins {
 		$::lglobal{marginspop}->focus;
 	} else {
 		$::lglobal{marginspop} = $top->Toplevel;
-		$::lglobal{marginspop}->title('Set Margins for Rewrap');
+		$::lglobal{marginspop}->title('Rewrap Margins');
 		$::lglobal{marginspop}->resizable('no', 'no');
 		
 	my $lmframe =
@@ -292,11 +292,11 @@ sub saveinterval {
     }
     else {
         $::lglobal{intervalpop} = $top->Toplevel;
-        $::lglobal{intervalpop}->title('Autosave Interval');
+        $::lglobal{intervalpop}->title('Auto Save Interval');
         $::lglobal{intervalpop}->resizable( 'no', 'no' );
         my $frame = $::lglobal{intervalpop}
             ->Frame->pack( -fill => 'x', -padx => 5, -pady => 5 );
-        $frame->Label( -text => 'Minutes between autosave' )
+        $frame->Label( -text => 'Minutes between auto save' )
             ->pack( -side => 'left' );
         my $entry = $frame->Entry(
             -background   => $::bkgcolor,
@@ -405,7 +405,7 @@ sub filePathsPopup {
 		$::lglobal{filepathspop}->focus;
 	} else {
 		$::lglobal{filepathspop} = $top->Toplevel;
-		$::lglobal{filepathspop}->title('Set File Paths');
+		$::lglobal{filepathspop}->title('File Paths');
 		my $f1 = $::lglobal{filepathspop}->Frame->pack(
 			-side   => 'top',
 			-anchor => 'n',
@@ -582,7 +582,7 @@ sub setDPurls {
 		$::lglobal{defurlspop}->focus;
 	} else {
 		$::lglobal{defurlspop} = $top->Toplevel;
-		$::lglobal{defurlspop}->title('URLs');
+		$::lglobal{defurlspop}->title('DP URLs');
 		my $f0 =
 		  $::lglobal{defurlspop}->Frame->pack( -side => 'top', -anchor => 'n' );
 		$f0->Label( -text => "Contact proofer with username:")

--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -161,25 +161,30 @@ sub setmargins {
 							  -to           => 10,
 		  )->pack( -side => 'left' );
 	}
-		::initialize_popup_without_deletebinding('marginspop');
-		$::lglobal{marginspop}->protocol(
-			'WM_DELETE_WINDOW' => sub {
-				$::lglobal{marginspop}->destroy;
-				undef $::lglobal{marginspop};
-				if ( ( $::blockrmargin < $::blocklmargin ) || ( $::rmargin < $::lmargin ) )
-				{
-					$top->messageBox(
-						  -icon    => 'error',
-						  -title   => 'Incorrect margins',
-						  -message => 'The left margin must be smaller than the right margin.',
-						  -type    => 'OK',
-					);
-					setmargins();
-				} else {
-					::savesettings();
-				}
+	my $button_frame =
+	  $::lglobal{marginspop}->Frame->pack( -side => 'top', -padx => 5, -pady => 3 );
+	my $button_ok = $button_frame->Button(
+		-activebackground => $::activecolor,
+		-text             => 'OK',
+		-command          => sub {
+			$::lglobal{marginspop}->destroy;
+			undef $::lglobal{marginspop};
+			if ( ( $::blockrmargin < $::blocklmargin ) || ( $::rmargin < $::lmargin ) )
+			{
+				$top->messageBox(
+					  -icon    => 'error',
+					  -title   => 'Incorrect margins',
+					  -message => 'The left margin must be smaller than the right margin.',
+					  -type    => 'OK',
+				);
+				setmargins();
+			} else {
+				::savesettings();
 			}
-		);
+		}
+	)->grid( -row => 3, -column => 2, -pady => 5 );
+
+		::initialize_popup_with_deletebinding('marginspop');
 	}
 	$::lglobal{marginspop}->raise;
 	$::lglobal{marginspop}->focus;

--- a/src/lib/Guiguts/SpellCheck.pm
+++ b/src/lib/Guiguts/SpellCheck.pm
@@ -999,7 +999,7 @@ sub spelloptions {
 	}
 	my $dicts;
 	my $dictlist;
-	my $spellop = $top->DialogBox( -title   => 'Spellcheck Options',
+	my $spellop = $top->DialogBox( -title   => 'Spell Check Options',
 								   -buttons => ['OK'] );
 	my $spellpathlabel =
 	  $spellop->add( 'Label', -text => 'Aspell executable file:' )->pack;

--- a/src/lib/Guiguts/SpellCheck.pm
+++ b/src/lib/Guiguts/SpellCheck.pm
@@ -1000,7 +1000,7 @@ sub spelloptions {
 	my $dicts;
 	my $dictlist;
 	my $spellop = $top->DialogBox( -title   => 'Spellcheck Options',
-								   -buttons => ['Close'] );
+								   -buttons => ['OK'] );
 	my $spellpathlabel =
 	  $spellop->add( 'Label', -text => 'Aspell executable file:' )->pack;
 	my $spellpathentry =

--- a/src/lib/Guiguts/TextProcessingMenu.pm
+++ b/src/lib/Guiguts/TextProcessingMenu.pm
@@ -47,7 +47,7 @@ sub text_convert_tb {
 
 sub text_convert_options {
 	my $top = shift;
-	my $options = $top->DialogBox( -title   => "Text Processing Options",
+	my $options = $top->DialogBox( -title   => "Auto-Convert Options",
 								   -buttons => ["OK"], );
 	my $italic_frame =
 	  $options->add('Frame')->pack( -side => 'top', -padx => 5, -pady => 3 );

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2032,7 +2032,7 @@ sub externalpopup {    # Set up the external commands menu
 				$::lglobal{extoptpop}->destroy;
 				undef $::lglobal{extoptpop};
 			},
-			-text  => 'Close',
+			-text  => 'OK',
 			-width => 8
 		)->pack( -side => 'top', -padx => 2, -anchor => 'n' );
 		::initialize_popup_with_deletebinding('extoptpop');
@@ -2262,7 +2262,7 @@ sub getprojectid {
 sub setprojectid {
 	my ( $textwindow, $top ) = ( $::textwindow, $::top );
 	my $projectidpop = $top->DialogBox(
-		-buttons => ['Close'],
+		-buttons => ['OK'],
 		-title   => 'DP Project ID',
 	);
 	$projectidpop->resizable( 'no', 'no' );

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1966,7 +1966,7 @@ sub externalpopup {    # Set up the external commands menu
 		$::lglobal{extoptpop}->raise;
 		$::lglobal{extoptpop}->focus;
 	} else {
-		$::lglobal{extoptpop} = $top->Toplevel( -title => 'External programs', );
+		$::lglobal{extoptpop} = $top->Toplevel( -title => 'External Programs', );
 		my $f0 =
 		  $::lglobal{extoptpop}->Frame->pack( -side => 'top', -anchor => 'n' );
 		$f0->Label( -text =>


### PR DESCRIPTION
This standardizes when we use `OK` vs when we use `Close` in dialogs. I've added a style guide as part of this.

I've also massaged dialog titles to match the menu item they came from and other small spacing and capitalization changes to make things more consistent.

The only functional change is adding an OK button to the Set Margins dialog.