### PR TITLE
Make track operations default to off

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -178,7 +178,7 @@ our $stayontop           = 0;
 our $suspectindex;
 our $toolside           = 'bottom';
 our $menulayout         = 'default';
-our $trackoperations    = 1;
+our $trackoperations    = 0;	# Default to off (tracking triggers edited flag)
 our $twowordsinhyphencheck = 0;
 our $unicodemenusplit   = 2; # 2 or 3
 our $utffontname        = 'Courier New';


### PR DESCRIPTION
Tracking operations causes the edited flag to be triggered
because operation tracking is stored in the bin file.
This is confusing to new users who generally wouldn't
use tracking anyway as it is not a reliable record of which
operations have been completed.
So, default to off.