### PR TITLE
Add "Always treat as UTF-8" option

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -183,6 +183,7 @@ our $twowordsinhyphencheck = 0;
 our $unicodemenusplit   = 2; # 2 or 3
 our $utffontname        = 'Courier New';
 our $utffontsize        = 14;
+our $utf8save           = 1;	# True = always save utf8, false = only if unicode characters in file
 our $verboseerrorchecks = 0;
 our $vislnnm            = 0;
 our $w3cremote          = 0;

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -986,7 +986,7 @@ EOM
 			multisearchsize multiterm nobell nohighlights projectfileslocation notoolbar oldspellchecklayout poetrylmargin projectfileslocation
 			recentfile_size rewrapalgo rmargin rmargindiff rwhyphenspace sc_char scannos_highlighted spellcheckwithenchant stayontop toolside 
 			trackoperations txt_conv_bold txt_conv_font txt_conv_gesperrt txt_conv_italic txt_conv_sc txt_conv_tb
-			twowordsinhyphencheck unicodemenusplit utffontname utffontsize
+			twowordsinhyphencheck unicodemenusplit utf8save utffontname utffontsize
 			url_no_proofer url_yes_proofer urlprojectpage urlprojectdiscussion
 			menulayout verboseerrorchecks vislnnm w3cremote wfstayontop/
 		  )

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -483,6 +483,12 @@ sub menu_preferences {
 					Button   => 'Set Rewrap ~Margins...',
 					-command => \&::setmargins
 				],
+				[
+					Checkbutton => "Always treat as UTF-8",
+					-variable   => \$::utf8save,
+					-onvalue    => 1,
+					-offvalue   => 0,
+				],
 			  ]
 		]
 	];

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -484,7 +484,7 @@ sub menu_preferences {
 					-command => \&::setmargins
 				],
 				[
-					Checkbutton => "Always treat as UTF-8",
+					Checkbutton => "Always Treat as ~UTF-8",
 					-variable   => \$::utf8save,
 					-onvalue    => 1,
 					-offvalue   => 0,

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2233,6 +2233,7 @@ sub columnizeselection {
 }
 
 sub currentfileisunicode {
+	return 1 if $::utf8save; # treat as unicode regardless of contents
 	my $textwindow = $::textwindow;
 	return $textwindow->search( '-regexp', '--', '[\x{100}-\x{FFFE}]', '1.0', 'end' );
 }


### PR DESCRIPTION
Previously, GG searched the file to see if there were
characters above \xFF in order to decide whether to
save, etc., as utf8.
Flag set via preferences now forces treating as utf8.
Default is on.