### PR TITLE
Preserve file permissions on saving

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -321,15 +321,17 @@ sub _bin_save {
 	}
 	my $bak = "$binname.bak";
 	if ( -e $bak ) {
-		my $perms = ( stat($bak) )[2] & 7777;
+		my $perms = ( stat($bak) )[2] & 0777;
 		unless ( $perms & 300 ) {
 			$perms = $perms | 300;
 			chmod $perms, $bak or warn "Can not back up .bin file: $!\n";
 		}
 		unlink $bak;
 	}
+	my $permsave;
 	if ( -e $binname ) {
-		my $perms = ( stat($binname) )[2] & 7777;
+		my $perms = ( stat($binname) )[2] & 0777;
+		$permsave = $perms;
 		unless ( $perms & 300 ) {
 			$perms = $perms | 300;
 			chmod $perms, $binname
@@ -393,6 +395,7 @@ sub _bin_save {
 "\$scannoslistpath = '@{[::escape_problems(::os_normal($::scannoslistpath))]}';\n\n";
 		print $fh '1;';
 		$fh->close;
+		chmod $permsave, $binname if $permsave;	# copy file permissions if overwriting
 	} else {
 		$top->BackTrace("Cannot open $binname:$!");
 	}

--- a/src/lib/Guiguts/TextUnicode.pm
+++ b/src/lib/Guiguts/TextUnicode.pm
@@ -100,11 +100,14 @@ sub SaveUTF {
 	}
 	$progress->withdraw if defined $progress;
 	close $tempfh;
+	my $permsave;
 	if ( -e $filename ) {
+		$permsave = ( stat($filename) )[2] & 0777;
 		chmod 0777, $filename;
 		unlink $filename;
 	}
 	if ( rename( $tempfilename, $filename ) ) {
+		chmod $permsave, $filename if $permsave;	# copy file permissions if overwriting
 		#$w->ResetUndo; #serves no purpose to reset undo
 		$w->FileName($filename);
 		return 1;


### PR DESCRIPTION
When saving an existing file (or bin file) remember its
file permissions before deleting it, so they can be copied
to the new version of the file. To fix reported bug that GG
was removing group/other access under Linux every save.

Also fixed incorrect use of decimal constant intended
to be octal constant.

Tested as best I could, given limited ability to set permissions on my Windows machine - "readonly"ness was preserved.