### PR TITLE
Require "[Footnote" to mark start of footnote

### DIFF
--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -1313,7 +1313,7 @@ sub footnotefind {
 	my ( $bracketndx, $nextbracketndx, $bracketstartndx, $bracketendndx );
 	$::lglobal{ftnoteindexstart} = $textwindow->index('fnindex');
 	$bracketstartndx =
-	  $textwindow->search( '-regexp', '--', '\[[Ff][Oo][Oo][Tt]',
+	  $textwindow->search( '-nocase', '--', '[Footnote',
 						   $::lglobal{ftnoteindexstart}, 'end' );
 	return ( 0, 0 ) unless $bracketstartndx;
 	$bracketndx = "$bracketstartndx+1c";


### PR DESCRIPTION
At just one point, "[foot" was accepted to start a
footnote, which messed up footnote processing.
Require "[Footnote" (case insensitive) instead.

Bug reported as footnotes going wrong when
text contained "at the [foot of the] south-east hills"