### PR TITLE
Use em or % for Auto-Illustration widths

### DIFF
--- a/src/headerdefault.txt
+++ b/src/headerdefault.txt
@@ -145,12 +145,15 @@ em.gesperrt
 
 img {
     max-width: 100%;
+    width: 100%;
     height: auto;
 }
 
 .figcenter {
     margin: auto;
     text-align: center;
+    page-break-inside: avoid;
+    max-width: 100%;
 }
 
 .figleft {
@@ -162,6 +165,8 @@ img {
     margin-right: 1em;
     padding: 0;
     text-align: center;
+    page-break-inside: avoid;
+    max-width: 100%;
 }
 
 .figright {
@@ -173,6 +178,8 @@ img {
     margin-right: 0;
     padding: 0;
     text-align: center;
+    page-break-inside: avoid;
+    max-width: 100%;
 }
 
 /* Footnotes */

--- a/src/headerdefault.txt
+++ b/src/headerdefault.txt
@@ -145,9 +145,10 @@ em.gesperrt
 
 img {
     max-width: 100%;
-    width: 100%;
     height: auto;
 }
+img.w100 {width: 100%;}
+
 
 .figcenter {
     margin: auto;

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1796,104 +1796,102 @@ sub htmlimage {
 sub htmlimageok {
 	my $textwindow = shift;
 	my $name = $::lglobal{imgname}->get;
-	if ($name) {
-		my $widthcn = my $width = $::lglobal{widthent}->get;
-		$widthcn =~ s/\./_/; # Convert decimal point to underscore for classname
-		return unless $name;
-		my ( $fname, $extension );
-		( $fname, $::globalimagepath, $extension ) =
-		  ::fileparse($name);
-		$::globalimagepath = ::os_normal($::globalimagepath);
-		$name =~ s/[\/\\]/\;/g;
-		my $tempname = $::globallastpath;
-		$tempname =~ s/[\/\\]/\;/g;
-		$name     =~ s/$tempname//;
-		$name     =~ s/;/\//g;
-		my $selection = $::lglobal{captiontext}->get;
-		$selection ||= '';
-		my $alt = $::lglobal{alttext}->get;
-		$alt =~ s/"/&quot;/g;
-		$alt = " alt=\"$alt\"";
-		$selection = "  <div class=\"caption\">$selection</div>\n"
-		  if $selection;
-		$::lglobal{preservep} = '' unless $selection;
-		my $title = $::lglobal{titltext}->get || '';
-		$title =~ s/"/&quot;/g;
-		$title = " title=\"$title\"" if $title;
+	return unless $name;
+	my $widthcn = my $width = $::lglobal{widthent}->get;
+	$widthcn =~ s/\./_/; # Convert decimal point to underscore for classname
+	my ( $fname, $extension );
+	( $fname, $::globalimagepath, $extension ) =
+	  ::fileparse($name);
+	$::globalimagepath = ::os_normal($::globalimagepath);
+	$name =~ s/[\/\\]/\;/g;
+	my $tempname = $::globallastpath;
+	$tempname =~ s/[\/\\]/\;/g;
+	$name     =~ s/$tempname//;
+	$name     =~ s/;/\//g;
+	my $selection = $::lglobal{captiontext}->get;
+	$selection ||= '';
+	my $alt = $::lglobal{alttext}->get;
+	$alt =~ s/"/&quot;/g;
+	$alt = " alt=\"$alt\"";
+	$selection = "  <div class=\"caption\">$selection</div>\n"
+	  if $selection;
+	$::lglobal{preservep} = '' unless $selection;
+	my $title = $::lglobal{titltext}->get || '';
+	$title =~ s/"/&quot;/g;
+	$title = " title=\"$title\"" if $title;
 
-		# Use filename as basis for an id - remove file extension first
-		$fname =~ s/\.[^\.]*$//;
-		my $idname = makeanchor( ::deaccentdisplay($fname) );
-		my $classname = 'illow' . ( $::lglobal{htmlimgwidthtype} eq '%' ? 'p' : 'e' ) . $widthcn;
-		my $classreg = '\.illow[pe][0-9\.]+'; # Match any automatically added illow classes
+	# Use filename as basis for an id - remove file extension first
+	$fname =~ s/\.[^\.]*$//;
+	my $idname = makeanchor( ::deaccentdisplay($fname) );
+	my $classname = 'illow' . ( $::lglobal{htmlimgwidthtype} eq '%' ? 'p' : 'e' ) . $widthcn;
+	my $classreg = '\.illow[pe][0-9\.]+'; # Match any automatically added illow classes
 
-		# Replace [Illustration] with div, img and caption
-		$textwindow->addGlobStart;
-		$textwindow->delete( 'thisblockstart', 'thisblockend' );
-		$textwindow->insert( 'thisblockstart',
-				"<div class=\"fig$::lglobal{htmlimgalignment} $classname\" id=\"$idname\" >\n"
-			  . "  <img src=\"$name\" $alt$title />\n"
-			  . "$selection</div>"
-			  . $::lglobal{preservep} );
-			  
-		# Write class into CSS block (sorted) - first find end of CSS
-		my $insertpoint = $textwindow->search( '--', '</style', '1.0', 'end' );
-		if ($insertpoint) {
-			my $cssdef = ".$classname {width: " . $width . "$::lglobal{htmlimgwidthtype};}";
-			# Unless this class has been added already ...
-			unless ($textwindow->search( '-backwards', '--', $cssdef, $insertpoint, '10.0' )) {
-				# Find end of last class definition in CSS
-				$insertpoint = $textwindow->search( '-backwards', '--', '}', $insertpoint, '10.0' );
-				if ($insertpoint) {
-					$insertpoint = $insertpoint . ' +1l'; # default position for first ever illow class
-					my $length = 0;
-					my $classpoint = $insertpoint;
-					# Loop back through illow classes to find correct place to insert
-					# If a smaller width is found, insert after it. If not, insert at start of list
-					while (	$classpoint = $textwindow->search( '-backwards', '-regexp',
-								'-count' => \$length, '--', $classreg, $classpoint, '10.0')) {
-						$insertpoint = $classpoint; # Potential insert point
-						my $testcn = $textwindow->get( "$classpoint+1c", "$classpoint+${length}c" );
-						if ( $testcn le $classname ) {
-							$insertpoint = $insertpoint . ' +1l'; # Insert after smaller width
-							last;
-						}
+	# Replace [Illustration] with div, img and caption
+	$textwindow->addGlobStart;
+	$textwindow->delete( 'thisblockstart', 'thisblockend' );
+	$textwindow->insert( 'thisblockstart',
+			"<div class=\"fig$::lglobal{htmlimgalignment} $classname\" id=\"$idname\" >\n"
+		  . "  <img class=\"w100\" src=\"$name\" $alt$title />\n"
+		  . "$selection</div>"
+		  . $::lglobal{preservep} );
+		  
+	# Write class into CSS block (sorted) - first find end of CSS
+	my $insertpoint = $textwindow->search( '--', '</style', '1.0', 'end' );
+	if ($insertpoint) {
+		my $cssdef = ".$classname {width: " . $width . "$::lglobal{htmlimgwidthtype};}";
+		# Unless this class has been added already ...
+		unless ($textwindow->search( '-backwards', '--', $cssdef, $insertpoint, '10.0' )) {
+			# Find end of last class definition in CSS
+			$insertpoint = $textwindow->search( '-backwards', '--', '}', $insertpoint, '10.0' );
+			if ($insertpoint) {
+				$insertpoint = $insertpoint . ' +1l'; # default position for first ever illow class
+				my $length = 0;
+				my $classpoint = $insertpoint;
+				# Loop back through illow classes to find correct place to insert
+				# If a smaller width is found, insert after it. If not, insert at start of list
+				while (	$classpoint = $textwindow->search( '-backwards', '-regexp',
+							'-count' => \$length, '--', $classreg, $classpoint, '10.0')) {
+					$insertpoint = $classpoint; # Potential insert point
+					my $testcn = $textwindow->get( "$classpoint+1c", "$classpoint+${length}c" );
+					if ( $testcn le $classname ) {
+						$insertpoint = $insertpoint . ' +1l'; # Insert after smaller width
+						last;
 					}
-					$textwindow->ntinsert( $insertpoint . ' linestart', $cssdef . "\n");
+				}
+				$textwindow->ntinsert( $insertpoint . ' linestart', $cssdef . "\n");
 
-					# Unless it already exists, add heading before first illow class
-					my $heading = '/* Illustration classes */';
-					unless ($textwindow->search( '--', $heading, '10.0', $insertpoint )) {
-						$insertpoint = $textwindow->search( '-regexp', '--', $classreg, '10.0', $insertpoint );
-						$textwindow->ntinsert( $insertpoint . ' linestart', "\n$heading\n") if ($insertpoint);
-					}
+				# Unless it already exists, add heading before first illow class
+				my $heading = '/* Illustration classes */';
+				unless ($textwindow->search( '--', $heading, '10.0', $insertpoint )) {
+					$insertpoint = $textwindow->search( '-regexp', '--', $classreg, '10.0', $insertpoint );
+					$textwindow->ntinsert( $insertpoint . ' linestart', "\n$heading\n") if ($insertpoint);
 				}
 			}
 		}
-		$textwindow->addGlobEnd;
-		
-		$::lglobal{htmlthumb}->delete
-		  if $::lglobal{htmlthumb};
-		$::lglobal{htmlthumb}->destroy
-		  if $::lglobal{htmlthumb};
-		$::lglobal{htmlorig}->delete
-		  if $::lglobal{htmlorig};
-		$::lglobal{htmlorig}->destroy
-		  if $::lglobal{htmlorig};
-		for (
-			$::lglobal{alttext},  $::lglobal{titltext},
-			$::lglobal{widthent}, $::lglobal{heightent},
-			$::lglobal{imagelbl}, $::lglobal{imgname}
-		  )
-		{
-			$_->destroy;
-		}
-		$textwindow->tagRemove( 'highlight', '1.0', 'end' );
-		$::lglobal{htmlimpop}->destroy
-		  if $::lglobal{htmlimpop};
-		undef $::lglobal{htmlimpop}
-		  if $::lglobal{htmlimpop};
 	}
+	$textwindow->addGlobEnd;
+	
+	$::lglobal{htmlthumb}->delete
+	  if $::lglobal{htmlthumb};
+	$::lglobal{htmlthumb}->destroy
+	  if $::lglobal{htmlthumb};
+	$::lglobal{htmlorig}->delete
+	  if $::lglobal{htmlorig};
+	$::lglobal{htmlorig}->destroy
+	  if $::lglobal{htmlorig};
+	for (
+		$::lglobal{alttext},  $::lglobal{titltext},
+		$::lglobal{widthent}, $::lglobal{heightent},
+		$::lglobal{imagelbl}, $::lglobal{imgname}
+	  )
+	{
+		$_->destroy;
+	}
+	$textwindow->tagRemove( 'highlight', '1.0', 'end' );
+	$::lglobal{htmlimpop}->destroy
+	  if $::lglobal{htmlimpop};
+	undef $::lglobal{htmlimpop}
+	  if $::lglobal{htmlimpop};
 }
 
 # Reset the width field to the default for the current type

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1824,8 +1824,8 @@ sub htmlimageok {
 		# Use filename as basis for an id - remove file extension first
 		$fname =~ s/\.[^\.]*$//;
 		my $idname = makeanchor( ::deaccentdisplay($fname) );
-		my $classname = 'illow' . $widthcn . ( $::lglobal{htmlimgwidthtype} eq '%' ? 'p' : 'e' );
-		my $classreg = '\.illow[0-9\.]+[pe]'; # Match any automatically added illow classes
+		my $classname = 'illow' . ( $::lglobal{htmlimgwidthtype} eq '%' ? 'p' : 'e' ) . $widthcn;
+		my $classreg = '\.illow[pe][0-9\.]+'; # Match any automatically added illow classes
 
 		# Replace [Illustration] with div, img and caption
 		$textwindow->addGlobStart;
@@ -1839,7 +1839,7 @@ sub htmlimageok {
 		# Write class into CSS block (sorted) - first find end of CSS
 		my $insertpoint = $textwindow->search( '--', '</style', '1.0', 'end' );
 		if ($insertpoint) {
-			my $cssdef = ".$classname {width: " . $widthcn . "$::lglobal{htmlimgwidthtype};}";
+			my $cssdef = ".$classname {width: " . $width . "$::lglobal{htmlimgwidthtype};}";
 			# Unless this class has been added already ...
 			unless ($textwindow->search( '-backwards', '--', $cssdef, $insertpoint, '10.0' )) {
 				# Find end of last class definition in CSS
@@ -1854,7 +1854,6 @@ sub htmlimageok {
 								'-count' => \$length, '--', $classreg, $classpoint, '10.0')) {
 						$insertpoint = $classpoint; # Potential insert point
 						my $testcn = $textwindow->get( "$classpoint+1c", "$classpoint+${length}c" );
-						print "$testcn\n";
 						if ( $testcn le $classname ) {
 							$insertpoint = $insertpoint . ' +1l'; # Insert after smaller width
 							last;

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -794,7 +794,10 @@ sub initialize {
 	$::lglobal{html_f}            = '<span class="antiqua">';	# HTML convert - default replacement for <f>
 	$::lglobal{html_g}            = '<em class="gesperrt">';	# HTML convert - default replacement for <g>
 	$::lglobal{html_i}            = '<i>';						# HTML convert - default replacement for <i>
-	$::lglobal{htmlimgar}         = 1;				# HTML image aspect ratio
+	$::lglobal{htmlimgwidthtype}  = '%';			# HTML image width in % or em
+	$::lglobal{htmlimgalignment}  = 'center';		# HTML image alignment
+	$::lglobal{htmlimagesizex}    = 0;				# HTML pixel width of file loaded in image dialog
+	$::lglobal{htmlimagesizey}    = 0;				# HTML pixel height of file loaded in image dialog
 	$::lglobal{isedited}          = 0;
 	$::lglobal{wf_ignore_case}    = 0;
 	$::lglobal{keep_latin1}       = 1;				# HTML convert - retain Latin1 characters


### PR DESCRIPTION
User can choose to specify width in em or %
When user loads image or changes between em & %
GG calculates and displays best guess at suitable width.
If ems, width is pixels/16
If %, width is small enough % that whole image should
fit horizontally & vertically on a 4:3 screen.

Minor fixes added after testing