### PR TITLE
Use Ctrl-b in place of Ctrl-n for search count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - HTML title wording puts book title first
 
 ### Improved Search & Replace functionality
-- a Count button (Ctrl+N) counts how many times the current search
+- a Count button (`ctrl+b`) counts how many times the current search
   settings would find a match
 - number of replacement terms can be changed by the user
 - search & replace preserves the position of page markers
@@ -44,7 +44,7 @@
    - `ctrl+o` - open file
    - `ctrl+shift+s` - save as...
    - `ctrl+j` - goto line
-   - `ctrl+n` - count number of search/replace matches
+   - `ctrl+b` - count number of search/replace matches
    - `ctrl+w` - rewrap selection
    - `ctrl+shift+w` - block rewrap selection
    - `ctrl+m` - indent +1

--- a/src/hotkeys.txt
+++ b/src/hotkeys.txt
@@ -35,8 +35,8 @@ F8 -- open Stealth Scannos search
 
 <ctrl>+f -- open Search & Replace popup
 <ctrl>+g -- continue search
-<ctrl>+n -- count number of matches
 <ctrl>+<shift>+g -- continue search in opposite direction
+<ctrl>+b -- count number of matches
 
 <ctrl>+i -- view current image (as See Img button)
 <ctrl>+j -- go to line

--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -108,7 +108,7 @@ sub keybindings {
 				::searchpopup();
 			}
 		}, '<<FindNextReverse>>' );
-	keybind( '<Control-n>',         sub {
+	keybind( '<Control-b>',         sub {
 			if ( $::lglobal{searchpop} ) {
 				my $searchterm = $::lglobal{searchentry}->get( '1.0', '1.end' );
 				::countmatches($searchterm);
@@ -226,6 +226,9 @@ sub keybindings {
 #	keybind( '<KeyCombo1>', sub { doit(); }, '<<MyEvent>>' );
 #	keybind( '<KeyCombo2>', undef,           '<<MyEvent>>' );
 #
+# Warning: Actually binds event to class TextUnicode rather than the text window
+# instance. Currently the main text window is the only instance anyway.
+# If changed in the future, see comments below about bindtags order.
 
 sub keybind {
 	my $textwindow = $::textwindow;
@@ -247,5 +250,19 @@ sub keybind {
 		print "Undefined arguments to keybind\n";
 	}
 }
+
+# Notes on bindtags order in case of future development:
+#
+# The callback subs executed depend on the bindtags list.
+# Default taglist order for Perl/Tk is class, instance, toplevel, all.
+# (Tcl/Tk default is instance, class, toplevel, all, so beware when reading docs.)
+#
+# A callback can "break" out of the taglist search, so if you want to avoid
+# default class behaviour for a specific widget, but don't want to change
+# it for the whole class, you must reorder the taglist
+# so the instance callback precedes the class one (like Tcl/Tk), e.g.
+#	my @tags = $widget->bindtags;
+#	$widget->bindtags([@tags[1, 0, 2, 3]]);
+# Finish instance callback with $widget->break so class callback won't be called
 
 1;

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1525,6 +1525,7 @@ sub searchpopup {
 		::initialize_popup_without_deletebinding('searchpop');
 		$::lglobal{searchpop}->minsize( 460, 127 );
 		$::lglobal{searchentry}->focus;
+
 		$::lglobal{searchpop}->protocol(
 			'WM_DELETE_WINDOW' => sub {
 				$::lglobal{regrepeat}->cancel;
@@ -1536,71 +1537,61 @@ sub searchpopup {
 				$::scannosearch = 0;    #no longer in a scanno search
 			}
 		);
-		$::lglobal{searchpop}->Tk::bind(
-			'<Return>' => sub {
-				$::lglobal{searchentry}->see('1.0');
-				$::lglobal{searchentry}->delete('1.end');
-				$::lglobal{searchentry}->delete( '2.0', 'end' );
-				$::lglobal{replaceentry}->see('1.0');
-				$::lglobal{replaceentry}->delete('1.end');
-				$::lglobal{replaceentry}->delete( '2.0', 'end' );
-				searchtext();
-				$top->raise;
-			}
-		);
-		$::lglobal{searchpop}->Tk::bind(
-			'<Control-f>' => sub {
-				$::lglobal{searchentry}->see('1.0');
-				$::lglobal{searchentry}->delete( '2.0', 'end' );
-				$::lglobal{replaceentry}->see('1.0');
-				$::lglobal{replaceentry}->delete( '2.0', 'end' );
-				searchtext();
-				$top->raise;
-			}
-		);
-		$::lglobal{searchpop}->Tk::bind(
-			'<Control-F>' => sub {
-				$::lglobal{searchentry}->see('1.0');
-				$::lglobal{searchentry}->delete( '2.0', 'end' );
-				$::lglobal{replaceentry}->see('1.0');
-				$::lglobal{replaceentry}->delete( '2.0', 'end' );
-				searchtext();
-				$top->raise;
-			}
-		);
-		$::lglobal{searchpop}->eventAdd(
-			'<<FindNexte>>' => '<Control-Key-G>',
-			'<Control-Key-g>'
-		);
-		$::lglobal{searchentry}->bind(
-			'<<FindNexte>>',
+		# Return: find in current direction
+		searchbind( '<Return>',
 			sub {
-				$::lglobal{searchentry}->delete('insert -1c')
-				  if ( $::lglobal{searchentry}->get('insert -1c') eq "\cG" );
+				searchtext();
+				$top->raise;
+			}
+		);
+		# Control-Return: find & replace
+		searchbind( '<Control-Return>',
+			sub {
+				replace( $::lglobal{replaceentry}->get( '1.0', '1.end' ) );
+				searchtext();
+				$top->raise;
+			}
+		);
+		# Shift-Return: replace
+		searchbind( '<Shift-Return>',
+			sub {
+				replace( $::lglobal{replaceentry}->get( '1.0', '1.end' ) );
+				$top->raise;
+			}
+		);
+		# Control-Shift-Return: replace all
+		searchbind( '<Control-Shift-Return>',
+			sub {
+				replaceall( $::lglobal{replaceentry}->get( '1.0', '1.end' ) );
+				$top->raise;
+			}
+		);
+		# Control-f: find in current direction
+		searchbind( '<Control-f>',
+			sub {
+				searchtext();
+				$top->raise;
+			}
+		);
+		# Control-g: repeat find in current direction
+		searchbind( '<Control-g>',
+			sub {
 				searchtext( $::lglobal{searchentry}->get( '1.0', '1.end' ) );
 				$textwindow->focus;
 			}
 		);
-		$::lglobal{searchpop}->eventAdd(
-			'<<FindPreve>>' => '<Control-Shift-G>',
-			'<Control-Shift-g>'
-		);
-		$::lglobal{searchentry}->bind(
-			'<<FindPreve>>',
+		# Control-Shift-g: repeat find in opposite direction
+		searchbind( '<Control-Shift-g>',
 			sub {
-				$::lglobal{searchentry}->delete('insert -1c')
-				  if ( $::lglobal{searchentry}->get('insert -1c') eq "\cG" );
 				$::lglobal{searchop2}->toggle;
 				searchtext( $::lglobal{searchentry}->get( '1.0', '1.end' ) );
 				$::lglobal{searchop2}->toggle;
 				$textwindow->focus;
 			}
 		);
-		$::lglobal{searchpop}->eventAdd( '<<FindCounte>>' => '<Control-N>', '<Control-n>' );
-		$::lglobal{searchentry}->bind( '<<FindCounte>>',
+		# Control-b: count occurrences
+		searchbind( '<Control-b>',
 			sub {
-				$::lglobal{searchentry}->delete('insert -1c')
-				  if ( $::lglobal{searchentry}->get('insert -1c') eq "\cN" );
 				countmatches( $::lglobal{searchentry}->get( '1.0', '1.end' ) );
 			}
 		);
@@ -1625,50 +1616,34 @@ sub searchpopup {
 				eval " sub { \$::lglobal{hasfocus} = \$::lglobal{replaceentry$_}; } "
 			);
 		}
-		$::lglobal{searchpop}->Tk::bind(
-			'<Control-Return>' => sub {
-				$::lglobal{searchentry}->see('1.0');
-				$::lglobal{searchentry}->delete('1.end');
-				$::lglobal{searchentry}->delete( '2.0', 'end' );
-				$::lglobal{replaceentry}->see('1.0');
-				$::lglobal{replaceentry}->delete('1.end');
-				$::lglobal{replaceentry}->delete( '2.0', 'end' );
-				replace( $::lglobal{replaceentry}->get( '1.0', '1.end' ) );
-				searchtext();
-				$top->raise;
-			}
-		);
-		$::lglobal{searchpop}->Tk::bind(
-			'<Shift-Return>' => sub {
-				$::lglobal{searchentry}->see('1.0');
-				$::lglobal{searchentry}->delete('1.end');
-				$::lglobal{searchentry}->delete( '2.0', 'end' );
-				$::lglobal{replaceentry}->see('1.0');
-				$::lglobal{replaceentry}->delete('1.end');
-				$::lglobal{replaceentry}->delete( '2.0', 'end' );
-				replace( $::lglobal{replaceentry}->get( '1.0', '1.end' ) );
-				$top->raise;
-			}
-		);
-		$::lglobal{searchpop}->Tk::bind(
-			'<Control-Shift-Return>' => sub {
-				$::lglobal{searchentry}->see('1.0');
-				$::lglobal{searchentry}->delete('1.end');
-				$::lglobal{searchentry}->delete( '2.0', 'end' );
-				$::lglobal{replaceentry}->see('1.0');
-				$::lglobal{replaceentry}->delete('1.end');
-				$::lglobal{replaceentry}->delete( '2.0', 'end' );
-				replaceall( $::lglobal{replaceentry}->get( '1.0', '1.end' ) );
-				$top->raise;
-			}
-		);
 	}
 	if ( length $searchterm ) {
 		$::lglobal{searchentry}->delete( '1.0', 'end' );
 		$::lglobal{searchentry}->insert( 'end', $searchterm );
+		# Multiline search string not supported
+		# Todo: consider Entry instead of Text widgets
+		$::lglobal{searchentry}->delete( '1.end', 'end' );
 		$::lglobal{searchentry}->tagAdd( 'sel', '1.0', 'end -1c' );
 		searchtext('');
 	}
+}
+
+# Bind a key-combination to a sub for the S&R dialog
+# Also disable default class behaviour for key on Text widgets
+# (e.g. Ctrl-b does "move left" by default)
+# See KeyBindings.pm for main text window equivalent
+sub searchbind {
+	my $lkey = shift;				# Key-combination (lower-case letter)
+	my $subr = shift;				# Subroutine to bind to key
+
+	my $ukey = $lkey;
+	$ukey =~ s/-([a-z])>/-\u$1>/;	# Create uppercase version
+
+	$::lglobal{searchpop}->bind( $lkey => $subr );
+	$::lglobal{searchpop}->bind( $ukey => $subr ) if $ukey ne $lkey;
+	# Disable default class bindings for Text widgets
+	$::lglobal{searchpop}->MainWindow->bind( "Tk::Text", $lkey, 'NoOp');
+	$::lglobal{searchpop}->MainWindow->bind( "Tk::Text", $ukey, 'NoOp') if $ukey ne $lkey;
 }
 
 # Add frames containing field and buttons for replacement terms


### PR DESCRIPTION
Since Ctrl-n might be wanted later for "New", use Ctrl-b
instead to count number of search matches.

Ctrl-b executes a default action of "move back one space"
in Text widgets. It was therefore necessary to disable that
default binding and bind the new action.

Ctrl-f was previously executing its default action (forward
one space) if pressed in the search/replace fields, as well as
its search function. Now fixed by new code in binding sub.
Also, no longer need for deleting Ctrl-g from text field when
that is pressed, nor removing second line of text if Enter key
(to search) was pressed in middle of text string.

Handling of multiline search string, e.g. by selecting 2 lines
of text in main window and pressing Ctrl-f was inconsistent.
Some paths through code attempted to remove all but the
first line, sometimes successfully. Some paths did not remove
additional lines. For now, only the first line selected is
included in the search box, though (as previously) user can
copy and paste multiple lines of text into the search or
replace boxes deliberately, but maybe with unexpected
results.

Consider replacing the Text boxes which allow multilines
with Entry boxes which are single line, for future release.

Notes also made in KeyBindings on order of callbacks in
Perl/Tk and how to override behaviour for a specific
widget if required in future.