### PR TITLE
Update links to manual & forum

### DIFF
--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -114,19 +114,14 @@ sub menu_help {
 	my $help_top = [
 		[ Button   => '~Manual [www]',
 			-command => sub {
-				::launchurl( "https://www.pgdp.net/wiki/PPTools/Guiguts" );
+				::launchurl( 'https://www.pgdp.net/wiki/PPTools/Guiguts/Guiguts_1.1_Manual' );
 			  }
 		],
 		[ Button  => 'Guiguts ~Help on DP Forum [www]',
-		  -command => sub { ::launchurl('https://www.pgdp.net/phpBB3/viewtopic.php?f=13&t=11466'); }
+		  -command => sub { ::launchurl('https://www.pgdp.net/phpBB3/viewtopic.php?t=11466'); }
 		],
 		[ Button => '~Keyboard Shortcuts',    -command => \&::hotkeyshelp ],
 		[ Button => '~Regex Quick Reference', -command => \&::regexref ],
-		[ Button => 'Re~wrap Markers [www]',
-		  -command => sub {
-			::launchurl( 'https://www.pgdp.net/wiki/PPTools/Guiguts/Rewrapping#Rewrap_Markers' );
-		  }
-		],
 	];
 	my $character_help = [
 		[ 'separator', '' ],


### PR DESCRIPTION
Link to new manual
Remove & from forum link (& is not allowed in URLs
launched from within GG on Windows)
Remove "Re-wrap Markers" help link - information is
in manual, and other areas are not linked to.