### PR TITLE
Fix Windows problem with spaces in dir name

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -262,7 +262,12 @@ sub win32_start {
 # Users never need to create a titled DOS window,
 # but they may need to run the 'start' command on files with spaces.
 #
-	@args = ( 'start', '', @args );
+	# If first argument after 'start' has quotes, it is interpreted as a title
+	# for the commmand window. So if a command has spaces in it, and so has
+	# quotes, the command is interpreted as the window title and doesn't execute.
+	# To solve this, add a dummy title argument. Note that it must have spaces
+	# because if it isn't quoted it will be interpreted as the command. Windows!
+	@args = ( 'start', 'Guiguts Command Window', @args );
 	my $cmdline = win32_cmdline(@args);
 	system $cmdline;
 }


### PR DESCRIPTION
When a process is spawned using "start", e.g. View in
Browser from External Operations, or View Project
Comments, it was failing on Window if the path had
spaces in it.
This is due to the start command in Windows
interpreting the first argument as the title of the
window if it has quotes round it. Solved by adding
a dummy title with spaces to force it to be quoted.