### PR TITLE
Add Basic Latin and Latin-1 Supp. to UCS

### DIFF
--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -296,6 +296,10 @@ sub utfcharsearchpopup {
 		my $stopit = 0;
 		# get lists of supported blocks and unicode characters at start
 		my %blocks = %{ $::lglobal{utfblocks} };
+		# Add Basic Latin and Latin-1 Supplement blocks
+		$blocks{'Basic Latin'} = [ '0000', '007F' ];
+		$blocks{'Latin-1 Supplement'} = [ '0080', '00FF' ];
+
 		my @lines = split /\n/,  do 'unicore/Name.pl';
 		$::lglobal{utfsearchpop} = $top->Toplevel;
 		$::lglobal{utfsearchpop}->title('Unicode Character Search');


### PR DESCRIPTION
I haven't edited Menu entries or dialog titles to make them match (as described in https://github.com/DistributedProofreaders/guiguts/issues/77). That seems like a separate issue to this bug fix.

Previous change from using Blocks.pl to using
Unicode menu hash meant that these two blocks
were omitted. Add them manually at start of sub.