### PR TITLE
Cause `make` or `make all` to build all versions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -116,8 +116,8 @@ Guiguts requires.
 
 ### Extracting Guiguts
 
-Unzip `guiguts-n.n.n.zip` to some location on your computer (double click the
-zip file in Finder or run `unzip guiguts-n.n.n.zip` on the command line). You
+Unzip `guiguts-mac-n.n.n.zip` to some location on your computer (double click the
+zip file in Finder or run `unzip guiguts-mac-n.n.n.zip` on the command line). You
 can move the `guiguts` directory it creates to anywhere you want. A common place
 for this is your home directory.
 
@@ -202,7 +202,7 @@ See also the [EBookMaker installation instructions](tools/ebookmaker/README.md).
 ## Other
 
 For other platforms, you will need to install Perl and the necessary
-[Perl modules](#perl-modules). Then extract `guiguts-n.n.n.zip` and run
+[Perl modules](#perl-modules). Then extract `guiguts-generic-n.n.n.zip` and run
 ```
 perl guiguts.pl
 ```

--- a/Makefile
+++ b/Makefile
@@ -9,29 +9,20 @@ ZIP=zip -rv9
 # files to include from the root
 INCLUDES=CHANGELOG.md INSTALL.md UPGRADE.md LICENSE.txt README.md THANKS.md
 
+TARGETS= generic win mac
 
-all: generic
+all: 
+	@for os in $(TARGETS); do \
+		echo "# Making $$os"; \
+		$(MAKE) $$os; \
+	done
 
-generic: common
+$(TARGETS): common
 	# Build tools
 	mkdir guiguts/tools
-	./tools/package-tools.sh generic $$(pwd)/guiguts/tools
+	./tools/package-tools.sh $@ $$(pwd)/guiguts/tools
 	# Create final zip
-	$(ZIP) guiguts-$(VERSION).zip guiguts
-
-win: common
-	# Build tools
-	mkdir guiguts/tools
-	./tools/package-tools.sh win $$(pwd)/guiguts/tools
-	# Create final zip
-	$(ZIP) guiguts-win-$(VERSION).zip guiguts
-
-mac: common
-	# Build tools
-	mkdir guiguts/tools
-	./tools/package-tools.sh mac $$(pwd)/guiguts/tools
-	# Create final zip
-	$(ZIP) guiguts-mac-$(VERSION).zip guiguts
+	$(ZIP) guiguts-$@-$(VERSION).zip guiguts
 
 common: clean
 	mkdir guiguts

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,8 +12,9 @@ Github.
 3. Commit the version update changes and tag the release
    (ie: `git tag r<version>`) and push it up to github
 
-4. From a Linux or MacOS system, confirm that you are working from a clean
-   git checkout. Then build the three releases:
+4. From a Linux or MacOS system, or a Windows system with MinGW installed,
+   confirm that you are working from a clean git checkout. Then build the
+   three releases using `make` or `make all` or
    ```
    make win
    make mac
@@ -21,8 +22,8 @@ Github.
    ```
    This creates three .zip files, one for each platform.
 
-   Be certain to keep the format
-   `guiguts-1.0.0.zip` (version number will vary) in order for
+   Be certain to keep the format `guiguts-platform-1.0.0.zip`
+   (platform and version number will vary) in order for
    the update mechanism to work correctly. Do not include
    `settings.rc` or `header.txt` as these may have been modified
    by the user and will be created if they do not exist.


### PR DESCRIPTION
Each OS target zip file needs to have a clean folder
and copies of generic files before the OS-specific
make. To force this, use recursive make to make each
OS's zip independently.

Only other expected difference is that the generic zip
will be called guiguts-generic-$(VERSION).zip rather
than guiguts-$(VERSION).zip