### PR TITLE
Fix online (remote) HTML validation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -239,12 +239,15 @@ Guiguts requires the following Perl modules to be installed via CPAN:
 * Tk
 * Tk::ToolBar
 
-The following modules are optional but recommended:
+The following modules are optional but recommended in order to provide
+all available functionality:
 
-* Text::LevenshteinXS
-* File::Which
-* Image::Size
-* LWP::Protocol::https
+* Text::LevenshteinXS               # Improved harmonics code
+* File::Which                       # Find tools on the system path
+* Image::Size                       # Report size of HTML images
+* LWP::Protocol::https              # Check for updates
+* WebService::Validator::HTML::W3C  # Online HTML validation
+* XML::XPath                        # Online HTML validation
 
 The required Perl modules can be installed with the included helper script:
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -240,14 +240,15 @@ Guiguts requires the following Perl modules to be installed via CPAN:
 * Tk::ToolBar
 
 The following modules are optional but recommended in order to provide
-all available functionality:
+all available functionality, such as auto-generating HTML image sizes, 
+online HTML validation, checking for updates, etc:
 
-* Text::LevenshteinXS               # Improved harmonics code
-* File::Which                       # Find tools on the system path
-* Image::Size                       # Report size of HTML images
-* LWP::Protocol::https              # Check for updates
-* WebService::Validator::HTML::W3C  # Online HTML validation
-* XML::XPath                        # Online HTML validation
+* Text::LevenshteinXS
+* File::Which
+* Image::Size
+* LWP::Protocol::https
+* WebService::Validator::HTML::W3C
+* XML::XPath
 
 The required Perl modules can be installed with the included helper script:
 ```

--- a/src/install_cpan_modules.pl
+++ b/src/install_cpan_modules.pl
@@ -9,10 +9,11 @@ my @modules = (
     "Text::LevenshteinXS",
     "File::Which",
     "Image::Size",
-    "LWP::Protocol::https",  # needed for update checking
-	# Required for remote HTML validation
-	"WebService::Validator::HTML::W3C",
-	"XML::XPath",
+    # Needed for update checking
+    "LWP::Protocol::https",
+    # Needed for remote HTML validation
+    "WebService::Validator::HTML::W3C",
+    "XML::XPath",
 );
 
 foreach my $module (@modules) {

--- a/src/install_cpan_modules.pl
+++ b/src/install_cpan_modules.pl
@@ -10,6 +10,9 @@ my @modules = (
     "File::Which",
     "Image::Size",
     "LWP::Protocol::https",  # needed for update checking
+	# Required for remote HTML validation
+	"WebService::Validator::HTML::W3C",
+	"XML::XPath",
 );
 
 foreach my $module (@modules) {

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -178,6 +178,7 @@ sub menu_preferences {
 				[ 'separator', '' ],
 				[
 					Checkbutton => 'Do W3C Validation Remotely',
+					-command    => \&::menurebuild,
 					-variable   => \$::w3cremote,
 					-onvalue    => 1,
 					-offvalue   => 0


### PR DESCRIPTION
Code was printing returned results from remote
HTML validation with "W3C" at the start, but then
removing all "W3C" lines. Now prints matching
format of local validator so lines are not removed.

Also fixed to include warnings as well as errors as
these should be corrected by PPer.

If validation does not occur, report the actual
error rather than 'Could not contact remote
validator'.

Online validation requires two perl modules in
order to work, so added these to the
optional/recommended list during installation.

Finally, switching between local and remote
validation in the Prefs menu did not rebuild the
menus, so the label for the previous validation
type still showed in the HTML menu.