### PR TITLE
Fix issue #105 - s/r infinite loop

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1053,10 +1053,14 @@ sub replaceall {
 		my $searchterm = $::lglobal{searchentry}->get( '1.0', '1.end' );
 		$::lglobal{lastsearchterm} = '';
 
-		# if not a search across line boundary
-		# and not a search within a selection do a speedy FindAndReplaceAll
-		unless ( ( $::sopt[3] ) or ((isvalid($searchterm)) && ( $replacement =~ $searchterm) ) )
-		{    #( $searchterm =~ m/\\n/ ) &&
+		# if not a regex search
+		# and replacement does not contain searchterm, including case insensitive format
+		# (to avoid an infinite loop bug in TextEdit's FindAndReplaceAll function)
+		# do a speedy FindAndReplaceAll
+		unless ( ( $::sopt[3] ) or
+		         ( isvalid($searchterm) and $replacement =~ $searchterm ) or
+		         ( isvalid($searchterm) and $::sopt[1] and $replacement =~ /$searchterm/i ) )
+		{
 			my $exactsearch = $searchterm;
 
 			# escape metacharacters for whole word matching


### PR DESCRIPTION
Fixes issue #105 

Due to a bug in TextEdit's FindAndReplaceAll
when the replacement string contains the
search string, GG did its own "slow" search and
replace all under those circumstances.
The code did not take into account that a
case-insensitive search needed a slightly different
test, e.g. replacing "the" with "The" but with the
case-insensitive flag set still went wrong.

New test checks for search string contained in
replacement string ignoring case if the user
has selected to ignore case.