### PR TITLE
Fix wrong projectID loading a new file

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -859,6 +859,7 @@ sub openfile {    # and open it
 	$::globallastpath           = ::os_normal($::globallastpath);
 	$name                       = ::os_normal($name);
 	$::lglobal{global_filename} = $name;
+	$::projectid = '';	# Clear project id from previous file - get new one later
 	my $binname = getbinname();
 
 	unless ( -e $binname ) {    #for backward compatibility
@@ -872,6 +873,8 @@ sub openfile {    # and open it
 	} else {
 		print "No bin file found, generating default bin file.\n";
 	}
+	# If no bin file, or bin file didn't have a project id,
+	# try to get one from the local project comments filename.
 	::getprojectid() unless $::projectid;
 	_recentupdate($name);
 	unless ( -e $::pngspath ) {


### PR DESCRIPTION
If a currently loaded file has a project ID, then a
new file is loaded that has no .bin file, the project
ID from the previous file did not get cleared. This
meant that links to project forum, etc., were
wrong.

Project ID is now cleared when file is loaded.