### PR TITLE
Fix pngs dir error after import prep files

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -199,6 +199,9 @@ sub file_import_preptext {
 	my $tmppath = $::globallastpath;
 	$tmppath =~ s|[^/\\]*[/\\]$||; # go one dir level up
 	$tmppath = ::catfile( $tmppath, $::defaultpngspath, '');
+	# ensure trailing slash - recent versions of catfile remove it
+	my $slash = $::OS_WIN ? "\\" : "/";
+	$tmppath .= $slash unless substr( $tmppath, -1 ) eq $slash;
 	$::pngspath = $tmppath if ( -e $tmppath );
 	$top->Unbusy( -recurse => 1 );
 	return;

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -198,8 +198,8 @@ sub file_import_preptext {
 	::file_mark_pages() if ( $::auto_page_marks );
 	my $tmppath = $::globallastpath;
 	$tmppath =~ s|[^/\\]*[/\\]$||; # go one dir level up
-	$tmppath = ::catfile( $tmppath, $::defaultpngspath, '');
-	# ensure trailing slash - recent versions of catfile remove it
+	$tmppath = ::catdir( $tmppath, $::defaultpngspath );
+	# ensure trailing slash
 	my $slash = $::OS_WIN ? "\\" : "/";
 	$tmppath .= $slash unless substr( $tmppath, -1 ) eq $slash;
 	$::pngspath = $tmppath if ( -e $tmppath );


### PR DESCRIPTION
Behaviour of File::Spec::Functions::catfile has
changed between Perl bundled with 1.0.25 and
latest Strawberry Perl. It now strips a trailing
slash rather than ensuring one is there.

This is the only place catfile is called without a
filename, so the only place where this issue can
arise. Append OS-specific slash to path.