### PR TITLE
Make CSS validation default to level 3

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -186,7 +186,7 @@ sub errorcheckpop_up {
 				if (
 					( $line =~ /^\s*$/i
 					)    # skip some unnecessary lines from W3C Validate CSS
-					or ( $line =~ /^{output/i )
+					or ( $line =~ /^{output/i and not $::verboseerrorchecks )
 					or ( $line =~ /^W3C/i )
 					or ( $line =~ /^URI/i )
 				  )
@@ -479,8 +479,8 @@ sub errorcheckrun {    # Runs Tidy, W3C Validate, and other error checks
 			}
 		}
 	} elsif ( $errorchecktype eq 'W3C Validate CSS' ) {
-		my $runner = ::runner::tofile("errors.err");
-		$runner->run( "java", "-jar", $::validatecsscommand, "file:$name" );
+		my $runner = ::runner::tofile( "errors.err", "errors.err" ); # stdout & stderr
+		$runner->run( "java", "-jar", $::validatecsscommand, "--profile=$::lglobal{cssvalidationlevel}", "file:$name" );
 	} elsif ( $errorchecktype eq 'pphtml' ) {
 		::run( "perl", "lib/ppvchecks/pphtml.pl", "-i", $name, "-o",
 				"errors.err" );

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -485,6 +485,12 @@ sub menu_preferences {
 					-onvalue    => 1,
 					-offvalue   => 0,
 				],
+				[
+					Checkbutton => "CSS Validation Level 2.1",
+					-variable   => \$::lglobal{cssvalidationlevel},
+					-onvalue    => 'css21',
+					-offvalue   => 'css3',
+				],
 			  ]
 		]
 	];


### PR DESCRIPTION
Local CSS validation previously defaulted to Level
3+SVG.
Now defaults to Level 3, though user can select
Level 2.1 via Prefs menu for this run of GG.

Also dealt with single line output by validator to
stderr which showed the options used for this
validation. When redirecting stdout to a file in
order to capture output from an external
program, you can now also redirect stderr, either
to the same file or a different one. Only used
for CSS validation at the moment - errors from
other tools that output to stderr will appear in
the command window.