### PR TITLE
Add cover page link to default HTML header

### DIFF
--- a/src/headerdefault.txt
+++ b/src/headerdefault.txt
@@ -7,6 +7,7 @@
     <title>
       TITLE, by AUTHOR&mdash;A Project Gutenberg eBook
     </title>
+    <link rel="coverpage" href="images/cover.jpg" />
     <style type="text/css">
 
 body {


### PR DESCRIPTION
Since all books now require a cover, add the code
to link it for ebookmaker into the default header.