### PR TITLE
Fix #79 - unable to cancel wordlist selection

### DIFF
--- a/src/lib/Guiguts/Highlight.pm
+++ b/src/lib/Guiguts/Highlight.pm
@@ -17,12 +17,13 @@ sub scannosfile {
 	$::scannoslistpath = ::os_normal($::scannoslistpath);
 	if ($::debug) { print "sub scannosfile1\n"; }
 	my $types = [ [ 'Text file', [ '.txt', ] ], [ 'All Files', ['*'] ], ];
-	$::scannoslist = $top->getOpenFile(
+	my $scannosfile = $top->getOpenFile(
 		-title      => 'List of words to highlight?',
 		-filetypes  => $types,
 		-initialdir => $::scannoslistpath
 	);
-	if ($::scannoslist) {
+	if ($scannosfile) {
+		$::scannoslist = $scannosfile;
 		my ( $name, $path, $extension ) =
 		  ::fileparse( $::scannoslist, '\.[^\.]*$' );
 		$::scannoslistpath = $path;
@@ -32,9 +33,9 @@ sub scannosfile {
 		::highlight_scannos() if ($::scannos_highlighted);
 		%{ $::lglobal{wordlist} } = ();
 		::highlight_scannos();
+		read_word_list();
 	}
 	if ($::debug) { print "sub scannosfile2:" . $::scannoslist . "\n"; }
-	read_word_list();
 	return;
 }
 ##routine to automatically highlight words in the text


### PR DESCRIPTION
At end of sub to choose file, it tried to read the
wordlist even if a file hadn't been chosen. That
sub recursively called the choose file sub.

Now only attempts to read wordlist if file has
been chosen. If no file chosen, previously
selected file remains the source for the wordlist.
If no file has even been chosen, then each time
user attempts to highlight wordlist words, they
will be asked to choose a wordlist file as before.