### PR TITLE
Fix errors dismissing dialogs via WM

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -431,7 +431,7 @@ sub regedit {
 		( $::reghints{ $::lglobal{searchentry}->get( '1.0', '1.end' ) } ) )
 	  if $::reghints{ $::lglobal{searchentry}->get( '1.0', '1.end' ) };
 	my $button = $editor->Show;
-	if ( $button =~ /save/i ) {
+	if ( defined $button and $button =~ /save/i ) {
 		open my $reg, ">", "$::lglobal{scannosfilename}";
 		print $reg "\%::scannoslist = (\n";
 		foreach my $word ( sort ( keys %::scannoslist ) ) {

--- a/src/lib/Guiguts/StatusBar.pm
+++ b/src/lib/Guiguts/StatusBar.pm
@@ -616,7 +616,7 @@ sub setlang {
 			-title   => 'Set language',
 			-popover => $top,
 			-command => sub {
-				if ( $_[0] eq 'OK' ) {
+				if ( defined $_[0] and $_[0] eq 'OK' ) {
 					::setedited(1);
 					$::booklang = $::lglobal{booklang};
 					update_lang_button();
@@ -1066,8 +1066,7 @@ sub gotoline {
 			-title   => 'Go To Line Number',
 			-popover => $top,
 			-command => sub {
-				no warnings 'uninitialized';
-				if ( $_[0] eq 'OK' ) {
+				if ( defined $_[0] and $_[0] eq 'OK' ) {
 					$::lglobal{line_number} =~ s/[\D.]//g;
 					my ( $last_line, $junk ) =
 					  split( /\./, $textwindow->index('end') );

--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -846,6 +846,7 @@ sub ital_adjust {
 	my $top = $::top;
 	return if $::lglobal{markuppop};
 	$::lglobal{markuppop} = $top->Toplevel( -title => 'Word count threshold', );
+	::initialize_popup_with_deletebinding('markuppop');
 	my $f0 =
 	  $::lglobal{markuppop}->Frame->pack( -side => 'top', -anchor => 'n' );
 	$f0->Label( -text =>


### PR DESCRIPTION
Fixes #113  - Word Count Threshold dialog can't
be popped once it's been dismissed via the
Window Manager button.

Also a few other boxes gave "undefined variable"
errors when dismissed via WM.