### PR TITLE
Adjust autogenerated image width handling

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -117,6 +117,7 @@ our $poetrylmargin    = 4;
 our $blockwrap;
 our $booklang      = 'en';
 our $defaultindent = 2;
+our $epubpercentoverride = 1;	# True = override % img widths to 100% for epubs
 our $failedsearch  = 0;
 our $fontname      = 'Courier New';
 our $fontsize      = 10;

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -987,7 +987,7 @@ EOM
 		# otherwise we can't have a default value of 1 without overwriting the user's setting
 		for (
 			qw/alpha_sort activecolor auto_page_marks auto_show_images autobackup autosave autosaveinterval bkgcolor
-			blocklmargin blockrmargin bold_char defaultindent donotcenterpagemarkers failedsearch
+			blocklmargin blockrmargin bold_char defaultindent donotcenterpagemarkers epubpercentoverride failedsearch
 			font_char fontname fontsize fontweight geometry
 			gesperrt_char globalaspellmode highlightcolor history_size
 			htmldiventry htmlspanentry ignoreversionnumber


### PR DESCRIPTION
1. If user specifies percentage width, don't allow
image to exceed its natural width, i.e. make the
maximum width the width dimension of the image
file.
2. Allow user to specify that the set percentage
width is to be overridden to 100% on handheld
devices (i.e. through ebookmaker generation)
Note that all images with that percentage width
either will or will not have override. Class CSS is
rewritten to ensure user's latest choice is used.