### PR TITLE
Fix #140 - Latin-1 menu insert into replace

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1701,6 +1701,11 @@ sub searchaddterms
 			-expand => 'y',
 			-fill   => 'x'
 		  );
+		$::lglobal{$replaceentry}->{_MENU_} = ();
+		$::lglobal{$replaceentry}->bind(
+			'<FocusIn>',
+			eval " sub { \$::lglobal{hasfocus} = \$::lglobal{$replaceentry}; } "
+		);
 		$msref->[$_]->Button(
 			-activebackground => $::activecolor,
 			-command          => sub {


### PR DESCRIPTION
When a new replace field was added with "+"
in the search & replace dialog, the focus binding
wasn't set up to record when focus was set to the
new field. This caused the Latin-1 chart to insert
its characters into the wrong field or the main
window.
Fixes #140.