### PR TITLE
Fix #131 - search/replace history not updated

### DIFF
--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -92,6 +92,7 @@ sub keybindings {
 	keybind( '<Control-f>',         sub { ::searchpopup(); } );
 	keybind( '<Control-g>',         sub {
 			if ( $::lglobal{searchpop} ) {
+				::update_sr_histories();
 				my $searchterm = $::lglobal{searchentry}->get( '1.0', '1.end' );
 				::searchtext($searchterm);
 			} else {
@@ -100,6 +101,7 @@ sub keybindings {
 		}, '<<FindNext>>' );
 	keybind( '<Control-Shift-g>',   sub {
 			if ( $::lglobal{searchpop} ) {
+				::update_sr_histories();
 				my $searchterm = $::lglobal{searchentry}->get( '1.0', '1.end' );
 				$::lglobal{searchop2}->toggle;
 				::searchtext($searchterm);
@@ -110,6 +112,7 @@ sub keybindings {
 		}, '<<FindNextReverse>>' );
 	keybind( '<Control-b>',         sub {
 			if ( $::lglobal{searchpop} ) {
+				::update_sr_histories();
 				my $searchterm = $::lglobal{searchentry}->get( '1.0', '1.end' );
 				::countmatches($searchterm);
 			}		


### PR DESCRIPTION
Search and replace histories were only updated
under some circumstances: not during "R & S" or
"Replace All" or "Count", nor when keyboard
shortcuts were used for S&R operations.

New sub to update search and replace histories
is now called whenever user initiates a S&R
(or Count) operation via the S&R dialog. Not
called from internal search routines.

Fixes #131