### PR TITLE
Fix #158 - error changing Jeebies level

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -1512,7 +1512,7 @@ sub jeebiespop_up {
 									 -text     => $_->[0],
 									 -variable => \$::jeebiesmode,
 									 -value    => $_->[1],
-									 -command  => \&saveset,
+									 -command  => \&::savesettings,
 			)->pack( -side => 'left', -padx => 2 );
 		}
 		$ptopframe->Button(


### PR DESCRIPTION
To save the new Jeebies setting, need to call
::savesettings, not saveset which doesn't exist.

Fixes #158 