### PR TITLE
Fix #160 - Make CSS validation level persistent

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -116,6 +116,7 @@ our $blockrmargin     = 72;
 our $poetrylmargin    = 4;
 our $blockwrap;
 our $booklang      = 'en';
+our $cssvalidationlevel = 'css3';	# CSS level checked by validator (css3 or css21)
 our $defaultindent = 2;
 our $epubpercentoverride = 1;	# True = override % img widths to 100% for epubs
 our $failedsearch  = 0;

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -480,7 +480,7 @@ sub errorcheckrun {    # Runs Tidy, W3C Validate, and other error checks
 		}
 	} elsif ( $errorchecktype eq 'W3C Validate CSS' ) {
 		my $runner = ::runner::tofile( "errors.err", "errors.err" ); # stdout & stderr
-		$runner->run( "java", "-jar", $::validatecsscommand, "--profile=$::lglobal{cssvalidationlevel}", "file:$name" );
+		$runner->run( "java", "-jar", $::validatecsscommand, "--profile=$::cssvalidationlevel", "file:$name" );
 	} elsif ( $errorchecktype eq 'pphtml' ) {
 		::run( "perl", "lib/ppvchecks/pphtml.pl", "-i", $name, "-o",
 				"errors.err" );

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -987,7 +987,7 @@ EOM
 		# otherwise we can't have a default value of 1 without overwriting the user's setting
 		for (
 			qw/alpha_sort activecolor auto_page_marks auto_show_images autobackup autosave autosaveinterval bkgcolor
-			blocklmargin blockrmargin bold_char defaultindent donotcenterpagemarkers epubpercentoverride failedsearch
+			blocklmargin blockrmargin bold_char cssvalidationlevel defaultindent donotcenterpagemarkers epubpercentoverride failedsearch
 			font_char fontname fontsize fontweight geometry
 			gesperrt_char globalaspellmode highlightcolor history_size
 			htmldiventry htmlspanentry ignoreversionnumber

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -478,7 +478,7 @@ sub menu_preferences {
 				],
 				[
 					Checkbutton => "CSS Validation Level 2.1",
-					-variable   => \$::lglobal{cssvalidationlevel},
+					-variable   => \$::cssvalidationlevel,
 					-onvalue    => 'css21',
 					-offvalue   => 'css3',
 				],

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -825,7 +825,6 @@ sub initialize {
 	$::lglobal{autofraction}      = 0;				# HTML convert - 1/2, 1/4, 3/4 to named entities
 	$::lglobal{codewarn}          = 1;
 	$::lglobal{cssblockmarkup}    = 1;				# HTML convert - Use <div>/CSS rather than <blockquote>
-	$::lglobal{cssvalidationlevel}= 'css3';			# CSS level checked by validator (css3 or css21)
 	$::lglobal{delay}             = 50;
 	$::lglobal{footstyle}         = 'end';
 	$::lglobal{ftnoteindexstart}  = '1.0';


### PR DESCRIPTION
Previous implementation did not persist the CSS
validation level across runs of Guiguts.

Value is now saved in setting.rc file along with
other similar preferences.

Fixes #160 