### PR TITLE
Fix #161 - good words on Linux

### DIFF
--- a/src/lib/Guiguts/SpellCheck.pm
+++ b/src/lib/Guiguts/SpellCheck.pm
@@ -535,12 +535,13 @@ sub spelladdgoodwords {
 	my $pwd = ::getcwd();
 	chdir $::globallastpath;
 	open( DAT, "good_words.txt" ) || die("Could not open good_words.txt!");
-	my @raw_data = <DAT>;
+	# Remove all newlines and/or carriage returns whatever the current OS
+	my @raw_data = map { s/[\n\r]+$//g; $_ } <DAT>;
 	close(DAT);
 	chdir $pwd;
 	my $word = q{};
 	foreach my $word (@raw_data) {
-		spellmyaddword( substr( $word, 0, -1 ) );
+		spellmyaddword( $word );
 	}
 }
 


### PR DESCRIPTION
In spell check dialog, option to add words from
good_words.txt into project dictionary was failing
under Linux.

Caused because line endings weren't being
stripped correctly when file was read in. File used
nl & cr for line end, but only one character was
stripped. Fixed by removing all nl & cr characters from end of line.

Fixes #161 