### PR TITLE
fix #175 - CSS validator line numbers wrong

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -257,10 +257,9 @@ sub errorcheckpop_up {
 						  or ( $thiserrorchecktype eq "Link Check" )
 						  or ( $thiserrorchecktype eq "pptxt" ) )
 				{
-					# Format line number, adjusting for start line of style block if CSS check
+					# Format line number, adjusting for tool's idea of start line
 					if ( $line =~ /Line : (\d+)/ ) {
-						my $lineno = $1;
-						$lineno += $lineadjust if $thiserrorchecktype eq "W3C Validate CSS";
+						my $lineno = $1 + $lineadjust;
 						$line =~ s/Line : (\d+)/line ${lineno}:1/;
 					}
 					push @errorchecklines, $line;


### PR DESCRIPTION
New version of validator reports line numbers
starting at beginning of CSS style block rather
than start of file.

Also remove historical adjustment of line number which causes double-click on error to go to the
line following the error.

Fixes #175 