### PR TITLE
Fix single-clicking in error windows

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -78,7 +78,7 @@ sub errorcheckpop_up {
 
     ::drag( $::lglobal{errorchecklistbox} );
     ::BindMouseWheel( $::lglobal{errorchecklistbox} );
-    $::lglobal{errorchecklistbox}->eventAdd( '<<view>>' => '<Button-1>', '<Return>' );
+    $::lglobal{errorchecklistbox}->eventAdd( '<<view>>' => '<ButtonRelease-1>', '<Return>' );
     $::lglobal{errorchecklistbox}->bind( '<<view>>', sub { errorcheckview(); } );
 
     # buttons 2 & 3 delete the clicked error and select the next error
@@ -1016,7 +1016,7 @@ sub gcheckpop_up {
         );
         $::lglobal{gcpop}->Icon( -image => $::icon );
         ::BindMouseWheel( $::lglobal{gclistbox} );
-        $::lglobal{gclistbox}->eventAdd( '<<view>>' => '<Button-1>', '<Return>' );
+        $::lglobal{gclistbox}->eventAdd( '<<view>>' => '<ButtonRelease-1>', '<Return>' );
         $::lglobal{gclistbox}->bind( '<<view>>', sub { gutcheckview() } );
         $::lglobal{gcpop}->bind(
             '<Configure>' => sub {
@@ -1463,7 +1463,7 @@ sub jeebiespop_up {
         );
         ::drag( $::lglobal{jelistbox} );
         ::BindMouseWheel( $::lglobal{jelistbox} );
-        $::lglobal{jelistbox}->eventAdd( '<<jview>>' => '<Button-1>', '<Return>' );
+        $::lglobal{jelistbox}->eventAdd( '<<jview>>' => '<ButtonRelease-1>', '<Return>' );
         $::lglobal{jelistbox}->bind( '<<jview>>', sub { jeebiesview() } );
         $::lglobal{jelistbox}->eventAdd(
             '<<jremove>>' => '<ButtonRelease-2>',


### PR DESCRIPTION
In the bookloupe, jeebies and "others" error
windows, single-clicking on an error was
supposed to take you to the error in the main
window. It actually took you to the previously
selected error.

This was due to the event being triggered on
the mouse button being pressed, rather than
released, so the list of errors had not actually
selected the one clicked on yet.

This should also fix #123, that clicking on errors
after running pphtml sometimes caused the bell
(system beep). When the error does not have a
line number, GG searches for the text at the start
of the line (between plus and colon symbol). The
error can be clicked multiple times to search
through the occurrences, and then the bell is
sounded when there are no more search
matches, just as with a normal search. Because
of the "previous error" bug, if the user removed
an unused definition, e.g. "h6", then clicked on
their next error (unused h5), it would first do a
search for h6 (causing a bell) before the user 
clicked again on the h5 error to jump to that.