### PR TITLE
Fix Page Separator undo/redo error message

### DIFF
--- a/src/lib/Guiguts/PageSeparators.pm
+++ b/src/lib/Guiguts/PageSeparators.pm
@@ -456,6 +456,7 @@ sub undojoin {
         return;
     }
     my $joinundo = pop @::joinundolist;
+    return unless $joinundo;
     push @::joinredolist, $joinundo;
     $textwindow->undo for ( 0 .. $joinundo );
     refreshpageseparator();
@@ -470,6 +471,7 @@ sub redojoin {
         return;
     }
     my $joinredo = pop @::joinredolist;
+    return unless $joinredo;
     push @::joinundolist, $joinredo;
     $textwindow->redo for ( 0 .. $joinredo );
 


### PR DESCRIPTION
Using Undo/Redo buttons when there was nothing
to undo/redo caused an "uninitialized value" error.

Fixes #100