### PR TITLE
Stop Bookloupe, View Options, Save My View generating errors

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -813,6 +813,7 @@ sub gcviewopts {
         for ( 0 .. $#{ $::lglobal{gcarray} } ) {
             $gccol         = int( $_ / $gcrows );
             $gcrow         = $_ % $gcrows;
+            $::gsopt[$_]   = 0 unless defined $::gsopt[$_];
             $gsoptions[$_] = $pframe1->Checkbutton(
                 -variable    => \$::gsopt[$_],
                 -command     => sub { gcwindowpopulate($linesref) },


### PR DESCRIPTION
If bookloupe view options were unset, the element in the array was never set, rather
than being zero, causing problems writing it out to setting.rc

Fixed by setting each array element to zero if undefined, prior to creating its
checkbutton.

Fixes #156