### PR TITLE
Convert hyphens at start of line to emdashes correctly (#166)

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -85,12 +85,13 @@ sub html_convert_ampersands {
 # double hyphens go to character entity ref. FIXME: Add option for real emdash.
 sub html_convert_emdashes {
     ::working("Converting Emdashes");
-    ::named( '(?<=[^-!])--(?=[^>])', '&mdash;' );
-    ::named( '(?<=[^<])!--(?=[^>])', '!&mdash;' );
-    ::named( '(?<=[^-])--$',         '&mdash;' );
-    ::named( '^--(?=[^-])',          '&mdash;' );
-    ::named( '^--$',                 '&mdash;' );
-    ::named( "\x{A0}",               '&nbsp;' );
+
+    # Avoid converting double hyphens in HTML comments <!--  -->
+    # Probably not strictly necessary, since no HTML comments in the file at this time
+    # Use negative lookbehind for "<!" and negative lookahead for ">"
+    ::named( '(?<!<!)--(?!>)', '&mdash;' );
+
+    ::named( "\x{A0}", '&nbsp;' );
     return;
 }
 


### PR DESCRIPTION
During HTML conversion, double hyphens are converted to emdashes.
Though probably unnecessary, regexps avoided converting them when preceded
by `<!` or followed by `>` presumably to avoid affecting HTML comments.
Use of positive lookahead/behind with negated character match didn't trap all cases,
so additional regexps were used, trapping the double hyphen at start of line, but not
more than two hyphens.
Replaced with single negative lookahead/behind regexp.

Fixes #166