### PR TITLE
Fix #194 - errors from enable/disable autosave

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2155,7 +2155,7 @@ sub toggle_autosave {
             -activebackground => 'SystemButtonFace'
         ) unless $::notoolbar;
     }
-    ::save_settings();
+    ::savesettings();
 }
 
 # expand current selection to span entire lines


### PR DESCRIPTION
When enabling/disabling autosave, the name of the subroutine to save the
settings was wrong.

Fixes #194