### PR TITLE
Make Variation Selectors Unicode block available

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -183,7 +183,6 @@ our $toolside              = 'bottom';
 our $menulayout            = 'default';
 our $trackoperations       = 0;               # Default to off (tracking triggers edited flag)
 our $twowordsinhyphencheck = 0;
-our $unicodemenusplit      = 2;               # 2 or 3
 our $utffontname           = 'Courier New';
 our $utffontsize           = 14;
 our $utf8save              = 1;               # True = always save utf8, false = only if unicode characters in file

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -959,7 +959,7 @@ EOM
             multisearchsize multiterm nobell nohighlights projectfileslocation notoolbar oldspellchecklayout poetrylmargin projectfileslocation
             recentfile_size rewrapalgo rmargin rmargindiff rwhyphenspace sc_char scannos_highlighted spellcheckwithenchant stayontop toolside
             trackoperations txt_conv_bold txt_conv_font txt_conv_gesperrt txt_conv_italic txt_conv_sc txt_conv_tb
-            twowordsinhyphencheck unicodemenusplit utf8save utffontname utffontsize
+            twowordsinhyphencheck utf8save utffontname utffontsize
             url_no_proofer url_yes_proofer urlprojectpage urlprojectdiscussion
             menulayout verboseerrorchecks vislnnm w3cremote wfstayontop/
         ) {

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -1718,11 +1718,8 @@ sub unicodemenu {
                     ],
                     map ( [
                             Button       => "$utfsorthash{$_}",
-                            -columnbreak => (
-                                ( $::unicodemenusplit == 3 && ( $_ eq '0D80' || $_ eq '2300' ) )
-                                  || ( $::unicodemenusplit == 2 && $_ eq '1740' ) ? 1 : 0
-                            ),
-                            -command => [
+                            -columnbreak => ( ( $_ eq '0D80' || $_ eq '2300' ) ? 1 : 0 ),
+                            -command     => [
                                 \&::utfpopup,
                                 $utfsorthash{$_},
                                 $::lglobal{utfblocks}{ $utfsorthash{$_} }[0],
@@ -1731,7 +1728,7 @@ sub unicodemenu {
                             -accelerator => $::lglobal{utfblocks}{ $utfsorthash{$_} }[0] . ' - '
                               . $::lglobal{utfblocks}{ $utfsorthash{$_} }[1]
                         ],
-                        ( sort ( keys %utfsorthash ) )[ 0 .. 67 ] ),
+                        ( sort ( keys %utfsorthash ) ) ),
                 ],
             );
         } else {
@@ -1745,21 +1742,15 @@ sub unicodemenu {
                     ],
                     map ( [
                             Button       => "$_",
-                            -columnbreak => (
-                                (
-                                    $::unicodemenusplit == 3
-                                      && ( $_ eq 'Ethiopic' || $_ eq 'Mongolian' )
-                                )
-                                  || ( $::unicodemenusplit == 2 && $_ eq 'Lao' ) ? 1 : 0
-                            ),
-                            -command => [
+                            -columnbreak => ( ( $_ eq 'Ethiopic' || $_ eq 'Mongolian' ) ? 1 : 0 ),
+                            -command     => [
                                 \&::utfpopup,                 $_,
                                 $::lglobal{utfblocks}{$_}[0], $::lglobal{utfblocks}{$_}[1]
                             ],
                             -accelerator => $::lglobal{utfblocks}{$_}[0] . ' - '
                               . $::lglobal{utfblocks}{$_}[1]
                         ],
-                        ( sort ( keys %{ $::lglobal{utfblocks} } ) )[ 0 .. 67 ] ),
+                        ( sort ( keys %{ $::lglobal{utfblocks} } ) ) ),
                 ],
             );
         }

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1028,7 +1028,8 @@ sub initialize {
         #'Tibetan' => ['0F00', '0FFF'],
         'Unified Canadian Aboriginal Syllabics' => [ '1400', '167F' ],
 
-        #'Variation Selectors' => ['FE00', 'FE0F'],
+        'Variation Selectors' => [ 'FE00', 'FE0F' ],
+
         #'Yi Radicals' => ['A490', 'A4CF'],
         #'Yi Syllables' => ['A000', 'A48F'],
         #'Yijing Hexagram Symbols' => ['4DC0', '4DFF'],


### PR DESCRIPTION
This makes the Variation Selectors block available in the Unicode menu and in the
selection menu in the Unicode block dialog. It also makes the Variation Selectors
available for searching in the Unicode Character Search dialog.

Note that some of these are typically not visible in a font, but the apparently empty
box can still be selected to insert them into the text.

Number of available blocks is too large for a 2-column menu to fit on many screens
so now forced to a 3-column menu (there was no way for the user to change this
anyway).

Also, removed use of explicit size of hash storing Unicode block names/ranges.

Fixes #200