### PR TITLE
Pull kindlegen binaries from GG 1.1.0

### DIFF
--- a/tools/kindlegen/README.md
+++ b/tools/kindlegen/README.md
@@ -6,17 +6,21 @@ or EPUB. KindleGen converts this source content to a single file which supports
 both KF8 and Mobi formats enabling publishers to create great-looking books
 that work on all Kindle devices and apps.
 
-https://www.amazon.com/gp/feature.html?docId=1000765211
+Before mid-August 2020 Amazon included kindlegen as a stand-alone download. They
+have since removed that and are instructing people to install the Kindle
+Previewer.
+
+https://www.amazon.com/gp/feature.html?docId=1000765261
 
 ## Packaging
 
-We include the full kindlegen package contents extracted as a convenience to
-the user.
+We ship the older kindlegen binaries included with Guiguts 1.1.0 as a
+convenience to the user. Future Guiguts versions will require the user to
+download and install the Kindle Previewer.
 
 ### MacOS
 
-As of 2020-06-17 the MacOS version of KindleGen at the link above is 32-bit
-only, meaning it will not work on Catalina.
+The MacOS version of KindleGen is 32-bit only and it will not work on Catalina.
 
 You will get the following error if you try to run this version of `kindlegen`
 on Catalina or later:

--- a/tools/kindlegen/package.sh
+++ b/tools/kindlegen/package.sh
@@ -11,13 +11,17 @@ mkdir $DEST
 cp README.md $DEST
 
 if [[ $OS == "win" ]]; then
-    URL=http://kindlegen.s3.amazonaws.com/kindlegen_win32_v2_9.zip
+    URL=https://github.com/DistributedProofreaders/guiguts/releases/download/r1.1.0/guiguts-win-1.1.0.zip
+    BINARY=kindlegen.exe
 elif [[ $OS == "mac" ]]; then
-    URL=http://kindlegen.s3.amazonaws.com/KindleGen_Mac_i386_v2_9.zip
+    URL=https://github.com/DistributedProofreaders/guiguts/releases/download/r1.1.0/guiguts-mac-1.1.0.zip
+    BINARY=kindlegen
 fi
 
 if [[ $URL != "" ]]; then
-    curl -L -o kindlegen.zip $URL
-    unzip kindlegen.zip -d $DEST
-    rm -rf kindlegen.zip
+    curl -L -o guiguts.zip $URL
+    unzip guiguts.zip guiguts/tools/kindlegen/$BINARY -d .
+    cp guiguts/tools/kindlegen/$BINARY $DEST
+    rm -rf guiguts
+    rm -rf guiguts.zip
 fi


### PR DESCRIPTION
Amazon removed kindlegen downloads, pointing people to KindlePreviewer instead. To ensure that 1.1.x releases still include the kindlegen binary, pull form the GG 1.1.0 release.

This isn't ideal, but it's probably better than removing kindlegen binaries from a 1.1.x release.