### PR TITLE
Remove old rewrap algorithm

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -162,7 +162,6 @@ our $projectid             = q{};
 our $projectfileslocation  = '';
 our $recentfile_size       = 9;
 our $regexpentry           = q();
-our $rewrapalgo            = 2;
 our $rmargin               = 72;
 our $rmargindiff           = 1;
 our $rwhyphenspace         = 1;

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -960,7 +960,7 @@ EOM
             htmldiventry htmlspanentry ignoreversionnumber
             intelligentWF ignoreversions italic_char jeebiesmode lastversioncheck lastversionrun lmargin
             multisearchsize multiterm nobell nohighlights projectfileslocation notoolbar oldspellchecklayout poetrylmargin projectfileslocation
-            recentfile_size rewrapalgo rmargin rmargindiff rwhyphenspace sc_char scannos_highlighted spellcheckwithenchant stayontop toolside
+            recentfile_size rmargin rmargindiff rwhyphenspace sc_char scannos_highlighted spellcheckwithenchant stayontop toolside
             trackoperations txt_conv_bold txt_conv_font txt_conv_gesperrt txt_conv_italic txt_conv_sc txt_conv_tb
             twowordsinhyphencheck utf8save utffontname utffontsize
             url_no_proofer url_yes_proofer urlprojectpage urlprojectdiscussion

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -452,12 +452,6 @@ sub menu_preferences {
                     -offvalue   => 0
                 ],
                 [
-                    Checkbutton => "Use Greedy, Traditional Rewrap Algorithm",
-                    -variable   => \$::rewrapalgo,
-                    -onvalue    => 1,
-                    -offvalue   => 2,
-                ],
-                [
                     Button   => 'Set Rewrap ~Margins...',
                     -command => \&::setmargins
                 ],

--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -144,23 +144,21 @@ sub setmargins {
             -to           => 120,
         )->pack( -side => 'left' );
 
-        if ( $::rewrapalgo == 2 ) {
-            my $rmdiffframe =
-              $::lglobal{marginspop}->Frame->pack( -side => 'top', -padx => 5, -pady => 3 );
-            my $rmdifflabel = $rmdiffframe->Label(
-                -width => 25,
-                -text  => 'Right Margin Max.-Opt. Diff.',
-            )->pack( -side => 'left' );
-            my $rmdiffentry = $rmdiffframe->Spinbox(
-                -width        => 6,
-                -background   => $::bkgcolor,
-                -relief       => 'sunken',
-                -textvariable => \$::rmargindiff,
-                -increment    => 1,
-                -from         => 0,
-                -to           => 10,
-            )->pack( -side => 'left' );
-        }
+        my $rmdiffframe =
+          $::lglobal{marginspop}->Frame->pack( -side => 'top', -padx => 5, -pady => 3 );
+        my $rmdifflabel = $rmdiffframe->Label(
+            -width => 25,
+            -text  => 'Right Margin Max.-Opt. Diff.',
+        )->pack( -side => 'left' );
+        my $rmdiffentry = $rmdiffframe->Spinbox(
+            -width        => 6,
+            -background   => $::bkgcolor,
+            -relief       => 'sunken',
+            -textvariable => \$::rmargindiff,
+            -increment    => 1,
+            -from         => 0,
+            -to           => 10,
+        )->pack( -side => 'left' );
         my $button_frame =
           $::lglobal{marginspop}->Frame->pack( -side => 'top', -padx => 5, -pady => 3 );
         my $button_ok = $button_frame->Button(

--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -215,7 +215,7 @@ sub selectrewrap {
                 if ($inblock) {
                     if ($enableindent) {
                         $indentblockend = $textwindow->search( '-regex', '--',
-                            '^$TEMPPAGEMARK*[pP\*Ll]\/', $thisblockstart, $end );
+                            "^$TEMPPAGEMARK*[pP\*Ll]\/", $thisblockstart, $end );
                         $indentblockend = $indentblockend || $end;
                         $textwindow->markSet( 'rewrapend', $indentblockend );
                         unless ($offset) { $offset = 0 }


### PR DESCRIPTION
New "Knuth" algorithm has been the default for years and gives more consistent
results, so no need to keep old one.

Removed replacement of brackets with special characters, since only used for old
rewrap style. Also removed special treatment of italic markup, since other HTML
markups not done, and anyway markup is removed from the text file well before
rewrapping.

Fixes #212 & #213