### PR TITLE
Stop autosave clashing with save

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -324,7 +324,7 @@ if (@ARGV) {
 } else {
     $lglobal{global_filename} = 'No File Loaded';
 }
-set_autosave() if $autosave;
+::reset_autosave();
 $textwindow->CallNextGUICallback;
 $top->repeat( 200, sub { _updatesel($textwindow) } );
 

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -375,7 +375,7 @@ sub menu_preferences {
                     Checkbutton => 'Enable ~Auto Save',
                     -variable   => \$::autosave,
                     -command    => sub {
-                        ::toggle_autosave();
+                        ::reset_autosave();
                         ::savesettings();
                     }
                 ],
@@ -384,7 +384,7 @@ sub menu_preferences {
                     -command => sub {
                         ::saveinterval();
                         ::savesettings();
-                        ::set_autosave() if $::autosave;
+                        ::reset_autosave();
                     }
                 ],
                 [

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -14,7 +14,7 @@ BEGIN {
       &natural_sort_length &natural_sort_freq &drag &cut &paste &textcopy &colcut &colcopy &colpaste &showversion
       &checkforupdates &checkforupdatesmonthly &gotobookmark &setbookmark &seeindex &ebookmaker
       &sidenotes &poetrynumbers &get_page_number &externalpopup
-      &xtops &toolbar_toggle &toggle_autosave &killpopup &expandselection &currentfileisunicode &currentfileislatin1
+      &xtops &toolbar_toggle &killpopup &expandselection &currentfileisunicode &currentfileislatin1
       &getprojectid &setprojectid &viewprojectcomments &viewprojectdiscussion &viewprojectpage
       &scrolldismiss);
 
@@ -2055,12 +2055,16 @@ sub toolbar_toggle {    # Set up / remove the tool bar
             -command => [ \&::savefile ],
             -tip     => 'Save',
         );
-        $::lglobal{savetool}->bind( '<3>', sub { ::set_autosave() } );
+
+        # Mouse-3 just resets the autosave timers
+        $::lglobal{savetool}->bind( '<3>', sub { ::reset_autosave() } );
+
+        # Shift-Mouse-3 toggles the autosave setting
         $::lglobal{savetool}->bind(
             '<Shift-3>',
             sub {
                 $::autosave = !$::autosave;
-                toggle_autosave();
+                ::reset_autosave();
             }
         );
         $::lglobal{toptool}->ToolButton(
@@ -2158,24 +2162,6 @@ sub toolbar_toggle {    # Set up / remove the tool bar
             -command => [ \&::footnotepop ],
             -tip     => 'Footnote Fixup'
         );
-    }
-    ::savesettings();
-}
-
-sub toggle_autosave {
-    if ($::autosave) {
-        ::set_autosave();
-    } else {
-        $::lglobal{autosaveid}->cancel;
-        undef $::lglobal{autosaveid};
-        $::lglobal{saveflashid}->cancel;
-        undef $::lglobal{saveflashid};
-        $::lglobal{saveflashingid}->cancel if $::lglobal{saveflashingid};
-        undef $::lglobal{saveflashingid};
-        $::lglobal{savetool}->configure(
-            -background       => 'SystemButtonFace',
-            -activebackground => 'SystemButtonFace'
-        ) unless $::notoolbar;
     }
     ::savesettings();
 }


### PR DESCRIPTION
Fixes #196

It was previously possible for an autosave to happen during a Save, Save As, or
Save Copy As. Since some of these do some manipulating of the filenames, this was
potentially a dangerous operation, and because some save operations pop a dialog
for the user to respond to, they could take a long time, increasing the likelihood of
a clash.

This edit turns off autosave during the manual save processes. It also tidies the code,
putting all the main autosave code into the same module, and simplifies the calls to
the main subroutine.

Finally, part of the Save As and Save Copy As code that needed editing (to avoid a
premature return) turned out to be unnecessary, so was removed. For the record,
there was code to check for a Bin File Collision. Historically, filename.txt had a bin
file called filename.bin. Hence, if the HTML file was saved as filename.html, it would
have had the same bin file name. More recently (1.0.25 or before) the naming of the
bin file was changed to be filename.txt.bin and filename.html.bin, so there is no
possibility of a collision.