### PR TITLE
Stop Tidy writing a file called `null`

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -31,7 +31,6 @@ sub errorcheckpop_up {
         -activebackground => $::activecolor,
         -command          => sub {
             errorcheckpop_up( $textwindow, $top, $errorchecktype );
-            unlink 'null' if ( -e 'null' );
         },
         -text  => $buttonlabel,
         -width => 16
@@ -416,9 +415,9 @@ sub errorcheckrun {    # Runs Tidy, W3C Validate, and other error checks
     }
     if ( $errorchecktype eq 'HTML Tidy' ) {
         if ($unicode) {
-            ::run( $::tidycommand, "-f", "errors.err", "-o", "null", "-utf8", $name );
+            ::run( $::tidycommand, "-f", "errors.err", "-e", "-utf8", $name );
         } else {
-            ::run( $::tidycommand, "-f", "errors.err", "-o", "null", $name );
+            ::run( $::tidycommand, "-f", "errors.err", "-e", $name );
         }
     } elsif ( $errorchecktype eq 'W3C Validate' ) {
         if ( $::w3cremote == 0 ) {

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -2330,7 +2330,6 @@ sub htmlgenpopup {
                 -activebackground => $::activecolor,
                 -command          => sub {
                     ::errorcheckpop_up( $textwindow, $top, 'Link Check' );
-                    unlink 'null' if ( -e 'null' );
                 },
                 -text  => 'Link Check',
                 -width => 16
@@ -2339,7 +2338,6 @@ sub htmlgenpopup {
                 -activebackground => $::activecolor,
                 -command          => sub {
                     ::errorcheckpop_up( $textwindow, $top, 'ppvimage' );
-                    unlink 'null' if ( -e 'null' );
                 },
                 -text  => 'ppvimage',
                 -width => 16
@@ -2348,7 +2346,6 @@ sub htmlgenpopup {
                 -activebackground => $::activecolor,
                 -command          => sub {
                     ::errorcheckpop_up( $textwindow, $top, 'HTML Tidy' );
-                    unlink 'null' if ( -e 'null' );
                 },
                 -text  => 'HTML Tidy',
                 -width => 16
@@ -2361,7 +2358,6 @@ sub htmlgenpopup {
                     } else {
                         ::errorcheckpop_up( $textwindow, $top, 'W3C Validate' );
                     }
-                    unlink 'null' if ( -e 'null' );
                 },
                 -text  => 'W3C Validate HTML',
                 -width => 16
@@ -2370,7 +2366,6 @@ sub htmlgenpopup {
                 -activebackground => $::activecolor,
                 -command          => sub {
                     ::errorcheckpop_up( $textwindow, $top, 'W3C Validate CSS' );    #validatecssrun('');
-                    unlink 'null' if ( -e 'null' );
                 },
                 -text  => 'W3C Validate CSS',
                 -width => 16
@@ -2379,7 +2374,6 @@ sub htmlgenpopup {
                 -activebackground => $::activecolor,
                 -command          => sub {
                     ::errorcheckpop_up( $textwindow, $top, 'pphtml' );
-                    unlink 'null' if ( -e 'null' );
                 },
                 -text  => 'pphtml',
                 -width => 16
@@ -2388,7 +2382,6 @@ sub htmlgenpopup {
                 -activebackground => $::activecolor,
                 -command          => sub {
                     ::errorcheckpop_up( $textwindow, $top, 'Check All' );
-                    unlink 'null' if ( -e 'null' );
                 },
                 -text  => 'Check All',
                 -width => 16

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -871,7 +871,6 @@ sub menubuildold {
                 Button   => 'pptxt...',
                 -command => sub {
                     ::errorcheckpop_up( $textwindow, $top, 'pptxt' );
-                    unlink 'null' if ( -e 'null' );
                 },
             ],
             [
@@ -1557,7 +1556,6 @@ sub menubuilddefault {
                 Button   => 'PPt~xt...',
                 -command => sub {
                     ::errorcheckpop_up( $textwindow, $top, 'pptxt' );
-                    unlink 'null' if ( -e 'null' );
                 },
             ],
         ]
@@ -1618,14 +1616,12 @@ sub menubuilddefault {
                     } else {
                         ::errorcheckpop_up( $textwindow, $top, 'W3C Validate' );
                     }
-                    unlink 'null' if ( -e 'null' );
                 }
             ],
             [
                 Button   => '~CSS Validator',
                 -command => sub {
                     ::errorcheckpop_up( $textwindow, $top, 'W3C Validate CSS' );
-                    unlink 'null' if ( -e 'null' );
                 }
             ],
             [ 'separator', '' ],
@@ -1633,28 +1629,24 @@ sub menubuilddefault {
                 Button   => 'HTML ~Link Checker',
                 -command => sub {
                     ::errorcheckpop_up( $textwindow, $top, 'Link Check' );
-                    unlink 'null' if ( -e 'null' );
                 }
             ],
             [
                 Button   => 'HTML ~Tidy',
                 -command => sub {
                     ::errorcheckpop_up( $textwindow, $top, 'HTML Tidy' );
-                    unlink 'null' if ( -e 'null' );
                 }
             ],
             [
                 Button   => '~PPhtml',
                 -command => sub {
                     ::errorcheckpop_up( $textwindow, $top, 'pphtml' );
-                    unlink 'null' if ( -e 'null' );
                 }
             ],
             [
                 Button   => 'PPV~image',
                 -command => sub {
                     ::errorcheckpop_up( $textwindow, $top, 'ppvimage' );
-                    unlink 'null' if ( -e 'null' );
                 }
             ],
             [

--- a/src/lib/Guiguts/Tests.pm
+++ b/src/lib/Guiguts/Tests.pm
@@ -63,8 +63,6 @@ sub runtests {
       if ok( File::Compare::compare_text( $LFNAME, 'tests/errorcheckbaseline.txt' ) == 0,
         "Check All successful" );
 
-    unlink 'null' if ( -e 'null' );    # Remove temporary "Tidy" output file.
-
     # Open/close README - allow for development system run from src subdirectory
     ok( ( -e "../README.md" or -e "README.md" ), "README.md exists" );
 


### PR DESCRIPTION
Instead of using `-o null` to attempt to send TIdy output to a null file and then having
to delete it, use `-e` argument to Tidy which suppresses output other than warnings
and errors.

Fixes #217 