### PR TITLE
Fix #227 - unknown color name `SystemButtonFace`

### DIFF
--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -363,10 +363,14 @@ sub reset_autosave {
         );
     }
 
+    # Save icon's default background color so it can be restored when turning off autosave
+    $::lglobal{savetoolcolor} = $::lglobal{savetool}->cget('-background')
+      if not $::lglobal{savetoolcolor};
+
     # Ensure the icon is the right color
     $::lglobal{savetool}->configure(
-        -background       => $::autosave ? 'green' : 'SystemButtonFace',
-        -activebackground => $::autosave ? 'green' : 'SystemButtonFace'
+        -background       => $::autosave ? 'green' : $::lglobal{savetoolcolor},
+        -activebackground => $::autosave ? 'green' : $::lglobal{savetoolcolor}
     ) unless $::notoolbar;
 
     ::savesettings();


### PR DESCRIPTION
It turns out that color name is not available on all platforms.
Safer solution is to store the button's default color before it ever gets changed.

Fixes #227