### PR TITLE
Remove use of `no warnings` pragma from code

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -1023,7 +1023,6 @@ sub jeebiesrun {
 sub gutcheckrun {
     my $textwindow = $::textwindow;
     my $top        = $::top;
-    no warnings;
     ::operationadd('Bookloupe/Gutcheck');
     ::hidepagenums();
     $textwindow->focus;

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -296,7 +296,6 @@ sub _bin_save {
     if ( defined $fh ) {
         print $fh "\%::pagenumbers = (\n";
         for my $page ( sort { $a cmp $b } keys %::pagenumbers ) {
-            no warnings 'uninitialized';
             if ( $page eq "Pg" ) {
                 next;
             }
@@ -309,15 +308,16 @@ sub _bin_save {
         }
         print $fh ");\n\n";
         delete $::proofers{''};
-        foreach my $page ( sort keys %::proofers ) {
-            no warnings 'uninitialized';
-            for my $round ( 1 .. $::lglobal{numrounds} ) {
-                if ( defined $::proofers{$page}->[$round] ) {
-                    print $fh '$::proofers{\''
-                      . $page . '\'}['
-                      . $round
-                      . '] = \''
-                      . $::proofers{$page}->[$round] . '\';' . "\n";
+        if ( $::lglobal{numrounds} ) {
+            foreach my $page ( sort keys %::proofers ) {
+                for my $round ( 1 .. $::lglobal{numrounds} ) {
+                    if ( defined $::proofers{$page}->[$round] ) {
+                        print $fh '$::proofers{\''
+                          . $page . '\'}['
+                          . $round
+                          . '] = \''
+                          . $::proofers{$page}->[$round] . '\';' . "\n";
+                    }
                 }
             }
         }

--- a/src/lib/Guiguts/PageSeparators.pm
+++ b/src/lib/Guiguts/PageSeparators.pm
@@ -244,6 +244,7 @@ sub processpageseparator {
     my $pagesep;
     $pagesep = $textwindow->get( $::searchstartindex, $::searchendindex )
       if ( $::searchstartindex && $::searchendindex );
+    return unless $pagesep;
     my $pagemark = $pagesep;
     $pagesep =~ m/^-----*\s?File:\s?([^\.]+)/;
     return unless $1;
@@ -638,11 +639,8 @@ sub delblanklines {
           $textwindow->search( '-nocase', '-regexp', '--',
             '^-----*\s*File:\s?(\S+)\.(png|jpg)---.*$',
             $::searchendindex, 'end' );
-        {
-            no warnings 'uninitialized';
-            $::searchstartindex = '2.0' if $::searchstartindex eq '1.0';
-        }
         last unless $::searchstartindex;
+        $::searchstartindex = '2.0' if $::searchstartindex eq '1.0';
         ( $r, $c ) = split /\./, $::searchstartindex;
         if ( $textwindow->get( ( $r - 1 ) . '.0', ( $r - 1 ) . '.end' ) eq '' ) {
             $textwindow->delete( "$::searchstartindex -1c", $::searchstartindex );

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -852,6 +852,7 @@ sub initialize {
     $::lglobal{lastsearchterm}     = '';
     $::lglobal{leave_utf}          = 1;                           # HTML convert - retain utf8 characters
     $::lglobal{longordlabel}       = 0;
+    $::lglobal{ordmaxlength}       = 1;
     $::lglobal{pageanch}           = 1;                           # HTML convert - add page anchors
     $::lglobal{pagecmt}            = 0;                           # HTML convert - page markers as comments
     $::lglobal{poetrynumbers}      = 0;                           # HTML convert - find & format poetry line numbers
@@ -859,6 +860,7 @@ sub initialize {
     $::lglobal{regaa}              = 0;
     $::lglobal{seepagenums}        = 0;
     $::lglobal{selectionsearch}    = 0;
+    $::lglobal{selmaxlength}       = 1;
     $::lglobal{shorthtmlfootnotes} = 1;                           # HTML convert - Footnote_3 rather than Footnote_3_3
     $::lglobal{showblocksize}      = 1;
     $::lglobal{showthispageimage}  = 0;

--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -1221,7 +1221,6 @@ sub distance {
     if ( $::lglobal{LevenshteinXS} ) {
         return Text::LevenshteinXS::distance(@_);
     }
-    no warnings;
     my $word1 = shift;
     my $word2 = shift;
     return 0 if $word1 eq $word2;

--- a/src/spawn.pl
+++ b/src/spawn.pl
@@ -13,9 +13,6 @@ die "fork(): $!" unless defined $pid;
 # Original process returns immediately
 exit if $pid;
 
-# No need to bother user with filename + line number messages
-no warnings 'exec';
+exec { $ARGV[0] } @ARGV;
+die "Error running $ARGV[0]: $!";
 
-if ( ( exec { $ARGV[0] } @ARGV ) < 0 ) {
-    print STDERR qq/Error running "$ARGV[0]": $!\n/;
-}


### PR DESCRIPTION
1. Most changes are minor, e.g. checking variable is not undefined.
2. Returning via next (html_convert_tb) fixed by returning a status code to calling
routine.
3. Improved comparison function for sorting in html_convert_pageanchors to cope
with Roman numerals instead of ignoring warnings.
4. Removed unused routines in ReflowGG.pm since these used `no warnings`
5. Max lengths of status bar fields initialised at start of program.
6. spawn.pl now uses recommended `die` after exec.

Fixes #230
Fixes #218