### PR TITLE
Fixes bugs in autosave code

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2033,6 +2033,7 @@ sub toolbar_toggle {    # Set up / remove the tool bar
     if ( $::notoolbar && $::lglobal{toptool} ) {
         $::lglobal{toptool}->destroy;
         undef $::lglobal{toptool};
+        undef $::lglobal{savetool};
     } elsif ( !$::notoolbar && !$::lglobal{toptool} ) {
         $::lglobal{toptool}  = $top->ToolBar( -side => $::toolside, -close => '30' );
         $::lglobal{toolfont} = $top->Font(
@@ -2051,6 +2052,7 @@ sub toolbar_toggle {    # Set up / remove the tool bar
             -command => [ \&::savefile ],
             -tip     => 'Save',
         );
+        ::reset_autosave();    # Ensure save icon color is correct for autosave setting
 
         # Mouse-3 just resets the autosave timers
         $::lglobal{savetool}->bind( '<3>', sub { ::reset_autosave() } );


### PR DESCRIPTION
1. Code tried to get background color even when icon was not shown, causing error.
2. Code tried to flash icon when it was not shown.
3. If toolbar was not shown at program start, then shown later, the autosave setting
was not reflected in the icon color, i.e. autosave was on, but icon was grey.

Fixes #246 