### PR TITLE
Find Previous Proofer Comment when already at a comment

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1777,8 +1777,11 @@ sub find_proofer_comment {
     $direction = 'forward' unless $direction;
     my $textwindow = $::textwindow;
     my $pattern    = '[**';
-    my $comment    = $textwindow->search( $direction eq 'reverse' ? '-backwards' : '-forwards',
-        '--', $pattern, "insert" );
+
+    # Avoid finding same one again
+    my $start   = $direction eq 'reverse' ? 'insert -1c' : 'insert';
+    my $comment = $textwindow->search( $direction eq 'reverse' ? '-backwards' : '-forwards',
+        '--', $pattern, $start );
     if ($comment) {
         my $index = $textwindow->index("$comment +1c");
         $textwindow->SetCursor($index);


### PR DESCRIPTION
Repeatedly finding next proofer comment paged through the proofer comments
forwards, but Find Previous kept re-finding the one at the current insert point.
Now start searching backwards from 1 character before insert point.
Fixes #245