### PR TITLE
Add test for pptxt tool to test suite

### DIFF
--- a/src/lib/Guiguts/Tests.pm
+++ b/src/lib/Guiguts/Tests.pm
@@ -40,6 +40,7 @@ sub runtests {
 
     runtesterrorcheck( "Bookloupe/Gutcheck", "textcheck.txt",   "blgcbaseline.txt" );
     runtesterrorcheck( "Jeebies",            "textcheck.txt",   "jeebiesbaseline.txt" );
+    runtesterrorcheck( "pptxt",              "textcheck.txt",   "pptxtbaseline.txt" );
     runtesterrorcheck( "W3C Validate",       "errorcheck.html", "htmlvalidatebaseline.txt" );
     runtesterrorcheck( "HTML Tidy",          "errorcheck.html", "tidybaseline.txt" );
     runtesterrorcheck( "ppvimage",           "errorcheck.html", "ppvimagebaseline.txt" );
@@ -153,6 +154,7 @@ sub runtesterrorcheck {
     open my $logfile, ">", $lfname
       or die "Unable to open $lfname for writing\n";
 
+    binmode $logfile, ":encoding(UTF-8)";
     ::errorcheckpop_up( $textwindow, $top, $TESTTYPE );
     for ( $::lglobal{errorchecklistbox}->get( 0, 'end' ) ) {
         print $logfile "$_\n";

--- a/src/lib/ppvchecks/pptxt.pl
+++ b/src/lib/ppvchecks/pptxt.pl
@@ -108,11 +108,6 @@ sub runProgram {
     &had_bad;
     &specials;
 
-    ( my $sec, my $min, my $hour, my $mday, my $mon, my $year, my $wday, my $yday, my $isdst ) =
-      localtime(time);
-    printf LOGFILE ( "\n%s\n", "=" x 80 );
-    printf LOGFILE "run completed: %4d-%02d-%02d %02d:%02d:%02d\n",
-      $year + 1900, $mon + 1, $mday, $hour, $min, $sec;
     close LOGFILE;
 }
 

--- a/src/tests/pptxtbaseline.txt
+++ b/src/tests/pptxtbaseline.txt
@@ -952,84 +952,84 @@ unusual characters check
        [] | [Sidenote: The Guards Division 1918.]
        [] | [Sidenote: The Guards Division.]
        [] | [Sidenote: The Guards Division.]
-       £ |    named men, paying £2: 5s. per quarter for each fortnightly
-       £ | a subscription of £100; but it was found that families were so well
-       £ | and Captain T. F. J. N. Thorne each bequeathed £1000 to the Fund. A
-       £ | performance, and a sum of no less than £650 was raised. In January 1916
-       · |                         DALLAS · SAN FRANCISCO
-       · |     Hoare, G. H. R·, ii. 338, 340, 341, 342, iii. 278
-       · | On the far side of the gully an abandoned 5·9 was taken over by No.
-       · | enemy's 5·9 guns registered on them. These men remained unable to
-       ½ |    repulsed 4½ English Divisions to-day. The enemy has been beaten
-       â |      "    24.   " Châtelet.
-       â |      "    24.   " Châtelet.
-       â | Aigle, and by the Americans at Château-Thierry, the Germans launched
-       â | Company to the Château grounds. The King's and No. 4 Companies had in
-       â | grounds of Mecquignies Château were strongly held by machine-guns,
-       â | reached Château-Thierry. The stubborn resistance of the French made any
-       â | seized the Château. In this fighting Second Lieutenant A. D. Anderson
-       â | the Château grounds. There they remained till the end of the month,
-       â | the meantime made good the high ground north of the Château, driving
-       â | the orchards and fields of the Château. Touch was established with the
-       æ |     12472  Cæsar, A. J.
-       è |      "    10.   " Ferrières.
-       è |      "    19.   " Mont St. Geneviève.
-       è | Boussières to St. Hilaire, when it prepared for the forthcoming attack.
-       è | But as soon as they emerged from Cattenières, and came on to the ridge
-       è | Carter was killed, being hit in the head. On reaching Flesquières
-       è | Flesquières. The 2nd Battalion Grenadier Guards was to follow the Irish
-       è | Lakerlière and Larbret, where it was billeted. On the 17th drafts
-       è | Masnières. The canal was being shelled at the time, but the Battalion
-       è | The Battalion had to be in position east of Flesquières at 9.20 A.M.,
-       è | The Third Division had taken Flesquières, but the Sixty-third Division
-       è | at which time the Battalion was to advance towards Flesquières. At zero
-       è | attack and capture the village of Flesquières, and on the left the
-       è | between Graincourt and Flesquières. The 1st Battalion Irish Guards
-       è | called upon, moved on later to Masnières. Cambrai could be seen in the
-       è | day it moved on to Cattenières, and Major Bailey, accompanied by the
-       è | east of Flesquières, and established itself only just short of Premy
-       è | encountered was to pass through and continue the advance on La Henières
-       è | from Flesquières to Premy Chapel. On the right the Third Division would
-       è | from Flesquières. This enabled the 2nd Battalion to push through Orival
-       è | intervals to Seranvillers _via_ Masnières and Crevecour. The next
-       è | marched back to St. Vaast, where it "embussed" for Carnières. There it
-       è | nine were wounded. On the 17th the Battalion marched to Carmières,
-       è | on afterwards to the spur running from Flesquières to Cantaing with a
-       è | south. Flesquières was captured in conjunction with the Third Division,
-       è | to carry Beet Trench. On nearing Flesquières, the enemy's machine-gun
-       è | to push on in the general direction of Cattenières.
-       è | to within a short distance of Cattenières, where the patrols were sent
-       è | trench-system north-west, north, and north-east of Flesquières, moving
-       è | were able to enfilade the troops advancing to Flesquières. When the
-       é |     Dec.   5.   " Verlée.
-       é |    No. 3 Company will be in support écheloned behind No. 4
-       é | 3 Company dug in in échelon to the right flank, with No. 4 Company in
-       é | Company Commanders, rode on to Bévillers to reconnoitre.
-       é | Quiévy, but no halt was made here, as it was found that the advanced
-       é | Two days, the 14th and 15th, were spent at Quiévy cleaning up and
-       é | advance in échelon behind the right flank, in the hope of getting
-       é | east of Quiévy, they were met by heavy machine-gun fire from the
-       é | l'Abbé.
-       é | marched by companies to Quiévy. The casualties during the three days'
-       é | moved forward in their support in échelon to their left flank, while
-       é | post, and to put up a Véry light perpendicular at dusk from his post on
-       é | the line north of La Bassée, and General von Quast, who commanded the
-       é | the rendezvous just east of Bévillers at 4 A.M. It was a very
-       é | them, with the result that Véry lights went up in quick succession, no
-       é | then moved his company to a position écheloned in rear of the King's
-       é | while Véry lights were sent up. Captain Churchill therefore retired
-       é | yards and écheloned in depth. No. 4 Company was to lead the attack on a
-       é | écheloned at a distance of 250 yards on their right, No. 2 Company in
-       ê |    _Forêt de Nieppe_. These now took up the fight, and the way to
-       ê |    a front of nearly 10,000 yards east of the Forêt de Nieppe,
-       ê | In July 1918 the band attended the French Fêtes in Paris, and remained
-       ê | south of the Forêt de Nieppe, in prolongation of the Australian line.
-       ô | and full of barbed wire, its rôle was to march in the wake of the
-       ô | the special rôle of occupying and fortifying Quesnoy Farm, and two
-       ö |      "    15.   " Sötenich.
-       ü |      "    12.   " Mürringen.
-       ü |      "    13.   " Büllingen.
-       ü |      "    13.   " Büllingen.
+       Â£ |    named men, paying Â£2: 5s. per quarter for each fortnightly
+       Â£ | a subscription of Â£100; but it was found that families were so well
+       Â£ | and Captain T. F. J. N. Thorne each bequeathed Â£1000 to the Fund. A
+       Â£ | performance, and a sum of no less than Â£650 was raised. In January 1916
+       Â· |                         DALLAS Â· SAN FRANCISCO
+       Â· |     Hoare, G. H. RÂ·, ii. 338, 340, 341, 342, iii. 278
+       Â· | On the far side of the gully an abandoned 5Â·9 was taken over by No.
+       Â· | enemy's 5Â·9 guns registered on them. These men remained unable to
+       Â½ |    repulsed 4Â½ English Divisions to-day. The enemy has been beaten
+       Ã¢ |      "    24.   " ChÃ¢telet.
+       Ã¢ |      "    24.   " ChÃ¢telet.
+       Ã¢ | Aigle, and by the Americans at ChÃ¢teau-Thierry, the Germans launched
+       Ã¢ | Company to the ChÃ¢teau grounds. The King's and No. 4 Companies had in
+       Ã¢ | grounds of Mecquignies ChÃ¢teau were strongly held by machine-guns,
+       Ã¢ | reached ChÃ¢teau-Thierry. The stubborn resistance of the French made any
+       Ã¢ | seized the ChÃ¢teau. In this fighting Second Lieutenant A. D. Anderson
+       Ã¢ | the ChÃ¢teau grounds. There they remained till the end of the month,
+       Ã¢ | the meantime made good the high ground north of the ChÃ¢teau, driving
+       Ã¢ | the orchards and fields of the ChÃ¢teau. Touch was established with the
+       Ã¦ |     12472  CÃ¦sar, A. J.
+       Ã¨ |      "    10.   " FerriÃ¨res.
+       Ã¨ |      "    19.   " Mont St. GeneviÃ¨ve.
+       Ã¨ | BoussiÃ¨res to St. Hilaire, when it prepared for the forthcoming attack.
+       Ã¨ | But as soon as they emerged from CatteniÃ¨res, and came on to the ridge
+       Ã¨ | Carter was killed, being hit in the head. On reaching FlesquiÃ¨res
+       Ã¨ | FlesquiÃ¨res. The 2nd Battalion Grenadier Guards was to follow the Irish
+       Ã¨ | LakerliÃ¨re and Larbret, where it was billeted. On the 17th drafts
+       Ã¨ | MasniÃ¨res. The canal was being shelled at the time, but the Battalion
+       Ã¨ | The Battalion had to be in position east of FlesquiÃ¨res at 9.20 A.M.,
+       Ã¨ | The Third Division had taken FlesquiÃ¨res, but the Sixty-third Division
+       Ã¨ | at which time the Battalion was to advance towards FlesquiÃ¨res. At zero
+       Ã¨ | attack and capture the village of FlesquiÃ¨res, and on the left the
+       Ã¨ | between Graincourt and FlesquiÃ¨res. The 1st Battalion Irish Guards
+       Ã¨ | called upon, moved on later to MasniÃ¨res. Cambrai could be seen in the
+       Ã¨ | day it moved on to CatteniÃ¨res, and Major Bailey, accompanied by the
+       Ã¨ | east of FlesquiÃ¨res, and established itself only just short of Premy
+       Ã¨ | encountered was to pass through and continue the advance on La HeniÃ¨res
+       Ã¨ | from FlesquiÃ¨res to Premy Chapel. On the right the Third Division would
+       Ã¨ | from FlesquiÃ¨res. This enabled the 2nd Battalion to push through Orival
+       Ã¨ | intervals to Seranvillers _via_ MasniÃ¨res and Crevecour. The next
+       Ã¨ | marched back to St. Vaast, where it "embussed" for CarniÃ¨res. There it
+       Ã¨ | nine were wounded. On the 17th the Battalion marched to CarmiÃ¨res,
+       Ã¨ | on afterwards to the spur running from FlesquiÃ¨res to Cantaing with a
+       Ã¨ | south. FlesquiÃ¨res was captured in conjunction with the Third Division,
+       Ã¨ | to carry Beet Trench. On nearing FlesquiÃ¨res, the enemy's machine-gun
+       Ã¨ | to push on in the general direction of CatteniÃ¨res.
+       Ã¨ | to within a short distance of CatteniÃ¨res, where the patrols were sent
+       Ã¨ | trench-system north-west, north, and north-east of FlesquiÃ¨res, moving
+       Ã¨ | were able to enfilade the troops advancing to FlesquiÃ¨res. When the
+       Ã© |     Dec.   5.   " VerlÃ©e.
+       Ã© |    No. 3 Company will be in support Ã©cheloned behind No. 4
+       Ã© | 3 Company dug in in Ã©chelon to the right flank, with No. 4 Company in
+       Ã© | Company Commanders, rode on to BÃ©villers to reconnoitre.
+       Ã© | QuiÃ©vy, but no halt was made here, as it was found that the advanced
+       Ã© | Two days, the 14th and 15th, were spent at QuiÃ©vy cleaning up and
+       Ã© | advance in Ã©chelon behind the right flank, in the hope of getting
+       Ã© | east of QuiÃ©vy, they were met by heavy machine-gun fire from the
+       Ã© | l'AbbÃ©.
+       Ã© | marched by companies to QuiÃ©vy. The casualties during the three days'
+       Ã© | moved forward in their support in Ã©chelon to their left flank, while
+       Ã© | post, and to put up a VÃ©ry light perpendicular at dusk from his post on
+       Ã© | the line north of La BassÃ©e, and General von Quast, who commanded the
+       Ã© | the rendezvous just east of BÃ©villers at 4 A.M. It was a very
+       Ã© | them, with the result that VÃ©ry lights went up in quick succession, no
+       Ã© | then moved his company to a position Ã©cheloned in rear of the King's
+       Ã© | while VÃ©ry lights were sent up. Captain Churchill therefore retired
+       Ã© | yards and Ã©cheloned in depth. No. 4 Company was to lead the attack on a
+       Ã© | Ã©cheloned at a distance of 250 yards on their right, No. 2 Company in
+       Ãª |    _ForÃªt de Nieppe_. These now took up the fight, and the way to
+       Ãª |    a front of nearly 10,000 yards east of the ForÃªt de Nieppe,
+       Ãª | In July 1918 the band attended the French FÃªtes in Paris, and remained
+       Ãª | south of the ForÃªt de Nieppe, in prolongation of the Australian line.
+       Ã´ | and full of barbed wire, its rÃ´le was to march in the wake of the
+       Ã´ | the special rÃ´le of occupying and fortifying Quesnoy Farm, and two
+       Ã¶ |      "    15.   " SÃ¶tenich.
+       Ã¼ |      "    12.   " MÃ¼rringen.
+       Ã¼ |      "    13.   " BÃ¼llingen.
+       Ã¼ |      "    13.   " BÃ¼llingen.
        Å“ |     Des VÅ“ux, F. W., i. 12, 61, 62, iii. 237
        Å“ | It was a skilful and daring manÅ“uvre, as the platoon was fired at from
        Å“ | PÅ“uilly. Its movements now depended on the Cavalry Corps, but as
@@ -1222,9 +1222,9 @@ unusual characters check
      ()// |       4  Hardinge, Hon. A. H. L., M.C. (Actg. Capt.)           1/12/17
      ()// |       4  Pryce, T. T., V.C., M.C. (Actg. Capt.)                13/4/18
      ()// |       4  Shelley, G. E. (Actg. Capt.)                          27/9/15
-     ()½ |    (3) 250 cigarettes or ½ lb. of tobacco, as preferred, is sent
+     ()Â½ |    (3) 250 cigarettes or Â½ lb. of tobacco, as preferred, is sent
      ()Å“ | (_b_) The heavy and continuous fighting for the village of MÅ“uvres
-     (é) | one company facing north, and one company (in échelon) facing east.
+     (Ã©) | one company facing north, and one company (in Ã©chelon) facing east.
      ++++ |     +---------------------+----------------+----------------+
      ++++ |     -------+------+---------------------------+--------------+-------------------
      /#[] | /#[5.3,60]
@@ -1236,12 +1236,12 @@ unusual characters check
      |||| |      Bat-  |Regtl.|   Rank and Name.          |   Regiment.  |Awards, Promotions,
      |||| |     talion.|  No. |                           |              |  etc.
      |||| |     |                     |    Officers.   |  Other Ranks.  |
-     ££ |    of £6: 15s. per man per quarter, or £2: 5s. per parcel per
-     ££ |    parcel. In some cases an adopter pays £4: 10s. for two, or £6:
-     ££ | total of £18,000 was invested in addition to the sum of £2100 placed at
-     ·· |                       NEW YORK · BOSTON · CHICAGO
-     èé | Portuguese front between Armentières and La Bassée, and the fighting
-     éé | and moved slowly forward through Fresnoy Farm, Bévillers, Quiévy,
+     Â£Â£ |    of Â£6: 15s. per man per quarter, or Â£2: 5s. per parcel per
+     Â£Â£ |    parcel. In some cases an adopter pays Â£4: 10s. for two, or Â£6:
+     Â£Â£ | total of Â£18,000 was invested in addition to the sum of Â£2100 placed at
+     Â·Â· |                       NEW YORK Â· BOSTON Â· CHICAGO
+     Ã¨Ã© | Portuguese front between ArmentiÃ¨res and La BassÃ©e, and the fighting
+     Ã©Ã© | and moved slowly forward through Fresnoy Farm, BÃ©villers, QuiÃ©vy,
      Å“// |       2  Des VÅ“ux, F. W.                                       14/9/14
     (){// |            (Actg. Major)                                     { 29/5/16
     (){// |            (Temp. Lieut.-Col.)                               { 27/9/18
@@ -1480,7 +1480,7 @@ unusual characters check
    |||||| |     |Other ranks|   4508  |   6939 |    21  |11,468 |
    |||||| |     |Scots Guards         |  107  |   149  | 2,072 |  4,002 |
    |||||| |     |Welsh Guards.        |   34  |    55  |   822 |  1,700 |
-   ··· |                   LONDON · BOMBAY · CALCUTTA · MADRAS
+   Â·Â·Â· |                   LONDON Â· BOMBAY Â· CALCUTTA Â· MADRAS
   (////)( |          Clive, P. A. (wounded 6/8/15 and 3/11/16) (attached
   )(//)// |            Lancs. Fusiliers) (wounded 4/11/14)                10/10/17
   |||||() |            |      |         |                 |              | (Croix de Guerre).
@@ -1591,7 +1591,7 @@ repeated word check
  confident that that spirit
  Lieut. C. C. Cubitt
  Lieut. C. C. Cubitt
- dug in in échelon
+ dug in in Ã©chelon
  E. F. F. Strangways
  they had had some
  who had had little
@@ -2893,7 +2893,7 @@ floating double quote |      2nd Lieut. H. J. Gibbon, M.C.                    " 
 floating double quote |      Lieut. G. W. Godman                              "     "
 floating double quote |       "    19.   " Binche.
 floating double quote |       "    20.   " Marchienne-au-Pont.
-floating double quote |       "    24.   " Châtelet.
+floating double quote |       "    24.   " ChÃ¢telet.
 floating double quote |       "    25.   " Fosse.
 floating double quote |       "    28.   " Naninne.
 floating double quote |       "    29.   " Sur Huy.
@@ -2902,9 +2902,9 @@ floating double quote |       "     6.   " Ocquier.
 floating double quote |       "    10.   " Grimonster.
 floating double quote |       "    11.   " Lierneux.
 floating double quote |       "    12.   " Rodt.
-floating double quote |       "    13.   " Büllingen.
+floating double quote |       "    13.   " BÃ¼llingen.
 floating double quote |       "    14.   " Oberhausen.
-floating double quote |       "    15.   " Sötenich.
+floating double quote |       "    15.   " SÃ¶tenich.
 floating double quote |       "    16.   " Schwerfen.
 floating double quote |       "    17.   " Lechenich.
 floating double quote |       "    18.   " Efferen.
@@ -2913,18 +2913,18 @@ floating double quote |       "    19.   " Anderlues.
 floating double quote |       "    20.   " Montignies-sur-Sambre.
 floating double quote |       "    24.   " Bambois.
 floating double quote |       "    28.   " Assesse.
-floating double quote |      Dec.   5.   " Verlée.
+floating double quote |      Dec.   5.   " VerlÃ©e.
 floating double quote |       "     6.   " Aisne.
 floating double quote |       "     7.   " Arbrefontaine.
 floating double quote |       "    11.   " Born.
-floating double quote |       "    12.   " Mürringen.
+floating double quote |       "    12.   " MÃ¼rringen.
 floating double quote |       "    13.   " Oberhausen.
 floating double quote |       "    15.   " Sinzenich.
 floating double quote |       "    16.   " Lechenich.
 floating double quote |       "    17.   " Efferen.
 floating double quote |       "    18.   " Widdersdorf.
 floating double quote |       "    20.   " Ehrenfeld (Cologne).
-floating double quote |       "    19.   " Mont St. Geneviève.
+floating double quote |       "    19.   " Mont St. GeneviÃ¨ve.
 floating double quote |       "    20.   " Charleroi.
 floating double quote |       "    24.   " Presles.
 floating double quote |       "    25.   " Lesves.
@@ -2939,16 +2939,16 @@ floating double quote |       "    14.   " Weywertz.
 floating double quote |       "    15.   " Ehrenfeld (by train).
 floating double quote |       "    19.  To Binche.
 floating double quote |       "    20.   " Marchienne-au-Pont.
-floating double quote |       "    24.   " Châtelet.
+floating double quote |       "    24.   " ChÃ¢telet.
 floating double quote |       "    25.   " Sart St. Laurent.
 floating double quote |       "    28.   " Dave.
 floating double quote |       "    29.   " Brionsart.
 floating double quote |      Dec.   5.   " Pont de Bonne (Modave).
 floating double quote |       "     6.   " Houmart.
-floating double quote |       "    10.   " Ferrières.
+floating double quote |       "    10.   " FerriÃ¨res.
 floating double quote |       "    11.   " Lierneux.
 floating double quote |       "    12.   " Blanche Fontaine.
-floating double quote |       "    13.   " Büllingen.
+floating double quote |       "    13.   " BÃ¼llingen.
 floating double quote |       "    14.   " Blumenthal.
 floating double quote |       "    15.   " Scheven.
 floating double quote |       "    16.   " Kommern.
@@ -2959,7 +2959,7 @@ floating double quote |       "    20.   " Kriel (Cologne).
          comma check |  on the Somme, about five miles from Bray, on December 1, 1915, and took
          comma check |  On May 29, 1916, Lieut.-General Sir Francis Lloyd, commanding the
          comma check |  November 19, 1914.
-  miscapitalization? |  l'Abbé.
+  miscapitalization? |  l'AbbÃ©.
          comma check |  cessation of hostilities, November 11, 1918.
          comma check |  was held at Chelsea Barracks on March 29, 1919.
          comma check |      Abbey, N. R., ii. 245, 262, 381, iii. 8, 34, 36, 39, 48, 237
@@ -3408,7 +3408,7 @@ floating double quote |       "    20.   " Kriel (Cologne).
          comma check |        187, 189, 242, 254, 255, iii. 30, 91, 95, 96, 97, 128, 278, 289
          comma check |      Hoare, E., i. 359, 360, iii. 241
          comma check |      Hoare, E. R. D., i. 308, 309, 319, ii. 191, 245, 262, 286, 381,
-         comma check |      Hoare, G. H. R·, ii. 338, 340, 341, 342, iii. 278
+         comma check |      Hoare, G. H. RÂ·, ii. 338, 340, 341, 342, iii. 278
          comma check |      Hobart, C. V. C., C.B.E., D.S.O., iii.  292, 321
          comma check |      Holbech, L., D.S.O., M.C., ii. 169, 187, 189, 209, 242, 373, 375,
          comma check |        376, 380, iii. 151, 153, 155, 156, 157, 179, 195, 278, 287, 290, 321
@@ -4432,7 +4432,7 @@ floating double quote |       "    20.   " Kriel (Cologne).
         spacey quote |      Lieut. G. W. Godman                              "     "
         spacey quote |       "    19.   " Binche.
         spacey quote |       "    20.   " Marchienne-au-Pont.
-        spacey quote |       "    24.   " Châtelet.
+        spacey quote |       "    24.   " ChÃ¢telet.
         spacey quote |       "    25.   " Fosse.
         spacey quote |       "    28.   " Naninne.
         spacey quote |       "    29.   " Sur Huy.
@@ -4441,9 +4441,9 @@ floating double quote |       "    20.   " Kriel (Cologne).
         spacey quote |       "    10.   " Grimonster.
         spacey quote |       "    11.   " Lierneux.
         spacey quote |       "    12.   " Rodt.
-        spacey quote |       "    13.   " Büllingen.
+        spacey quote |       "    13.   " BÃ¼llingen.
         spacey quote |       "    14.   " Oberhausen.
-        spacey quote |       "    15.   " Sötenich.
+        spacey quote |       "    15.   " SÃ¶tenich.
         spacey quote |       "    16.   " Schwerfen.
         spacey quote |       "    17.   " Lechenich.
         spacey quote |       "    18.   " Efferen.
@@ -4452,18 +4452,18 @@ floating double quote |       "    20.   " Kriel (Cologne).
         spacey quote |       "    20.   " Montignies-sur-Sambre.
         spacey quote |       "    24.   " Bambois.
         spacey quote |       "    28.   " Assesse.
-        spacey quote |      Dec.   5.   " Verlée.
+        spacey quote |      Dec.   5.   " VerlÃ©e.
         spacey quote |       "     6.   " Aisne.
         spacey quote |       "     7.   " Arbrefontaine.
         spacey quote |       "    11.   " Born.
-        spacey quote |       "    12.   " Mürringen.
+        spacey quote |       "    12.   " MÃ¼rringen.
         spacey quote |       "    13.   " Oberhausen.
         spacey quote |       "    15.   " Sinzenich.
         spacey quote |       "    16.   " Lechenich.
         spacey quote |       "    17.   " Efferen.
         spacey quote |       "    18.   " Widdersdorf.
         spacey quote |       "    20.   " Ehrenfeld (Cologne).
-        spacey quote |       "    19.   " Mont St. Geneviève.
+        spacey quote |       "    19.   " Mont St. GeneviÃ¨ve.
         spacey quote |       "    20.   " Charleroi.
         spacey quote |       "    24.   " Presles.
         spacey quote |       "    25.   " Lesves.
@@ -4478,16 +4478,16 @@ floating double quote |       "    20.   " Kriel (Cologne).
         spacey quote |       "    15.   " Ehrenfeld (by train).
         spacey quote |       "    19.  To Binche.
         spacey quote |       "    20.   " Marchienne-au-Pont.
-        spacey quote |       "    24.   " Châtelet.
+        spacey quote |       "    24.   " ChÃ¢telet.
         spacey quote |       "    25.   " Sart St. Laurent.
         spacey quote |       "    28.   " Dave.
         spacey quote |       "    29.   " Brionsart.
         spacey quote |      Dec.   5.   " Pont de Bonne (Modave).
         spacey quote |       "     6.   " Houmart.
-        spacey quote |       "    10.   " Ferrières.
+        spacey quote |       "    10.   " FerriÃ¨res.
         spacey quote |       "    11.   " Lierneux.
         spacey quote |       "    12.   " Blanche Fontaine.
-        spacey quote |       "    13.   " Büllingen.
+        spacey quote |       "    13.   " BÃ¼llingen.
         spacey quote |       "    14.   " Blumenthal.
         spacey quote |       "    15.   " Scheven.
         spacey quote |       "    16.   " Kommern.
@@ -4495,7 +4495,4 @@ floating double quote |       "    20.   " Kriel (Cologne).
         spacey quote |       "    18.   " Efferen.
         spacey quote |       "    20.   " Kriel (Cologne).
 --------------------------------------------------------------------------------
-================================================================================
-run completed: 2020-09-27 15:22:37
 Check is complete: pptxt
-


### PR DESCRIPTION
1. Add test
2. Write to logfile in utf-8 encoding (avoid wide character print messages)
3. Remove date stamp from pptxt output so test compare can work
4. Add baseline file
5. Remove previously added pptext.txt

Fixes #249