### PR TITLE
Fix #257 - crash when cancelling Load Checkfile

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -172,7 +172,11 @@ sub errorcheckpop_up {
     ::working($errorchecktype);
     if ( $errorchecktype eq 'Load Checkfile' ) {
         $fname = $::lglobal{errorcheckpop}->getOpenFile( -title => 'File Name?' );
-        last if ( not $fname );
+        if ( not $fname ) {    # if cancelled, close dialog and exit
+            ::killpopup('errorcheckpop');
+            ::working();
+            return;
+        }
     } else {
         push @errorchecklines, "Beginning check: " . $errorchecktype;
         if ( errorcheckrun($errorchecktype) ) {


### PR DESCRIPTION
Removal of loop during #251 left a `last` command which exited the routine unsafely.

Fixes #257.