### PR TITLE
Correct display of Unicode block dialog from Unicode menu

### DIFF
--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -673,9 +673,8 @@ sub menu_unicode {
                 'command',
                 "$_",
                 -columnbreak => menu_unicode_break($_),
-                -command     => sub {
-                    ::utfpopup( $_, $::lglobal{utfblocks}{$_}[0], $::lglobal{utfblocks}{$_}[1] );
-                },
+                -command =>
+                  [ \&::utfpopup, $_, $::lglobal{utfblocks}{$_}[0], $::lglobal{utfblocks}{$_}[1] ],
                 -accelerator => $::lglobal{utfblocks}{$_}[0] . ' - ' . $::lglobal{utfblocks}{$_}[1]
             ],
             ( sort menu_unicode_sort ( keys %{ $::lglobal{utfblocks} } ) ) ),


### PR DESCRIPTION
Caused by code in #258 (developer naivete)

Late edit to change command action within map to an anonymous sub failed to take
account of the ensuing change of meaning of $_.
Reverted to the previous structure: reference to utfpopup with its arguments.

FIxes #262