### PR TITLE
Fix divide by zero error when Image::Size not loaded

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1997,8 +1997,8 @@ sub thumbnailbrowse {
               . $::lglobal{htmlimagesizey} / $EMPX . " em "
               . "($::lglobal{htmlimagesizex} x $::lglobal{htmlimagesizey} px)" );
     } else {
-        $::lglobal{htmlimagesizex} = 0;
-        $::lglobal{htmlimagesizey} = 0;
+        $::lglobal{htmlimagesizex} = $xythumb;
+        $::lglobal{htmlimagesizey} = $xythumb;
         $::lglobal{htmlimggeom}->configure( -text => "File size: unknown" );
         $::lglobal{htmlimgmaxwidth}->configure( -text => "" );
     }


### PR DESCRIPTION
Use thumbnail instead of 0 default size if image size cannot be determined.

Fixes #242 