### PR TITLE
Speed up some operations by reducing update frequency

### DIFF
--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -752,8 +752,7 @@ sub footnotefixup {
         ) if $::lglobal{fnsecondpass};
         $pointer = '';
         $anchor  = '';
-        $textwindow->yview('end');
-        $textwindow->see($start) if $start;
+        $textwindow->see($start) if $start and not ::updatedrecently();
         $textwindow->tagAdd( 'footnote', $start, $end );
         $textwindow->markSet( 'insert', $start );
         $::lglobal{fnindexbrowse}->insert( 'end', $::lglobal{fnindex} )
@@ -1156,10 +1155,10 @@ sub footnotetidy {
         $end = $textwindow->index( 'fne' . $::lglobal{fnindex} );
         $textwindow->delete("$end-1c");
         $textwindow->tagAdd( 'sel', 'fns' . $::lglobal{fnindex}, "$end+1c" );
-        ::selectrewrap( $textwindow, $::lglobal{seepagenums},
-            $::scannos_highlighted, $::rwhyphenspace );
+        ::selectrewrap('silentmode');    # slow to rewrap if screen updated for every note
         $::lglobal{fnindex}++;
         last if $::lglobal{fnindex} > $::lglobal{fntotal};
+        $textwindow->update unless ::updatedrecently();    # do occasional updates
     }
     $textwindow->addGlobEnd;
 }

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -443,7 +443,7 @@ sub html_convert_body {
 
     #step through all the lines
     while ( $step <= $ler ) {
-        unless ( $step % 500 ) {    #refresh window every 550 steps
+        unless ( ::updatedrecently() ) {    # slow if updated too frequently
             $textwindow->see("$step.0");
             $textwindow->update;
         }
@@ -972,8 +972,6 @@ sub html_convert_body {
                 push @contents, "<a href=\"#" . $aname . "\">" . $completeheader . "</a><br />\n";
             }
             $selection .= '<h2';
-            $textwindow->see("$step.0");
-            $textwindow->update;
 
             #open subheading with <p>
         } elsif ( $last5[2] && ( $last5[2] =~ /<h2/ ) && ($selection) ) {

--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -184,8 +184,7 @@ sub keybindings {
         '<Control-w>',
         sub {
             $textwindow->addGlobStart;
-            ::selectrewrap( $textwindow, $::lglobal{seepagenums},
-                $::scannos_highlighted, $::rwhyphenspace );
+            ::selectrewrap();
             $textwindow->addGlobEnd;
         }
     );

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -408,8 +408,7 @@ sub menu_tools {
             -command => sub {
                 $textwindow->addGlobStart;
                 $textwindow->selectAll;
-                ::selectrewrap( $textwindow, $::lglobal{seepagenums},
-                    $::scannos_highlighted, $::rwhyphenspace );
+                ::selectrewrap();
                 $textwindow->addGlobEnd;
                 $textwindow->see('1.0');
             }
@@ -420,8 +419,7 @@ sub menu_tools {
             -accelerator => 'Ctrl+w',
             -command     => sub {
                 $textwindow->addGlobStart;
-                ::selectrewrap( $textwindow, $::lglobal{seepagenums},
-                    $::scannos_highlighted, $::rwhyphenspace );
+                ::selectrewrap();
                 $textwindow->addGlobEnd;
             }
         ],

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -227,7 +227,7 @@ sub searchtext {
         $::searchendindex = $textwindow->index("$::searchstartindex +1c")
           unless $length;
 
-        unless ($silentmode) {
+        unless ( $silentmode or ::updatedrecently() ) {
             $textwindow->markSet( 'insert', $::searchstartindex )
               if $::searchstartindex;    # position the cursor at the index
             $textwindow->tagAdd( 'highlight', $::searchstartindex, $::searchendindex )
@@ -246,14 +246,14 @@ sub searchtext {
         if ( $::sopt[2] ) {
             $::searchstartindex = $end;
 
-            unless ($silentmode) {
+            unless ( $silentmode or ::updatedrecently() ) {
                 $textwindow->markSet( 'insert', $::searchstartindex );
                 $textwindow->see($::searchendindex);
             }
         } else {
             $::searchendindex = $start;
 
-            unless ($silentmode) {
+            unless ( $silentmode or ::updatedrecently() ) {
                 $textwindow->markSet( 'insert', $start );
                 $textwindow->see($start);
             }
@@ -272,7 +272,7 @@ sub searchtext {
             }
         }
     }
-    unless ($silentmode) {
+    unless ( $silentmode or ::updatedrecently() ) {
         ::updatesearchlabels();
         ::update_indicators();
     }
@@ -1085,14 +1085,15 @@ sub replaceall {
     #print "repl:$replacement:ranges:@ranges:\n";
     $textwindow->focus;
     ::opstop();
-    while ( searchtext() ) {    # keep calling search() and replace() until you return undef
+
+    # keep calling search() and replace() until no more matches
+    while ( searchtext() ) {
         last unless replace($replacement);
         last if $::operationinterrupt;
-        $textwindow->update;
+        $textwindow->update unless ::updatedrecently();    # Too slow if update window after every match
     }
     $::operationinterrupt = 0;
-    $::lglobal{stoppop}->destroy;
-    undef $::lglobal{stoppop};
+    ::killstoppop();
 }
 
 # Reset search from start of doc if new search term

--- a/src/lib/Guiguts/Tests.pm
+++ b/src/lib/Guiguts/Tests.pm
@@ -68,14 +68,7 @@ sub runtests {
 
     ok( 1 == do { $textwindow->selectAll; 1 }, "Select All" );
 
-    ok(
-        1 == do {
-            ::selectrewrap( $textwindow, $::lglobal{seepagenums},
-                $::scannos_highlighted, $::rwhyphenspace );
-            1;
-        },
-        "Rewrap Selection"
-    );
+    ok( 1 == do { ::selectrewrap(); 1 }, "Rewrap Selection" );
 
     ok( 1 == do { $textwindow->SaveUTF($WRAPOUTFILE); ::setedited(0); 1 },
         "File saved as $WRAPOUTFILE" );

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -16,7 +16,7 @@ BEGIN {
       &sidenotes &poetrynumbers &get_page_number &externalpopup
       &xtops &toolbar_toggle &killpopup &expandselection &currentfileisunicode &currentfileislatin1
       &getprojectid &setprojectid &viewprojectcomments &viewprojectdiscussion &viewprojectpage
-      &scrolldismiss);
+      &scrolldismiss &updatedrecently);
 
 }
 
@@ -2417,5 +2417,33 @@ sub viewprojectpage {
     ::setprojectid() unless $::projectid;
     ::launchurl( $::urlprojectpage . $::projectid ) if $::projectid;
 }
+
+# Allow for infrequent window updates to display during long operations
+# Timings are only accurate to seconds, not milliseconds
+# Routine keeps returning true until UPDATE_FREQUENCY seconds have passed.
+# It then resets the base time and returns false.
+# It is the user's responsibility to do the update when false is returned.
+#
+# Usage:
+#   while ( lots_of_repeats ) {
+#       my_processing_sub();
+#       my_update_sub() unless ::updatedrecently();
+#   }
+#
+
+{    # Block to make variables local & persistent
+    my $UPDATE_FREQUENCY = 1;        # in seconds
+    my $lastcalled       = time();
+
+    sub updatedrecently {
+
+        # Return true if not long since last time save
+        return 1 if time() - $lastcalled < $UPDATE_FREQUENCY;
+
+        # Too long since last time save, so save new time and return false
+        $lastcalled = time();
+        return 0;
+    }
+}    # end of variable-enclosing block
 
 1;


### PR DESCRIPTION
New routine, `updatedrecently`, can be called before repeated window updates
to check if it's time to do another update. Update frequency set to 1 second.

Implemented for rewrapping, for "slow" Replace All (fast one is done in one call),
for several footnote operations(first pass, move to landing zone, and tidy up), and for
HTML body conversion. Speed-ups of 3x or more.

Also removed parameters passed to selectrewrap() since they were ignored in the
routine, paving the way for an argument to trigger silent mode which does no
screen updating when called from footnote code.

Fixes #153
Also fixes #277