### PR TITLE
Speed up some operations by hiding line numbers

### DIFF
--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -673,6 +673,7 @@ sub fnview {
 sub footnotefixup {
     my $top        = $::top;
     my $textwindow = $::textwindow;
+    ::hidelinenumbers();    # To speed updating of text window
     ::hidepagenums();
     ::operationadd('Reindex footnotes') if $::lglobal{fnsecondpass} == 1;
     my ( $start, $end, $anchor, $pointer );
@@ -844,6 +845,7 @@ sub footnotefixup {
         $::lglobal{fnmvinlinebutton}->configure( '-state' => 'normal' );
     }
     footnoteshow();
+    ::restorelinenumbers();
 }
 
 sub getlz {
@@ -1143,7 +1145,9 @@ sub footnotetidy {
     footnotefixup();
     return unless $::lglobal{fntotal} > 0;
     $::lglobal{fnindex} = 1;
+    ::hidelinenumbers();    # To speed updating of text window
     $textwindow->addGlobStart;
+
     while (1) {
         $begin = $textwindow->index( 'fns' . $::lglobal{fnindex} );
         $textwindow->delete( "$begin+1c", "$begin+10c" );
@@ -1161,6 +1165,7 @@ sub footnotetidy {
         $textwindow->update unless ::updatedrecently();    # do occasional updates
     }
     $textwindow->addGlobEnd;
+    ::restorelinenumbers();
 }
 
 sub setanchor {

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -438,6 +438,8 @@ sub html_convert_body {
         $blkclose = '</p></blockquote>';
     }
 
+    ::hidelinenumbers();    # To speed updating of text window
+
     #last line and column
     ( $ler, $lec ) = split /\./, $thisblockend;
 
@@ -1021,7 +1023,7 @@ sub html_convert_body {
     $contentstext = "<p>" . $contentstext . "</p>"
       unless is_paragraph_open( $textwindow, $incontents );
     $textwindow->insert( $incontents, $contentstext ) if @contents;
-    return;
+    ::restorelinenumbers();
 }
 
 # Put <div class="chapter"> before, and </div> after h2 elements, including pagenum

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -787,12 +787,7 @@ sub menu_preferences_appearance {
             -variable   => \$::vislnnm,
             -onvalue    => 1,
             -offvalue   => 0,
-            -command    => sub {
-                $::vislnnm
-                  ? $textwindow->showlinenum
-                  : $textwindow->hidelinenum;
-                ::savesettings();
-            }
+            -command    => sub { ::displaylinenumbers($::vislnnm) },
         ],
         [
             Checkbutton => 'Auto Show Page Images',

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1082,7 +1082,7 @@ sub replaceall {
         }
     }
 
-    #print "repl:$replacement:ranges:@ranges:\n";
+    ::hidelinenumbers();    # To speed updating of text window
     $textwindow->focus;
     ::opstop();
 
@@ -1094,6 +1094,7 @@ sub replaceall {
     }
     $::operationinterrupt = 0;
     ::killstoppop();
+    ::restorelinenumbers();
 }
 
 # Reset search from start of doc if new search term

--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -61,6 +61,7 @@ sub selectrewrap {
     my $silentmode = shift;
     my $textwindow = $::textwindow;
     unless ($silentmode) {
+        ::hidelinenumbers();    # To speed updating of text window
         ::hidepagenums();
         ::savesettings();
     }
@@ -342,6 +343,7 @@ sub selectrewrap {
         $textwindow->see($start);
         $textwindow->Unbusy;
         ::update_indicators();
+        ::restorelinenumbers();
     }
 }
 

--- a/src/lib/Guiguts/StatusBar.pm
+++ b/src/lib/Guiguts/StatusBar.pm
@@ -149,12 +149,16 @@ AAAAACH5BAAAAAAALAAAAAAMAAwAAwQfMMg5BaDYXiw178AlcJ6VhYFXoSoosm7KvrR8zfXHRQA7
         -data   => 'R0lGODlhBwAEAIAAAAAAAP///yH5BAEAAAEALAAAAAAHAAQAAAIIhA+BGWoNWSgAOw=='
     );
     ::drag($textwindow);
+
+    # Row and column of insert position
     $::lglobal{current_line_label} = $::counter_frame->Label(
         -text       => 'L:1/1 C:0',
         -width      => 18,
         -relief     => 'ridge',
         -background => 'gray',
     )->grid( -row => 1, -column => 0, -sticky => 'nw' );
+
+    # Mouse-1 to go to line number
     $::lglobal{current_line_label}->bind(
         '<1>',
         sub {
@@ -163,16 +167,15 @@ AAAAACH5BAAAAAAALAAAAAAMAAwAAwQfMMg5BaDYXiw178AlcJ6VhYFXoSoosm7KvrR8zfXHRQA7
             ::update_indicators();
         }
     );
+
+    # Mouse-3 to toggle line number display
     $::lglobal{current_line_label}->bind(
         '<3>',
         sub {
-            if   ($::vislnnm) { $::vislnnm = 0 }
-            else              { $::vislnnm = 1 }
-            $textwindow->showlinenum if $::vislnnm;
-            $textwindow->hidelinenum unless $::vislnnm;
-            ::savesettings();
+            ::displaylinenumbers( !$::vislnnm );
         }
     );
+
     $::lglobal{selectionlabel} = $::counter_frame->Label(
         -text       => ' No Selection ',
         -relief     => 'ridge',

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -16,7 +16,7 @@ BEGIN {
       &sidenotes &poetrynumbers &get_page_number &externalpopup
       &xtops &toolbar_toggle &killpopup &expandselection &currentfileisunicode &currentfileislatin1
       &getprojectid &setprojectid &viewprojectcomments &viewprojectdiscussion &viewprojectpage
-      &scrolldismiss &updatedrecently);
+      &scrolldismiss &updatedrecently &hidelinenumbers &restorelinenumbers &displaylinenumbers);
 
 }
 
@@ -872,9 +872,6 @@ sub initialize {
                 return unless $::nohighlights;
                 $::textwindow->HighlightAllPairsBracketingCursor;
             },
-            sub {
-                $::textwindow->hidelinenum unless $::vislnnm;
-            }
         ]
     );
 
@@ -2445,5 +2442,23 @@ sub viewprojectpage {
         return 0;
     }
 }    # end of variable-enclosing block
+
+# Show/hide line numbers based on input argument
+sub displaylinenumbers {
+    $::vislnnm = shift;
+    $::vislnnm ? $::textwindow->showlinenum : $::textwindow->hidelinenum;
+    ::savesettings();
+}
+
+# Temporarily hide line numbers to speed up some operations
+# Note that the global flag is not changed
+sub hidelinenumbers {
+    $::textwindow->hidelinenum if $::vislnnm;
+}
+
+# Restore the line numbers after they have been temporarily hidden
+sub restorelinenumbers {
+    $::textwindow->showlinenum if $::vislnnm;
+}
 
 1;


### PR DESCRIPTION
Some operations that do lots of window updating take longer when line numbers
are showing. After #153, gain a further speed-up by hiding line numbers temporarily.

Example timings in seconds:
(1.1.1 with linenums, 1.1.1 without linenums, dev version)
Rewrap 10K line file:  36, 18, 6
Convert 10K line file to HTML: 8, 3, 3
100K line file with 550 footnotes:
Fixup 13, 10, 6
Move to LZ 14, 10, 7
Tidy 98, 90, 32

Fixes #278