### PR TITLE
Centralise handling of sounding bell for warnings

### DIFF
--- a/src/lib/Guiguts/ASCIITables.pm
+++ b/src/lib/Guiguts/ASCIITables.pm
@@ -371,7 +371,7 @@ sub insertline {
     my @ranges      = $textwindow->tagRanges('table');
     my $range_total = @ranges;
     if ( $range_total == 0 ) {
-        $textwindow->bell;
+        ::soundbell();
         return;
     } else {
         $textwindow->addGlobStart;

--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -1126,7 +1126,7 @@ sub footnoteadjust {
       if $::lglobal{footpop};
 
     if ( $end eq "$start+10c" ) {
-        $textwindow->bell unless $::nobell;
+        ::soundbell();
         return;
     }
     $::lglobal{fnarray}->[ $::lglobal{fnindex} ][0] = $start if $start;

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -2738,7 +2738,7 @@ sub markup {
                 if ( exists $inthash{ '#' . ( lc($match) ) } ) {
                     $textwindow->tagAdd( 'highlight', $anchorstartindex, $anchorendindex );
                     $textwindow->see($anchorstartindex);
-                    $textwindow->bell unless $::nobell;
+                    ::soundbell();
                     $top->messageBox(
                         -icon    => 'error',
                         -message => "More than one instance of the anchor $match2 in text.",

--- a/src/lib/Guiguts/PageNumbers.pm
+++ b/src/lib/Guiguts/PageNumbers.pm
@@ -154,7 +154,7 @@ sub pnumadjust {
         my $frame5 = $::lglobal{pagemarkerpop}->Frame->pack( -pady => 5 );
         $frame5->Button(
             -activebackground => $::activecolor,
-            -command          => sub { $textwindow->bell unless ::pageadd() },
+            -command          => sub { ::soundbell() unless ::pageadd() },
             -text             => 'Add',
             -width            => 8
         )->grid( -row => 1, -column => 1 );
@@ -325,8 +325,10 @@ sub pgrenum {    # Re sequence page markers
         $end = $::lglobal{pagenumentry}->get unless $end;
         while ( $marks[$#marks] ne $end ) { pop @marks }
     }
-    $textwindow->bell unless $offset;
-    return            unless $offset;
+    unless ($offset) {
+        ::soundbell();
+        return;
+    }
     ::hidepagenums();
     $textwindow->markSet( 'insert', '1.0' );
     %::pagenumbers = ();

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -260,7 +260,7 @@ sub searchtext {
         }
         $::lglobal{selectionsearch} = 0;
         unless ( $::lglobal{regaa} or $silentmode ) {
-            $textwindow->bell unless $::nobell;
+            ::soundbell();
             $::lglobal{searchbutton}->flash if defined $::lglobal{searchpop};
             $::lglobal{searchbutton}->flash if defined $::lglobal{searchpop};
 
@@ -663,7 +663,7 @@ sub findascanno {
     $word = $::lglobal{scannosarray}[ $::lglobal{scannosindex} ];
     $::lglobal{searchentry}->delete( '1.0', 'end' );
     $::lglobal{replaceentry}->delete( '1.0', 'end' );
-    $textwindow->bell unless ( $word || $::nobell || $::lglobal{regaa} );
+    ::soundbell()                   unless ( $word || $::lglobal{regaa} );
     $::lglobal{searchbutton}->flash unless ( $word || $::lglobal{regaa} );
     $::lglobal{regtracker}->configure(
         -text => ( $::lglobal{scannosindex} + 1 ) . '/' . scalar( @{ $::lglobal{scannosarray} } ) );
@@ -2044,7 +2044,7 @@ sub orphanedbrackets {
                     $brkresult->configure( -text => "No more orphaned $brackets found." );
                     $brnextbt->configure( -state => 'disabled', -text => 'Next' );
                     $textwindow->tagRemove( 'highlight', '1.0', 'end' );
-                    $textwindow->bell unless $::nobell;
+                    ::soundbell();
                     return;
                 }
                 brnext( $brkresult, $brnextbt );
@@ -2095,7 +2095,7 @@ sub orphanedbrackets {
             $brkresult->configure( -text => "No more orphaned $brackets found." );
             $brnextbt->configure( -text => 'Next', -state => 'disabled' );
             $textwindow->tagRemove( 'highlight', '1.0', 'end' );
-            $textwindow->bell unless $::nobell;
+            ::soundbell();
         }
     }
 
@@ -2196,7 +2196,7 @@ sub orphanedbrackets {
             $brkresult->configure( -text => "No more orphaned $brackets found." );
             $brnextbt->configure( -text => 'Next', -state => 'disabled' );
             $textwindow->tagRemove( 'highlight', '1.0', 'end' );
-            $textwindow->bell unless $::nobell;
+            ::soundbell();
         }
     }
 }

--- a/src/lib/Guiguts/SpellCheck.pm
+++ b/src/lib/Guiguts/SpellCheck.pm
@@ -84,10 +84,7 @@ sub spellchecknext {
     $textwindow->tagRemove( 'highlight', '1.0', 'end' );    # unhighlight any higlighted text
     spellclearvars();
     $::lglobal{misspelledlabel}->configure( -text => 'Not in Dictionary:' );
-    unless ($::nobell) {
-        $textwindow->bell
-          if ( $::lglobal{nextmiss} >= ( scalar( @{ $::lglobal{misspelledlist} } ) ) );
-    }
+    ::soundbell() if $::lglobal{nextmiss} >= ( scalar( @{ $::lglobal{misspelledlist} } ) );
     $::lglobal{suggestionlabel}->configure( -text => 'Suggestions:' );
     return
       if $::lglobal{nextmiss} >= ( scalar( @{ $::lglobal{misspelledlist} } ) );    # no more misspelled words, bail
@@ -201,7 +198,7 @@ sub spellreplace {
     my $textwindow = $::textwindow;
     ::hidepagenums();
     my $replacement = $::lglobal{spreplaceentry}->get;          # get the word for the replacement box
-    $textwindow->bell unless ( $replacement || $::nobell );
+    ::soundbell() unless $replacement;
     my $misspelled = $::lglobal{misspelledentry}->get;
     return unless $replacement;
     $textwindow->replacewith( $::lglobal{matchindex},
@@ -240,8 +237,10 @@ sub spellmisspelled_replace {
 sub spelladdword {
     my $textwindow = $::textwindow;
     my $term       = $::lglobal{misspelledentry}->get;
-    $textwindow->bell unless ( $term || $::nobell );
-    return            unless $term;
+    unless ($term) {
+        ::soundbell();
+        return;
+    }
     print OUT "*$term\n";
     print OUT "#\n";
 }
@@ -250,8 +249,10 @@ sub spelladdword {
 sub spellmyaddword {
     my $textwindow = $::textwindow;
     my $term       = shift;
-    $textwindow->bell unless ( $term || $::nobell );
-    return            unless $term;
+    unless ($term) {
+        ::soundbell();
+        return;
+    }
     getprojectdic();
     $::projectdict{$term} = '';
     open( my $dic, '>:bytes', "$::lglobal{projectdictname}" );
@@ -446,8 +447,10 @@ sub spellignoreall {
     my $textwindow = $::textwindow;
     my $next;
     my $word = $::lglobal{misspelledentry}->get;        # get word you want to ignore
-    $textwindow->bell unless ( $word || $::nobell );
-    return            unless $word;
+    unless ($word) {
+        ::soundbell();
+        return;
+    }
     my @ignorelist = @{ $::lglobal{misspelledlist} };    # copy the misspellings array
     @{ $::lglobal{misspelledlist} } = ();                # then clear it
     foreach my $next (@ignorelist) {                     # then put all of the words you are NOT ignoring back into the

--- a/src/lib/Guiguts/StatusBar.pm
+++ b/src/lib/Guiguts/StatusBar.pm
@@ -746,7 +746,7 @@ sub gotopage {
             -command => sub {
                 if ( ( defined $_[0] ) and ( $_[0] eq 'OK' ) ) {
                     unless ( $::lglobal{lastpage} ) {
-                        $::lglobal{gotopagpop}->bell;
+                        ::soundbell();
                         $::lglobal{gotopagpop}->destroy;
                         undef $::lglobal{gotopagpop};
                         return;
@@ -761,7 +761,7 @@ sub gotopage {
                     unless ( exists $::pagenumbers{ 'Pg' . $::lglobal{lastpage} }
                         && defined $::pagenumbers{ 'Pg' . $::lglobal{lastpage} } ) {
                         delete $::pagenumbers{ 'Pg' . $::lglobal{lastpage} };
-                        $::lglobal{gotopagpop}->bell;
+                        ::soundbell();
                         $::lglobal{gotopagpop}->destroy;
                         undef $::lglobal{gotopagpop};
                         return;
@@ -808,7 +808,7 @@ sub gotolabel {
                         }
                     }
                     unless ($mark) {
-                        $::lglobal{gotolabpop}->bell;
+                        ::soundbell();
                         $::lglobal{gotolabpop}->destroy;
                         undef $::lglobal{gotolabpop};
                         return;


### PR DESCRIPTION
1. One or two calls to bell did not respect the nobell flag
2. All calls now go through Utilities::soundbell
3. As well as sounding bell if permitted, also flash the first label on the status bar as a
visual warning.

Fixes #280 