### PR TITLE
Retain "Start at Beginning" setting when using Count in S&R dialog

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -299,6 +299,9 @@ sub countmatches {
     my $savesopt2 = $::sopt[2];
     $::sopt[2] = 0;
 
+    # save Start at Beginning flag, because searching clears it
+    my $savesopt4 = $::sopt[4];
+
     # save selectionsearch flag and clear it
     my $saveselectionsearch = $::lglobal{selectionsearch};
     $::lglobal{selectionsearch} = 0;
@@ -311,6 +314,7 @@ sub countmatches {
     $::searchstartindex         = $savesearchstartindex;
     $::searchendindex           = $savesearchendindex;
     $::sopt[2]                  = $savesopt2;
+    $::sopt[4]                  = $savesopt4;
     $::lglobal{selectionsearch} = $saveselectionsearch;
 
     # restore selection range if there was one before counting


### PR DESCRIPTION
Although the "Start at Beginning" flag has no effect on Count, the flag gets cleared
by any search operation. So save it before Counting and restore it afterwards.

Fixes #293