### PR TITLE
Fix error messages when Import is cancelled or bad file loaded

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -1018,16 +1018,17 @@ sub file_import_markup {
         -title      => 'Open File',
         -initialdir => $::globallastpath
     );
-    if ( defined($name) and length($name) ) {
-        ::openfile($name);
-    }
+    return unless defined($name) and length($name);
+    ::openfile($name);
     $::lglobal{global_filename} = 'No File Loaded';
     $textwindow->FileName( $::lglobal{global_filename} );
+
     my $firstline = $textwindow->get( '1.0', '1.end' );
     if ( $firstline =~ '##### Do not edit this line.' ) {
         $textwindow->delete( '1.0', '2.0' );
     }
     my $binstart = $textwindow->search( '-exact', '--', '##### Do not edit below.', '1.0', 'end' );
+    return unless $binstart;    # File is not an exported .gut file
     my ( $row, $col ) = split( /\./, $binstart );
     $textwindow->delete( "$row.0", "$row.end" );
     my $binfile = $textwindow->get( "$row.0", "end" );


### PR DESCRIPTION
File-->Content Providing-->Import One File with Page Sep Markup had a check to
see if a filename was given before it tried to open it. However, even if none was given
it still went on to execute the rest of the routine. Fixed by returning earlier if
cancelled.

Also, if a junk file is loaded, just abandon the routine, rather than try to work through
with uninitialised variables. Situation too rare to warrant detailed error handling.

Fixes #290