### PR TITLE
Avoid deleting text when converting inline sidenotes to HTML

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1164,8 +1164,14 @@ sub html_convert_sidenotes {
             $thisblockstart = $thisnoteend;
             $thisnoteend    = $textwindow->search( '--', ']</p>', $thisblockstart, 'end' );
         }
-        $textwindow->ntdelete( $thisnoteend, "$thisnoteend+5c" )
-          if $thisnoteend;
+        if ($thisnoteend) {
+            my $dtext = $textwindow->get( $thisnoteend, "$thisnoteend+5c" );
+            if ( $dtext eq ']</p>' ) {    # normal footnote in its own paragraph
+                $textwindow->ntdelete( $thisnoteend, "$thisnoteend+5c" );
+            } elsif ( substr( $dtext, 0, 1 ) =~ ']' ) {    # inline footnote
+                $textwindow->ntdelete( $thisnoteend, "$thisnoteend+1c" );
+            }
+        }
         $textwindow->ntinsert( $thisnoteend, '</div>' ) if $thisnoteend;
     }
     while ( $thisblockstart = $textwindow->search( '--', '</div></div></p>', '1.0', 'end' ) ) {


### PR DESCRIPTION
Although files should not come out of the proofing rounds with sidenotes inline,
some PPers may make them inline in certain circumstances, e.g.
`This sentence [Sidenote: Notes] has an inline sidenote`
Since the code was assuming the sidenote would have a trailing `</p>` it deleted
4 more characters after the closing `]`.
Now it only does that if they characters are `]</p>`. If it's just a `]`, then just that
one character is deleted.

Fixes #271 and prepares the way for #272 to work successfully if implemented.