### PR TITLE
Make jeebies use same tempfile mechanism as other tools

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -211,9 +211,9 @@ sub nofileloadedwarning {
     my $top = $::top;
     if ( $::lglobal{global_filename} =~ m/No File Loaded/ ) {
         my $dialog = $top->Dialog(
-            -text    => "No file loaded.",
+            -text    => "File has not been saved.",
             -bitmap  => 'warning',
-            -title   => "No File Loaded",
+            -title   => "No Filename",
             -buttons => ['OK']
         );
         my $answer = $dialog->Show;

--- a/src/lib/ppvchecks/pptxt.pl
+++ b/src/lib/ppvchecks/pptxt.pl
@@ -53,7 +53,6 @@ sub runProgram {
 
     open LOGFILE, "> $outfile" || die "output file error\n";
 
-    print LOGFILE "processing $srctext to $outfile\n\n";
     printf LOGFILE ( "%s\n", "-" x 80 );
 
     open INFILE, $srctext;

--- a/src/tests/pptxtbaseline.txt
+++ b/src/tests/pptxtbaseline.txt
@@ -1,5 +1,4 @@
 Beginning check: pptxt
-processing errors.tmp to errors.err
 --------------------------------------------------------------------------------
 asterisk check
  no unexpected asterisks found in text.


### PR DESCRIPTION
Jeebies used to save the current file if edited, and run on the current file, unlike
other tools which saved to a temporary file for checking.

Now all tools use the same mechanism, with temp filenames stored in variables.
The temp files are also in the user's working directory, not the installation dir.

Also pptxt no longer reports the filename it is converting - no other tools do it,
and it's a nuisance in the text environment.

Fixes #299