### PR TITLE
Use `killpopup` to destroy widgets

### DIFF
--- a/src/lib/Guiguts/ASCIITables.pm
+++ b/src/lib/Guiguts/ASCIITables.pm
@@ -198,8 +198,7 @@ sub tablefx {
                 $textwindow->tagRemove( 'table',   '1.0', 'end' );
                 $textwindow->tagRemove( 'linesel', '1.0', 'end' );
                 $textwindow->markUnset( 'tblstart', 'tblend' );
-                $::lglobal{tblfxpop}->destroy;
-                undef $::lglobal{tblfxpop};
+                ::killpopup('tblfxpop');
             }
         );
         tblselect();

--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -127,8 +127,7 @@ sub doutfbuttons {
     my $rows       = ( ( hex $end ) - ( hex $start ) + 1 ) / 16 - 1;
     my ( @buttons, $blln );
     $blln = $::lglobal{utfpop}->Balloon( -initwait => 750 );
-    $::lglobal{pframe}->destroy if $::lglobal{pframe};
-    undef $::lglobal{pframe};
+    ::killpopup('pframe');
     $::lglobal{pframe} =
       $::lglobal{utfpop}->Frame( -background => $::bkgcolor )
       ->pack( -expand => 'y', -fill => 'both' );
@@ -184,8 +183,7 @@ sub utfpopup {
     my $blln;
     my ( $frame, $sizelabel, @buttons );
     my $rows = ( ( hex $end ) - ( hex $start ) + 1 ) / 16 - 1;
-    $::lglobal{utfpop}->destroy if $::lglobal{utfpop};
-    undef $::lglobal{utfpop};
+    ::killpopup('utfpop');
     $::lglobal{utfpop} = $top->Toplevel;
     ::initialize_popup_without_deletebinding('utfpop');
     $blln = $::lglobal{utfpop}->Balloon( -initwait => 750 );
@@ -266,8 +264,7 @@ sub utfpopup {
         'WM_DELETE_WINDOW' => sub {
             $blln->destroy;
             undef $blln;
-            $::lglobal{utfpop}->destroy;
-            undef $::lglobal{utfpop};
+            ::killpopup('utfpop');
         }
     );
     $top->Unbusy( -recurse => 1 );
@@ -570,10 +567,7 @@ sub utfcharentrypopup {
         $frame1->Button(
             -text    => 'Close',
             -width   => 8,
-            -command => sub {
-                $::lglobal{utfentrypop}->destroy;
-                undef $::lglobal{utfentrypop};
-            },
+            -command => sub { ::killpopup('utfentrypop'); },
         )->grid( -row => 1, -column => 2 );
         $inentry->Tk::bind(
             '<Return>',

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -19,10 +19,7 @@ sub errorcheckpop_up {
     ::hidepagenums();
 
     # Destroy and start afresh if already popped
-    if ( $::lglobal{errorcheckpop} ) {
-        $::lglobal{errorcheckpop}->destroy;
-        undef $::lglobal{errorcheckpop};
-    }
+    ::killpopup('errorcheckpop');
     $::lglobal{errorcheckpop} = $top->Toplevel;
     $::lglobal{errorcheckpop}->title($errorchecktype);
 
@@ -926,9 +923,8 @@ sub gcviewopts {
         ::initialize_popup_without_deletebinding('gcviewoptspop');
         $::lglobal{gcviewoptspop}->protocol(
             'WM_DELETE_WINDOW' => sub {
-                $::lglobal{gcviewoptspop}->destroy;
-                undef $::lglobal{gcviewoptspop};
-                unlink 'gutreslts.tmp';    #cat('gutreslts.tmp')
+                ::killpopup('gcviewoptspop');
+                unlink 'gutreslts.tmp';
             }
         );
     }

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -361,18 +361,9 @@ sub clearvars {
 
 ## Destroy some popups and labels when closing a file
 sub clearpopups {
-    if ( $::lglobal{img_num_label} ) {
-        $::lglobal{img_num_label}->destroy;
-        undef $::lglobal{img_num_label};
-    }
-    if ( $::lglobal{pagebutton} ) {
-        $::lglobal{pagebutton}->destroy;
-        undef $::lglobal{pagebutton};
-    }
-    if ( $::lglobal{previmagebutton} ) {
-        $::lglobal{previmagebutton}->destroy;
-        undef $::lglobal{previmagebutton};
-    }
+    ::killpopup('img_num_label');
+    ::killpopup('pagebutton');
+    ::killpopup('previmagebutton');
     ::killpopup('footpop');
     ::killpopup('footcheckpop');
     ::killpopup('htmlgenpop');
@@ -605,8 +596,7 @@ sub file_guess_page_marks {
                     $textwindow->markSet( "Pg$number", "$lnum.0" );
                     $textwindow->markGravity( "Pg$number", 'left' );
                 }
-                $::lglobal{guesspgmarkerpop}->destroy;
-                undef $::lglobal{guesspgmarkerpop};
+                ::killpopup('guesspgmarkerpop');
             },
             -text  => 'Guess Page #s',
             -width => 18

--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -315,8 +315,7 @@ sub footnotepop {
         $::lglobal{footpop}->protocol(
             'WM_DELETE_WINDOW' => sub {
                 ::killpopup('footcheckpop');
-                $::lglobal{footpop}->destroy;
-                undef $::lglobal{footpop};
+                ::killpopup('footpop');
                 $textwindow->tagRemove( 'footnote', '1.0', 'end' );
             }
         );
@@ -512,8 +511,7 @@ sub fnjoin {
 
     # reload the Check Footnotes window to update the list
     if ( defined( $::lglobal{footcheckpop} ) ) {
-        $::lglobal{footcheckpop}->destroy;
-        undef $::lglobal{footcheckpop};
+        ::killpopup('footcheckpop');
         fnview( $::lglobal{fnindex} );
     }
     footnoteshow();

--- a/src/lib/Guiguts/Greek.pm
+++ b/src/lib/Guiguts/Greek.pm
@@ -704,8 +704,7 @@ sub greekpopup {
                     $::lglobal{buttons}->{$image}->destroy;
                 }
                 %attributes = ();
-                $::lglobal{grpop}->destroy;
-                undef $::lglobal{grpop};
+                ::killpopup('grpop');
             }
         );
         $glatin->select;

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1718,23 +1718,7 @@ sub htmlimage {
             -background => $::bkgcolor,
         )->grid( -row => 1, -column => 1 );
         $::lglobal{imagelbl}->bind( $::lglobal{imagelbl}, '<1>', \&thumbnailbrowse );
-        $::lglobal{htmlimpop}->protocol(
-            'WM_DELETE_WINDOW' => sub {
-                $::lglobal{htmlthumb}->delete  if $::lglobal{htmlthumb};
-                $::lglobal{htmlthumb}->destroy if $::lglobal{htmlthumb};
-                $::lglobal{htmlorig}->delete   if $::lglobal{htmlorig};
-                $::lglobal{htmlorig}->destroy  if $::lglobal{htmlorig};
-                for (
-                    $::lglobal{alttext},   $::lglobal{titltext}, $::lglobal{widthent},
-                    $::lglobal{heightent}, $::lglobal{imagelbl}, $::lglobal{imgname}
-                ) {
-                    $_->destroy;
-                }
-                $textwindow->tagRemove( 'highlight', '1.0', 'end' );
-                $::lglobal{htmlimpop}->destroy;
-                undef $::lglobal{htmlimpop};
-            }
-        );
+        $::lglobal{htmlimpop}->protocol( 'WM_DELETE_WINDOW' => sub { htmlimagedestroy(); } );
         $::lglobal{htmlimpop}->transient($top);
     }
     $::lglobal{alttext}->delete( 0, 'end' )                       if $::lglobal{alttext};
@@ -1849,26 +1833,16 @@ sub htmlimageok {
         }
     }
     $textwindow->addGlobEnd;
+    htmlimagedestroy();
+}
 
-    $::lglobal{htmlthumb}->delete
-      if $::lglobal{htmlthumb};
-    $::lglobal{htmlthumb}->destroy
-      if $::lglobal{htmlthumb};
-    $::lglobal{htmlorig}->delete
-      if $::lglobal{htmlorig};
-    $::lglobal{htmlorig}->destroy
-      if $::lglobal{htmlorig};
-    for (
-        $::lglobal{alttext},   $::lglobal{titltext}, $::lglobal{widthent},
-        $::lglobal{heightent}, $::lglobal{imagelbl}, $::lglobal{imgname}
-    ) {
-        $_->destroy;
-    }
-    $textwindow->tagRemove( 'highlight', '1.0', 'end' );
-    $::lglobal{htmlimpop}->destroy
-      if $::lglobal{htmlimpop};
-    undef $::lglobal{htmlimpop}
-      if $::lglobal{htmlimpop};
+sub htmlimagedestroy {
+    $::lglobal{htmlthumb}->delete if $::lglobal{htmlthumb};
+    ::killpopup('htmlthumb');
+    $::lglobal{htmlorig}->delete if $::lglobal{htmlorig};
+    ::killpopup('htmlorig');
+    $::textwindow->tagRemove( 'highlight', '1.0', 'end' );
+    ::killpopup('htmlimpop');
 }
 
 # Reset the width field to the default for the current type
@@ -2329,13 +2303,7 @@ sub htmlgenpopup {
             -width => 16,
         )->grid( -row => 1, -column => 2, -padx => 5, -pady => 1 );
 
-        ::initialize_popup_without_deletebinding('htmlgenpop');
-        $::lglobal{htmlgenpop}->protocol(
-            'WM_DELETE_WINDOW' => sub {
-                $::lglobal{htmlgenpop}->destroy;
-                undef $::lglobal{htmlgenpop};
-            }
-        );
+        ::initialize_popup_with_deletebinding('htmlgenpop');
     }
 }
 
@@ -2587,13 +2555,7 @@ sub htmlmarkpopup {
             -width            => 16
         )->grid( -row => 1, -column => 1, -padx => 1, -pady => 2 );
 
-        ::initialize_popup_without_deletebinding('markpop');
-        $::lglobal{markpop}->protocol(
-            'WM_DELETE_WINDOW' => sub {
-                $::lglobal{markpop}->destroy;
-                undef $::lglobal{markpop};
-            }
-        );
+        ::initialize_popup_with_deletebinding('markpop');
     }
 }
 
@@ -2703,16 +2665,11 @@ sub markup {
                             $done = '<a href="' . $name . "\">";
                             $textwindow->insert( $thisblockstart, $done );
                         }
-                        $::lglobal{elinkpop}->destroy;
-                        undef $::lglobal{elinkpop};
+                        ::killpopup('elinkpop');
                     }
                 )->pack( -pady => 4 );
-                $::lglobal{elinkpop}->protocol(
-                    'WM_DELETE_WINDOW' => sub {
-                        $::lglobal{elinkpop}->destroy;
-                        undef $::lglobal{elinkpop};
-                    }
-                );
+                $::lglobal{elinkpop}
+                  ->protocol( 'WM_DELETE_WINDOW' => sub { ::killpopup('elinkpop'); } );
                 $::lglobal{elinkpop}->Icon( -image => $::icon );
                 $::lglobal{elinkpop}->transient( $::lglobal{markpop} );
                 $::lglobal{linkentry}->focus;
@@ -2831,8 +2788,7 @@ sub markup {
                 $::lglobal{linkpop}->protocol(
                     'WM_DELETE_WINDOW' => sub {
                         $::geometryhash{linkpop} = $::lglobal{linkpop}->geometry;
-                        $::lglobal{linkpop}->destroy;
-                        undef $::lglobal{linkpop};
+                        ::killpopup('linkpop');
                     }
                 );
                 $::lglobal{linkpop}->Icon( -image => $::icon );
@@ -2847,8 +2803,7 @@ sub markup {
                         $textwindow->insert( $thisblockend, $done );
                         $done = "<a href=\"" . $name . "\">";
                         $textwindow->insert( $thisblockstart, $done );
-                        $::lglobal{linkpop}->destroy;
-                        undef $::lglobal{linkpop};
+                        ::killpopup('linkpop');
                     }
                 );
                 my $tempvar   = lc( makeanchor( ::deaccentdisplay($selection) ) );
@@ -3858,8 +3813,7 @@ sub pageadjust {
                 }
                 $recalc->invoke;
                 ::setedited(1);
-                $::lglobal{pagelabelpop}->destroy;
-                undef $::lglobal{pagelabelpop};
+                ::killpopup('pagelabelpop');
             }
         )->grid( -row => 1, -column => 2, -padx => 5 );
         my $frame1 = $::lglobal{pagelabelpop}->Scrolled(

--- a/src/lib/Guiguts/HelpMenu.pm
+++ b/src/lib/Guiguts/HelpMenu.pm
@@ -53,10 +53,7 @@ EOM
         my $button_ok = $::lglobal{aboutpop}->Button(
             -activebackground => $::activecolor,
             -text             => 'OK',
-            -command          => sub {
-                $::lglobal{aboutpop}->destroy;
-                undef $::lglobal{aboutpop};
-            }
+            -command          => sub { ::killpopup('aboutpop'); }
         )->pack( -pady => 6 );
         $::lglobal{aboutpop}->resizable( 'no', 'no' );
         $::lglobal{aboutpop}->raise;
@@ -90,14 +87,12 @@ sub hotkeyshelp {
         my $button_ok = $frame->Button(
             -activebackground => $::activecolor,
             -text             => 'Close',
-            -command          => sub {
-                $::lglobal{hotkeyspop}->destroy;
-                undef $::lglobal{hotkeyspop};
-            }
+            -command          => sub { ::killpopup('hotkeyspop'); }
         )->pack;
         ::initialize_popup_with_deletebinding('hotkeyspop');
         ::drag($rotextbox);
         $rotextbox->focus;
+
         if ( -e 'hotkeys.txt' ) {
             if ( open my $ref, '<', 'hotkeys.txt' ) {
                 while (<$ref>) {
@@ -131,10 +126,7 @@ sub regexref {
         my $button_ok = $::lglobal{regexrefpop}->Button(
             -activebackground => $::activecolor,
             -text             => 'Close',
-            -command          => sub {
-                $::lglobal{regexrefpop}->destroy;
-                undef $::lglobal{regexrefpop};
-            }
+            -command          => sub { ::killpopup('regexrefpop'); }
         )->pack;
         ::initialize_popup_with_deletebinding('regexrefpop');
         ::drag($regtext);

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -872,46 +872,26 @@ sub menu_preferences_toolbar {
         [
             Radiobutton => 'Toolbar on Top',
             -variable   => \$::toolside,
-            -command    => sub {
-                $::lglobal{toptool}->destroy
-                  if $::lglobal{toptool};
-                undef $::lglobal{toptool};
-                ::toolbar_toggle();
-            },
-            -value => 'top'
+            -command    => sub { ::toolbar_toggle(); },
+            -value      => 'top'
         ],
         [
             Radiobutton => 'Toolbar on Bottom',
             -variable   => \$::toolside,
-            -command    => sub {
-                $::lglobal{toptool}->destroy
-                  if $::lglobal{toptool};
-                undef $::lglobal{toptool};
-                ::toolbar_toggle();
-            },
-            -value => 'bottom'
+            -command    => sub { ::toolbar_toggle(); },
+            -value      => 'bottom'
         ],
         [
             Radiobutton => 'Toolbar on Left',
             -variable   => \$::toolside,
-            -command    => sub {
-                $::lglobal{toptool}->destroy
-                  if $::lglobal{toptool};
-                undef $::lglobal{toptool};
-                ::toolbar_toggle();
-            },
-            -value => 'left'
+            -command    => sub { ::toolbar_toggle(); },
+            -value      => 'left'
         ],
         [
             Radiobutton => 'Toolbar on Right',
             -variable   => \$::toolside,
-            -command    => sub {
-                $::lglobal{toptool}->destroy
-                  if $::lglobal{toptool};
-                undef $::lglobal{toptool};
-                ::toolbar_toggle();
-            },
-            -value => 'right'
+            -command    => sub { ::toolbar_toggle(); },
+            -value      => 'right'
         ],
         [ 'separator', '' ],
         [

--- a/src/lib/Guiguts/MultiLingual.pm
+++ b/src/lib/Guiguts/MultiLingual.pm
@@ -225,8 +225,7 @@ sub multilangpopup {
         ::drag($multiwclistbox);
         $::lglobal{multispellpop}->protocol(
             'WM_DELETE_WINDOW' => sub {
-                $::lglobal{multispellpop}->destroy;
-                undef $::lglobal{multispellpop};
+                ::killpopup('multispellpop');
                 undef $multiwclistbox;
             }
         );

--- a/src/lib/Guiguts/PageNumbers.pm
+++ b/src/lib/Guiguts/PageNumbers.pm
@@ -38,8 +38,7 @@ sub togglepagenums {
         $textwindow->tagRemove( 'pagenum', '1.0', 'end' );
         if ( $::lglobal{pagemarkerpop} ) {
             $::geometryhash{pagemarkerpop} = $::lglobal{pagemarkerpop}->geometry;
-            $::lglobal{pagemarkerpop}->destroy;
-            undef $::lglobal{pagemarkerpop};
+            ::killpopup('pagemarkerpop');
         }
     } else {
         $::lglobal{seepagenums} = 1;
@@ -207,8 +206,7 @@ sub pnumadjust {
         $::lglobal{pagemarkerpop}->bind( $::lglobal{pagemarkerpop}, '<Delete>' => \&::pageremove );
         $::lglobal{pagemarkerpop}->protocol(
             'WM_DELETE_WINDOW' => sub {
-                $::lglobal{pagemarkerpop}->destroy;
-                undef $::lglobal{pagemarkerpop};
+                ::killpopup('pagemarkerpop');
                 ::hidepagenums();
             }
         );

--- a/src/lib/Guiguts/PageSeparators.pm
+++ b/src/lib/Guiguts/PageSeparators.pm
@@ -47,10 +47,7 @@ EOM
         my $button_ok = $::lglobal{pagesephelppop}->Button(
             -activebackground => $::activecolor,
             -text             => 'Close',
-            -command          => sub {
-                $::lglobal{pagesephelppop}->destroy;
-                undef $::lglobal{pagesephelppop};
-            }
+            -command          => sub { ::killpopup('pagesephelppop'); }
         )->pack;
         $::lglobal{pagesephelppop}->resizable( 'yes', 'yes' );
     }
@@ -592,8 +589,7 @@ sub separatorpopup {
         ::initialize_popup_without_deletebinding('pageseppop');
         $::lglobal{pageseppop}->protocol(
             'WM_DELETE_WINDOW' => sub {
-                $::lglobal{pageseppop}->destroy;
-                undef $::lglobal{pageseppop};
+                ::killpopup('pageseppop');
                 $textwindow->tagRemove( 'highlight', '1.0', 'end' );
             }
         );

--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -165,8 +165,7 @@ sub setmargins {
             -activebackground => $::activecolor,
             -text             => 'OK',
             -command          => sub {
-                $::lglobal{marginspop}->destroy;
-                undef $::lglobal{marginspop};
+                ::killpopup('marginspop');
                 if ( ( $::blockrmargin < $::blocklmargin ) || ( $::rmargin < $::lmargin ) ) {
                     $top->messageBox(
                         -icon    => 'error',
@@ -249,8 +248,7 @@ sub fontsize {
             -activebackground => $::activecolor,
             -text             => 'OK',
             -command          => sub {
-                $::lglobal{fontpop}->destroy;
-                undef $::lglobal{fontpop};
+                ::killpopup('fontpop');
                 ::savesettings();
             }
         )->grid( -row => 3, -column => 2, -pady => 5 );
@@ -310,15 +308,13 @@ sub saveinterval {
             -text    => 'OK',
             -command => sub {
                 $::autosaveinterval = 5 unless $::autosaveinterval;
-                $::lglobal{intervalpop}->destroy;
-                undef $::lglobal{intervalpop};
+                ::killpopup('intervalpop');
             },
         )->pack;
         $::lglobal{intervalpop}->protocol(
             'WM_DELETE_WINDOW' => sub {
                 $::autosaveinterval = 5 unless $::autosaveinterval;
-                $::lglobal{intervalpop}->destroy;
-                undef $::lglobal{intervalpop};
+                ::killpopup('intervalpop');
             }
         );
         $::lglobal{intervalpop}->Icon( -image => $::icon );
@@ -634,8 +630,7 @@ sub filePathsPopup {
             -activebackground => $::activecolor,
             -text             => 'OK',
             -command          => sub {
-                $::lglobal{filepathspop}->destroy;
-                undef $::lglobal{filepathspop};
+                ::killpopup('filepathspop');
                 ::savesettings();
             }
         )->pack;
@@ -674,8 +669,7 @@ sub setDPurls {
             -activebackground => $::activecolor,
             -text             => 'OK',
             -command          => sub {
-                $::lglobal{defurlspop}->destroy;
-                undef $::lglobal{defurlspop};
+                ::killpopup('defurlspop');
                 ::savesettings();
             }
         )->grid( -row => 5, -column => 0, -columnspan => 2, -pady => 5 );

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1498,8 +1498,7 @@ sub searchpopup {
             'WM_DELETE_WINDOW' => sub {
                 $::lglobal{regrepeat}->cancel;
                 undef $::lglobal{regrepeat};
-                $::lglobal{searchpop}->destroy;
-                undef $::lglobal{searchpop};
+                ::killpopup('searchpop');
                 $textwindow->tagRemove( 'highlight', '1.0', 'end' );
                 undef $::lglobal{hintpop} if $::lglobal{hintpop};
                 $::scannosearch = 0;    #no longer in a scanno search
@@ -1768,9 +1767,8 @@ sub stealthscanno {
     if ( defined $::lglobal{searchpop} ) {
         $::lglobal{regrepeat}->cancel;
         undef $::lglobal{regrepeat};
-        $::lglobal{searchpop}->destroy;
+        ::killpopup('searchpop');
     }
-    undef $::lglobal{searchpop};
     searchoptset(qw/1 x x 0 1/);    # force search to begin at start of doc, whole word
     if ( ::loadscannos() ) {
         ::savesettings();
@@ -2060,8 +2058,7 @@ sub orphanedbrackets {
         ::initialize_popup_without_deletebinding('brkpop');
         $::lglobal{brkpop}->protocol(
             'WM_DELETE_WINDOW' => sub {
-                $::lglobal{brkpop}->destroy;
-                undef $::lglobal{brkpop};
+                ::killpopup('brkpop');
                 $textwindow->tagRemove( 'highlight', '1.0', 'end' );
             }
         );
@@ -2248,8 +2245,7 @@ sub searchsize {    # Pop up a window where you can adjust the search history si
             -width   => 10,
             -command => sub {
                 ::savesettings();
-                $::lglobal{srchhistsizepop}->destroy;
-                undef $::lglobal{srchhistsizepop};
+                ::killpopup('srchhistsizepop');
             }
         )->pack;
         $::lglobal{srchhistsizepop}->resizable( 'no', 'no' );

--- a/src/lib/Guiguts/SpellCheck.pm
+++ b/src/lib/Guiguts/SpellCheck.pm
@@ -911,8 +911,7 @@ sub spellchecker {    # Set up spell check window
 sub endaspell {
     my $textwindow = $::textwindow;
     @{ $::lglobal{misspelledlist} } = ();
-    $::lglobal{spellpopup}->destroy;
-    undef $::lglobal{spellpopup};                                # completely remove spellcheck window
+    ::killpopup('spellpopup');                                   # completely remove spellcheck window
     print OUT "\cC\n" if $::lglobal{spellpid};                   # send quit signal to aspell
     aspellstop();                                                # and remove the process
     $textwindow->tagRemove( 'highlight', '1.0', 'end' );

--- a/src/lib/Guiguts/StatusBar.pm
+++ b/src/lib/Guiguts/StatusBar.pm
@@ -585,8 +585,7 @@ sub setlang {
                     update_lang_button();
                     ::readlabels();
                 }
-                $::lglobal{setlangpop}->destroy;
-                undef $::lglobal{setlangpop};
+                ::killpopup('setlangpop');
             }
         );
         $::lglobal{setlangpop}->resizable( 'no', 'no' );
@@ -660,8 +659,7 @@ sub selection {
             -text    => 'Close',
             -width   => 8,
             -command => sub {
-                $::lglobal{selectionpop}->destroy;
-                undef $::lglobal{selectionpop};
+                ::killpopup('selectionpop');
                 undef $::lglobal{selsentry};
                 undef $::lglobal{seleentry};
             },
@@ -670,8 +668,7 @@ sub selection {
         ::initialize_popup_without_deletebinding('selectionpop');
         $::lglobal{selectionpop}->protocol(
             'WM_DELETE_WINDOW' => sub {
-                $::lglobal{selectionpop}->destroy;
-                undef $::lglobal{selectionpop};
+                ::killpopup('selectionpop');
                 undef $::lglobal{selsentry};
                 undef $::lglobal{seleentry};
             }
@@ -717,11 +714,9 @@ sub gotoline {
                     $textwindow->markSet( 'insert', "$::lglobal{line_number}.0" );
                     $textwindow->see('insert');
                     update_indicators();
-                    $::lglobal{gotolinepop}->destroy;
-                    undef $::lglobal{gotolinepop};
+                    ::killpopup('gotolinepop');
                 } else {
-                    $::lglobal{gotolinepop}->destroy;
-                    undef $::lglobal{gotolinepop};
+                    ::killpopup('gotolinepop');
                 }
             }
         );
@@ -747,8 +742,7 @@ sub gotopage {
                 if ( ( defined $_[0] ) and ( $_[0] eq 'OK' ) ) {
                     unless ( $::lglobal{lastpage} ) {
                         ::soundbell();
-                        $::lglobal{gotopagpop}->destroy;
-                        undef $::lglobal{gotopagpop};
+                        ::killpopup('gotopagpop');
                         return;
                     }
                     if ( $::lglobal{pagedigits} == 3 ) {
@@ -762,8 +756,7 @@ sub gotopage {
                         && defined $::pagenumbers{ 'Pg' . $::lglobal{lastpage} } ) {
                         delete $::pagenumbers{ 'Pg' . $::lglobal{lastpage} };
                         ::soundbell();
-                        $::lglobal{gotopagpop}->destroy;
-                        undef $::lglobal{gotopagpop};
+                        ::killpopup('gotopagpop');
                         return;
                     }
                     my $index = $textwindow->index( 'Pg' . $::lglobal{lastpage} );
@@ -771,11 +764,9 @@ sub gotopage {
                     ::seeindex( 'insert -2l', 1 );
                     $textwindow->focus;
                     update_indicators();
-                    $::lglobal{gotopagpop}->destroy;
-                    undef $::lglobal{gotopagpop};
+                    ::killpopup('gotopagpop');
                 } else {
-                    $::lglobal{gotopagpop}->destroy;
-                    undef $::lglobal{gotopagpop};
+                    ::killpopup('gotopagpop');
                 }
             }
         );
@@ -809,8 +800,7 @@ sub gotolabel {
                     }
                     unless ($mark) {
                         ::soundbell();
-                        $::lglobal{gotolabpop}->destroy;
-                        undef $::lglobal{gotolabpop};
+                        ::killpopup('gotolabpop');
                         return;
                     }
                     my $index = $textwindow->index($mark);
@@ -818,11 +808,9 @@ sub gotolabel {
                     ::seeindex( 'insert -2l', 1 );
                     $textwindow->focus;
                     ::update_indicators();
-                    $::lglobal{gotolabpop}->destroy;
-                    undef $::lglobal{gotolabpop};
+                    ::killpopup('gotolabpop');
                 } else {
-                    $::lglobal{gotolabpop}->destroy;
-                    undef $::lglobal{gotolabpop};
+                    ::killpopup('gotolabpop');
                 }
             }
         );

--- a/src/lib/Guiguts/TextProcessingMenu.pm
+++ b/src/lib/Guiguts/TextProcessingMenu.pm
@@ -313,8 +313,7 @@ sub fixpopup {
             -command          => sub {
                 $::lglobal{fixpop}->UnmapWindow;
                 fixup();
-                $::lglobal{fixpop}->destroy;
-                undef $::lglobal{fixpop};
+                ::killpopup('fixpop');
             },
             -text  => 'Go!',
             -width => 14

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -630,8 +630,7 @@ sub working {
         $::lglobal{worklabel}->configure( -text => "\n\n\nWorking....\n$msg\nPlease wait.\n\n\n" );
         $::lglobal{workpop}->update;
     } elsif ( defined $::lglobal{workpop} ) {
-        $::lglobal{workpop}->destroy;
-        undef $::lglobal{workpop};
+        ::killpopup('workpop');
     } else {
         $::lglobal{workpop} = $top->Toplevel;
         $::lglobal{workpop}->transient($top);
@@ -644,8 +643,7 @@ sub working {
         $::lglobal{workpop}->resizable( 'no', 'no' );
         $::lglobal{workpop}->protocol(
             'WM_DELETE_WINDOW' => sub {
-                $::lglobal{workpop}->destroy;
-                undef $::lglobal{workpop};
+                ::killpopup('workpop');
             }
         );
         $::lglobal{workpop}->Icon( -image => $::icon );
@@ -1388,8 +1386,7 @@ sub scrolldismiss {
     my $textwindow = $::textwindow;
     return unless $::lglobal{scroller};
     $textwindow->configure( -cursor => $::lglobal{oldcursor} );
-    $::lglobal{scroller}->destroy;
-    $::lglobal{scroller} = '';
+    ::killpopup('scroller');
     $::lglobal{scroll_id}->cancel if $::lglobal{scroll_id};
     $::lglobal{scroll_id} = '';
 }
@@ -2156,8 +2153,7 @@ sub externalpopup {    # Set up the external commands menu
                 # save the settings and rebuild the menu
                 ::savesettings();
                 ::menurebuild();
-                $::lglobal{extoptpop}->destroy;
-                undef $::lglobal{extoptpop};
+                ::killpopup('extoptpop');
             },
             -text  => 'OK',
             -width => 8
@@ -2172,14 +2168,18 @@ sub xtops {    # run an external program through the external commands menu
     ::runner( ::cmdinterp( $::extops[$index]{command} ) );
 }
 
-sub toolbar_toggle {    # Set up / remove the tool bar
+#
+# Remove / set up the tool bar
+sub toolbar_toggle {
     my $textwindow = $::textwindow;
     my $top        = $::top;
-    if ( $::notoolbar && $::lglobal{toptool} ) {
-        $::lglobal{toptool}->destroy;
-        undef $::lglobal{toptool};
-        undef $::lglobal{savetool};
-    } elsif ( !$::notoolbar && !$::lglobal{toptool} ) {
+
+    # Destroy existing toolbar
+    ::killpopup('toptool');
+    undef $::lglobal{savetool};
+
+    # Create toolbar unless not wanted
+    unless ($::notoolbar) {
         $::lglobal{toptool}  = $top->ToolBar( -side => $::toolside, -close => '30' );
         $::lglobal{toolfont} = $top->Font(
             -family => 'Times',

--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -275,11 +275,9 @@ sub wordfrequency {
         ::drag( $::lglobal{wclistbox} );
         $::lglobal{wfpop}->protocol(
             'WM_DELETE_WINDOW' => sub {
-                $::lglobal{wfpop}->destroy;
-                undef $::lglobal{wfpop};
+                ::killpopup('wfpop');
                 undef $::lglobal{wclistbox};
-                $::lglobal{markuppop}->destroy if $::lglobal{markuppop};
-                undef $::lglobal{markuppop};
+                ::killpopup('markuppop');
             }
         );
         ::BindMouseWheel( $::lglobal{wclistbox} );
@@ -827,12 +825,9 @@ sub ital_adjust {
     )->grid( -row => 1, -column => 1, -padx => 2, -pady => 4 );
     $f1->Button(
         -activebackground => $::activecolor,
-        -command          => sub {
-            $::lglobal{markuppop}->destroy;
-            undef $::lglobal{markuppop};
-        },
-        -text  => 'OK',
-        -width => 8
+        -command          => sub { ::killpopup('markuppop'); },
+        -text             => 'OK',
+        -width            => 8
     )->grid( -row => 2, -column => 1, -padx => 2, -pady => 4 );
 }
 
@@ -1074,8 +1069,7 @@ sub harmonicspop {
         ::drag( $::lglobal{hlistbox} );
         $::lglobal{hpopup}->protocol(
             'WM_DELETE_WINDOW' => sub {
-                $::lglobal{hpopup}->destroy;
-                undef $::lglobal{hpopup};
+                ::killpopup('hpopup');
                 undef $::lglobal{hlistbox};
             }
         );


### PR DESCRIPTION
Many occurrences, including slight variations, of
```
destroy popup if it is defined
undefine it
```
changed to `::killpopup('popupname');`

Fixes #297