### PR TITLE
Improve stealth scannos

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -259,7 +259,9 @@ sub searchtext {
             }
         }
         $::lglobal{selectionsearch} = 0;
-        unless ( $::lglobal{regaa} or $silentmode ) {
+
+        # Warn user string was not found, unless auto-advancing scannos, or silent mode
+        unless ( ( $::lglobal{doscannos} and $::lglobal{regaa} ) or $silentmode ) {
             ::soundbell();
             $::lglobal{searchbutton}->flash if defined $::lglobal{searchpop};
             $::lglobal{searchbutton}->flash if defined $::lglobal{searchpop};

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -923,7 +923,7 @@ sub initialize {
     $::lglobal{pageanch}           = 1;                           # HTML convert - add page anchors
     $::lglobal{pagecmt}            = 0;                           # HTML convert - page markers as comments
     $::lglobal{poetrynumbers}      = 0;                           # HTML convert - find & format poetry line numbers
-    $::lglobal{regaa}              = 0;
+    $::lglobal{regaa}              = 1;                           # Auto-advance stealth scannos
     $::lglobal{seepagenums}        = 0;
     $::lglobal{selectionsearch}    = 0;
     $::lglobal{selmaxlength}       = 1;


### PR DESCRIPTION
Two separate commits

Fix #317 - stop scanno auto-advance from affecting `string not found` alerts

Fix #211 - make auto-advance on by default

 