### PR TITLE
Remove use of yview for mouse wheel and forcing scrollbars

### DIFF
--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -307,7 +307,6 @@ sub utfcharsearchpopup {
             -sticky     => 'wne',
         )->pack( -expand => 'y', -fill => 'both', -anchor => 'nw' );
         ::drag($pane);
-        ::BindMouseWheel($pane);
         my $fontlist = $cframe->BrowseEntry(
             -label     => 'Font',
             -browsecmd => sub {

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -112,9 +112,7 @@ sub errorcheckpop_up {
             $textwindow->markUnset($_) for values %::errors;
         }
     );
-
     ::drag( $::lglobal{errorchecklistbox} );
-    ::BindMouseWheel( $::lglobal{errorchecklistbox} );
 
     # button 1 views the error
     $::lglobal{errorchecklistbox}->eventAdd( '<<view>>' => '<ButtonRelease-1>', '<Return>' );
@@ -375,9 +373,7 @@ sub errorcheckpop_up {
     } else {
         $::lglobal{errorchecklistbox}->insert( 'end', @errorchecklines );
     }
-    $::lglobal{errorchecklistbox}->yview( 'scroll', 1, 'units' );
     $::lglobal{errorchecklistbox}->update;
-    $::lglobal{errorchecklistbox}->yview( 'scroll', -1, 'units' );
     $::lglobal{errorchecklistbox}->focus;
     $::lglobal{errorcheckpop}->raise;
 }

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -618,9 +618,6 @@ sub oppopupdate {
         $::lglobal{oplistbox}->insert( 'end', "$value $::operationshash{$value}" );
     }
     $::lglobal{oplistbox}->update;
-    $::lglobal{oplistbox}->yview( 'scroll', 1, 'units' );
-    $::lglobal{oplistbox}->update;
-    $::lglobal{oplistbox}->yview( 'scroll', -1, 'units' );
 }
 
 sub operationadd {

--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -654,7 +654,6 @@ sub fnview {
         if ($allcheckspassed) {
             ::operationadd('Footnote check passed');
         }
-        ::BindMouseWheel($ftext);
         $ftext->see("1.0 + $fnindex l") if $fnindex;
     }
 }

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -2789,7 +2789,6 @@ sub markup {
                 -pady   => 2
             );
             ::drag($linklistbox);
-            ::BindMouseWheel($linklistbox);
             $linklistbox->eventAdd( '<<trans>>' => '<Double-Button-1>' );
             $linklistbox->bind(
                 '<<trans>>',
@@ -3904,9 +3903,7 @@ sub pageadjust {
                 $pagetrack{$num}[5]->insert( 'end', $::pagenumbers{$page}{base} );
             }
         }
-        $frame1->yview( 'scroll', => 1, 'units' );
         $top->update;
-        $frame1->yview( 'scroll', -1, 'units' );
     }
 }
 

--- a/src/lib/Guiguts/MultiLingual.pm
+++ b/src/lib/Guiguts/MultiLingual.pm
@@ -255,9 +255,6 @@ sub showAllWords {
     $multiwclistbox->delete('0');
     $multiwclistbox->insert( '0', $savedHeader );
     $multiwclistbox->update;
-    $multiwclistbox->yview( 'scroll', 1, 'units' );
-    $multiwclistbox->update;
-    $multiwclistbox->yview( 'scroll', -1, 'units' );
 }
 
 sub showUnspeltWords {
@@ -295,9 +292,6 @@ sub showUnspeltWords {
     $multiwclistbox->delete('0');
     $multiwclistbox->insert( '0', $savedHeader );
     $multiwclistbox->update;
-    $multiwclistbox->yview( 'scroll', 1, 'units' );
-    $multiwclistbox->update;
-    $multiwclistbox->yview( 'scroll', -1, 'units' );
 }
 
 sub showspeltforeignwords {
@@ -350,9 +344,6 @@ sub showspeltforeignwords {
     $multiwclistbox->delete('0');
     $multiwclistbox->insert( '0', $savedHeader );
     $multiwclistbox->update;
-    $multiwclistbox->yview( 'scroll', 1, 'units' );
-    $multiwclistbox->update;
-    $multiwclistbox->yview( 'scroll', -1, 'units' );
 }
 
 # update global lists
@@ -390,9 +381,6 @@ sub showmisspelledlist {
     $multiwclistbox->delete('0');
     $multiwclistbox->insert( '0', $savedHeader );
     $multiwclistbox->update;
-    $multiwclistbox->yview( 'scroll', 1, 'units' );
-    $multiwclistbox->update;
-    $multiwclistbox->yview( 'scroll', -1, 'units' );
 }
 
 #show project dictionary
@@ -413,9 +401,6 @@ sub showprojectdict {
     $multiwclistbox->delete('0');
     $multiwclistbox->insert( '0', $savedHeader );
     $multiwclistbox->update;
-    $multiwclistbox->yview( 'scroll', 1, 'units' );
-    $multiwclistbox->update;
-    $multiwclistbox->yview( 'scroll', -1, 'units' );
 }
 
 # outputs various arrays to files
@@ -574,7 +559,7 @@ sub setmultiplelanguages {
     my $dictlabel = $spellop->add( 'Label', -text => 'Dictionary files' )->pack;
     my $dictlist  = $spellop->add(
         'ScrlListbox',
-        -scrollbars => 'oe',
+        -scrollbars => 'e',
         -selectmode => 'browse',
         -background => $::bkgcolor,
         -height     => 10,

--- a/src/lib/Guiguts/SpellCheck.pm
+++ b/src/lib/Guiguts/SpellCheck.pm
@@ -352,9 +352,7 @@ sub spellshow_guesses {
     $::lglobal{replacementlist}->activate(0);
     $::lglobal{spreplaceentry}->delete( '0', 'end' );
     $::lglobal{spreplaceentry}->insert( 'end', $::lglobal{guesslist}[0] );
-    $::lglobal{replacementlist}->yview( 'scroll', 1, 'units' );
     $::lglobal{replacementlist}->update;
-    $::lglobal{replacementlist}->yview( 'scroll', -1, 'units' );
     $::lglobal{suggestionlabel}->configure( -text => @{ $::lglobal{guesslist} } . ' Suggestions:' );
 }
 
@@ -548,7 +546,7 @@ sub spellchecker {    # Set up spell check window
           ->pack( -side => 'top', -anchor => 'n', -pady => 5 );
         $::lglobal{replacementlist} = $spf1->ScrlListbox(
             -background => $::bkgcolor,
-            -scrollbars => 'osoe',
+            -scrollbars => 'se',
             -font       => $::lglobal{font},
             -width      => 40,
             -height     => 4,
@@ -901,7 +899,6 @@ sub spellchecker {    # Set up spell check window
         $::lglobal{replacementlist}->bind( '<Double-Button-1>', \&spellmisspelled_replace );
         $::lglobal{replacementlist}
           ->bind( '<Triple-Button-1>', sub { spellmisspelled_replace(); spellreplace() } );
-        ::BindMouseWheel( $::lglobal{replacementlist} );
         spelloptions()
           unless $::globalspellpath && -e $::globalspellpath;    # Check to see if we know where Aspell is
         spellcheckfirst();                                       # Start the spellcheck
@@ -986,7 +983,7 @@ sub spelloptions {
       $spellop->add( 'Label', -text => 'Dictionary files (double-click to select):' )->pack;
     $dictlist = $spellop->add(
         'ScrlListbox',
-        -scrollbars => 'oe',
+        -scrollbars => 'e',
         -selectmode => 'browse',
         -background => $::bkgcolor,
         -height     => 10,

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -9,7 +9,7 @@ BEGIN {
     @EXPORT = qw(&openpng &get_image_file &arabic &roman &popscroll
       &cmdinterp &nofileloadedwarning &win32_cmdline &win32_start
       &win32_is_exe &win32_create_process &dos_path &runner &debug_dump &run &launchurl &escape_regexmetacharacters
-      &deaccentsort &deaccentdisplay &readlabels &BindMouseWheel &working &initialize &fontinit &initialize_popup_with_deletebinding
+      &deaccentsort &deaccentdisplay &readlabels &working &initialize &fontinit &initialize_popup_with_deletebinding
       &initialize_popup_without_deletebinding &titlecase &os_normal &escape_problems &natural_sort_alpha
       &natural_sort_length &natural_sort_freq &drag &cut &paste &textcopy &colcut &colcopy &colpaste &showversion
       &checkforupdates &checkforupdatesmonthly &gotobookmark &setbookmark &seeindex &ebookmaker
@@ -593,33 +593,6 @@ sub readlabels {
         my $index = index( $::convertcharssinglesearch, $chararray[$i] );
         substr $::convertcharssinglesearch,  $index, 1, '';
         substr $::convertcharssinglereplace, $index, 1, '';
-    }
-}
-
-sub BindMouseWheel {
-    my ($w) = @_;
-    if ($::OS_WIN) {
-        $w->bind(
-            '<MouseWheel>' => [
-                sub {
-                    $_[0]->yview( 'scroll', -( $_[1] / 120 ) * 3, 'units' );
-                },
-                ::Ev('D')
-            ]
-        );
-    } else {
-        $w->bind(
-            '<4>' => sub {
-                $_[0]->yview( 'scroll', -3, 'units' )
-                  unless $Tk::strictMotif;
-            }
-        );
-        $w->bind(
-            '<5>' => sub {
-                $_[0]->yview( 'scroll', +3, 'units' )
-                  unless $Tk::strictMotif;
-            }
-        );
     }
 }
 

--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -280,7 +280,6 @@ sub wordfrequency {
                 ::killpopup('markuppop');
             }
         );
-        ::BindMouseWheel( $::lglobal{wclistbox} );
         $::lglobal{wclistbox}->eventAdd( '<<search>>' => '<ButtonRelease-3>' );
         $::lglobal{wclistbox}->bind(
             '<<search>>',
@@ -571,9 +570,7 @@ sub alphanumcheck {
     }
     $::lglobal{wfsaveheader} = "$wordw mixed alphanumeric words.";
     sortanddisplaywords( \%display );
-    $::lglobal{wclistbox}->yview( 'scroll', 1, 'units' );
     $::lglobal{wclistbox}->update;
-    $::lglobal{wclistbox}->yview( 'scroll', -1, 'units' );
     @::wfsearchopt = qw/0 x x 0/;
     $top->Unbusy;
 }
@@ -1074,7 +1071,6 @@ sub harmonicspop {
                 undef $::lglobal{hlistbox};
             }
         );
-        ::BindMouseWheel( $::lglobal{hlistbox} );
         $::lglobal{hlistbox}->eventAdd( '<<search>>' => '<ButtonRelease-3>' );
         $::lglobal{hlistbox}->bind(
             '<<search>>',
@@ -1290,9 +1286,6 @@ sub sortanddisplaywords {
     $::lglobal{wclistbox}->delete('0');
     $::lglobal{wclistbox}->insert( '0', $::lglobal{wfsaveheader} );
     $::lglobal{wclistbox}->update;
-    $::lglobal{wclistbox}->yview( 'scroll', 1, 'units' );
-    $::lglobal{wclistbox}->update;
-    $::lglobal{wclistbox}->yview( 'scroll', -1, 'units' );
 }
 
 sub nofileloaded {


### PR DESCRIPTION
It appears as though BindMouseWheel is not necessary for scrolled widgets to
scroll using the mouse wheel. With or without it, some do and some don't, probably
depending on focus and type of widget being scrolled.

Also, yview was used to scroll down and up one line on several widgets when they
get created, possibly to force optional scrollbars to become active. Without it, as
long as scrollbars are not marked as optional, their behaviour seems identical.

Please check on non-Windows platforms if possible.
Also, does this fix #77 - failed to autoload yview?