### PR TITLE
Scanno dialog fixes

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -261,7 +261,7 @@ sub searchtext {
         $::lglobal{selectionsearch} = 0;
 
         # Warn user string was not found, unless auto-advancing scannos, or silent mode
-        unless ( ( $::lglobal{doscannos} and $::lglobal{regaa} ) or $silentmode ) {
+        unless ( ( $::scannosearch and $::lglobal{regaa} ) or $silentmode ) {
             ::soundbell();
             $::lglobal{searchbutton}->flash if defined $::lglobal{searchpop};
             $::lglobal{searchbutton}->flash if defined $::lglobal{searchpop};

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -569,8 +569,10 @@ sub getnextscanno {
     unless ( searchtext() ) {
         if ( $::lglobal{regaa} ) {
             while (1) {
-                last
-                  if ( $::lglobal{scannosindex}++ >= $#{ $::lglobal{scannosarray} } );
+                if ( $::lglobal{scannosindex}++ >= $#{ $::lglobal{scannosarray} } ) {
+                    $::lglobal{scannosindex} = $#{ $::lglobal{scannosarray} };
+                    last;
+                }
                 ::findascanno();
                 last if searchtext();
             }
@@ -672,7 +674,7 @@ sub findascanno {
     ::soundbell()                   unless ( $word || $::lglobal{regaa} );
     $::lglobal{searchbutton}->flash unless ( $word || $::lglobal{regaa} );
     $::lglobal{regtracker}->configure(
-        -text => ( $::lglobal{scannosindex} + 1 ) . '/' . scalar( @{ $::lglobal{scannosarray} } ) );
+        -text => ( $::lglobal{scannosindex} + 1 ) . '/' . ( $#{ $::lglobal{scannosarray} } + 1 ) );
     $::lglobal{hintmessage}->delete( '1.0', 'end' )
       if ( defined( $::lglobal{hintpop} ) );
     return 0 unless $word;
@@ -1399,8 +1401,7 @@ sub searchpopup {
                 -activebackground => $::activecolor,
                 -command          => sub {
                     $::lglobal{scannosindex}++
-                      unless (
-                        $::lglobal{scannosindex} >= scalar( @{ $::lglobal{scannosarray} } ) );
+                      unless $::lglobal{scannosindex} >= $#{ $::lglobal{scannosarray} };
                     getnextscanno();
                 },
                 -text  => 'Next Stealtho',


### PR DESCRIPTION
Two commits:

1. Stop Search button flashing during scanno auto-advance

#317 used the wrong variable to see if scanno checks were being done. Although
this fixed the intended issue, it meant warning was given even during scannos.

2. Stop current scanno number exceeding the max number of scannos

It was possible to make the S&R box show scanno 46 out of 45.
The automatic advance code and the Next Stealtho button both failed to restrict the
current scanno index to the maximum index correctly. Now fixed.