### PR TITLE
Improve Page Separator Fixup undo/redo

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -201,9 +201,7 @@ our %geometryhash;    #Geometry of some windows in one hash.
 $geometryhash{wfpop} = q{};
 our %positionhash;    #Position of other windows in one hash.
 our %manualhash;      # subpage of manual for each dialog
-our @bookmarks = ( 0, 0, 0, 0, 0, 0 );
-our @joinundolist;
-our @joinredolist;
+our @bookmarks  = ( 0, 0, 0, 0, 0, 0 );
 our @multidicts = ();
 our @mygcview;
 our %operationshash;    # New format {operation, time}


### PR DESCRIPTION
Page Separator Fixup had its own undo and redo lists, storing numbers of operations
to be undone, possibly because of the previously recursive nature of the code. It was
not reliable and did not always return the text to its previous state.

Special undo/redo lists have been removed, and the generic undo/redo method
used, including glob functionality around single user operations. Hence it is possible
to undo a single manual join or many auto-joins with a single click.

Fixes #320 