### PR TITLE
Check regex validity more thoroughly to avoid warnings

### DIFF
--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -106,7 +106,7 @@ sub insertit {
     my $isatext = 0;
     my $spot;
 
-    # Tk::Text matches searchentry and replaceentries
+    # Tk::Text/Tk::Entry match various text entry boxes
     $isatext = $::lglobal{hasfocus}->isa('Tk::Text') || $::lglobal{hasfocus} == $::textwindow;
     if ($isatext) {
         $spot = $::lglobal{hasfocus}->index('insert');

--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -119,7 +119,7 @@ sub keybindings {
         sub {
             if ( $::lglobal{searchpop} ) {
                 ::update_sr_histories();
-                my $searchterm = $::lglobal{searchentry}->get( '1.0', '1.end' );
+                my $searchterm = $::lglobal{searchentry}->get;
                 ::searchtext($searchterm);
             } else {
                 ::searchpopup();
@@ -132,7 +132,7 @@ sub keybindings {
         sub {
             if ( $::lglobal{searchpop} ) {
                 ::update_sr_histories();
-                my $searchterm = $::lglobal{searchentry}->get( '1.0', '1.end' );
+                my $searchterm = $::lglobal{searchentry}->get;
                 $::lglobal{searchop2}->toggle;
                 ::searchtext($searchterm);
                 $::lglobal{searchop2}->toggle;
@@ -147,7 +147,7 @@ sub keybindings {
         sub {
             if ( $::lglobal{searchpop} ) {
                 ::update_sr_histories();
-                my $searchterm = $::lglobal{searchentry}->get( '1.0', '1.end' );
+                my $searchterm = $::lglobal{searchentry}->get;
                 ::countmatches($searchterm);
             }
         }

--- a/src/lib/Guiguts/TextProcessingMenu.pm
+++ b/src/lib/Guiguts/TextProcessingMenu.pm
@@ -456,7 +456,7 @@ sub fixup {
 sub text_uppercase_smallcaps {
     ::searchpopup();
     ::searchoptset(qw/0 x x 1/);
-    $::lglobal{searchentry}->delete( '1.0', 'end' );
+    $::lglobal{searchentry}->delete( 0, 'end' );
     $::lglobal{searchentry}->insert( 'end', "<sc>(\\n?[^<]+)</sc>" );
     $::lglobal{replaceentry}->delete( '1.0', 'end' );
     $::lglobal{replaceentry}->insert( 'end', "\\U\$1\\E" );
@@ -477,7 +477,7 @@ sub txt_auto_uppercase_smallcaps {
 sub text_remove_smallcaps_markup {
     ::searchpopup();
     ::searchoptset(qw/0 x x 1/);
-    $::lglobal{searchentry}->delete( '1.0', 'end' );
+    $::lglobal{searchentry}->delete( 0, 'end' );
     $::lglobal{searchentry}->insert( 'end', "<sc>(\\n?[^<]+)</sc>" );
     $::lglobal{replaceentry}->delete( '1.0', 'end' );
     $::lglobal{replaceentry}->insert( 'end', "\$1" );
@@ -486,7 +486,7 @@ sub text_remove_smallcaps_markup {
 sub txt_manual_sc_conversion {
     ::searchpopup();
     ::searchoptset(qw/0 x x 1/);
-    $::lglobal{searchentry}->delete( '1.0', 'end' );
+    $::lglobal{searchentry}->delete( 0, 'end' );
     $::lglobal{replaceentry}->delete( '1.0', 'end' );
     $::lglobal{replaceentry1}->delete( '1.0', 'end' );
     $::lglobal{replaceentry2}->delete( '1.0', 'end' );

--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -317,7 +317,7 @@ sub wordfrequency {
                     $sword =~ s/([^\w\s\\])/\\$1/g;
                     ::searchoptset(qw/0 x x 1/);
                 }
-                $::lglobal{searchentry}->delete( '1.0', 'end' );
+                $::lglobal{searchentry}->delete( 0, 'end' );
                 $::lglobal{searchentry}->insert( 'end', $sword );
                 ::updatesearchlabels();
                 $::lglobal{searchentry}->after( $::lglobal{delay} );
@@ -1092,7 +1092,7 @@ sub harmonicspop {
                 ::searchpopup();
                 $sword =~ s/\d+\s+([\w'-]*)/$1/;
                 $sword =~ s/\s+\*\*\*\*$//;
-                $::lglobal{searchentry}->delete( '1.0', 'end' );
+                $::lglobal{searchentry}->delete( 0, 'end' );
                 $::lglobal{searchentry}->insert( 'end', $sword );
                 ::updatesearchlabels();
                 $::lglobal{searchentry}->after( $::lglobal{delay} );


### PR DESCRIPTION
Although a check on regex validity already existed, it only detected compile errors,
not Perl warnings.

In order to trap these it was necessary to override the warning handler. However,
these are only called once for a specific error on a specific regex. It was therefore
necessary to replace the timer checking the regex every 0.5 seconds with a validate
routine which is better anyway. One example of why this is needed is if the dialog
was popped with the same bad regex again - no warning would be raised and the
regex would not be flagged as bad to the user.

This necessitated changing the Text field to an Entry field (which was noted as a
Todo anyway) & also adjust associated method calls.

Fixes #315