### PR TITLE
Do not flash status bar label in addition to S&R dialog search button

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -262,7 +262,7 @@ sub searchtext {
 
         # Warn user string was not found, unless auto-advancing scannos, or silent mode
         unless ( ( $::scannosearch and $::lglobal{regaa} ) or $silentmode ) {
-            ::soundbell();
+            ::soundbell('noflash');
             $::lglobal{searchbutton}->flash if defined $::lglobal{searchpop};
             $::lglobal{searchbutton}->flash if defined $::lglobal{searchpop};
 
@@ -701,7 +701,7 @@ sub findascanno {
     $word = $::lglobal{scannosarray}[ $::lglobal{scannosindex} ];
     $::lglobal{searchentry}->delete( 0, 'end' );
     $::lglobal{replaceentry}->delete( 0, 'end' );
-    ::soundbell()                   unless ( $word || $::lglobal{regaa} );
+    ::soundbell('noflash')          unless ( $word || $::lglobal{regaa} );
     $::lglobal{searchbutton}->flash unless ( $word || $::lglobal{regaa} );
     $::lglobal{regtracker}->configure(
         -text => ( $::lglobal{scannosindex} + 1 ) . '/' . ( $#{ $::lglobal{scannosarray} } + 1 ) );

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2499,10 +2499,12 @@ sub restorelinenumbers {
 }    # end of variable-enclosing block
 
 # Sound bell unless global nobell flag is set
-# Also flash first label on status bar
+# Also flash first label on status bar unless noflash argument is given
 sub soundbell {
+    my $noflash = shift;
     $::textwindow->bell unless $::nobell;
-    return              unless $::lglobal{current_line_label};
+    return if $noflash;
+    return unless $::lglobal{current_line_label};
     for ( 1 .. 5 ) {
         $::lglobal{current_line_label}->after( $::lglobal{delay} );
         $::lglobal{current_line_label}->configure( -background => $::activecolor );


### PR DESCRIPTION
If bell is turned off, the first label in the status bar is flashed in place of sounding the
bell. In the S&R dialog, the Search button flashes if the search string is not found.
It is not necessary and takes too long to flash both of these.

Suppress the status bar flash in the specific S&R dialog case with an optional arg to
the soundbell routine.

Fixes #323