### PR TITLE
Word frequency utf8 and sorting improvements

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1542,29 +1542,39 @@ sub drag {
     );
 }
 
-## Ultra fast natural sort - wants an array
+#
+# Sorts an array of strings, handling case and accents intelligently
+# Sorting is case-insensitive and ignores accents, except for "identical" words
+# which are sorted according to normal sort order, e.g. Ab, ab, ABc, Abc, AxY, Axy, etc.
 sub natural_sort_alpha {
-    my $i;
-    s/(\d+(,\d+)*)/pack 'aNa*', 0, length $1, $1/eg, $_ .= ' ' . $i++
-      for ( my @x = map { lc deaccentsort $_} @_ );
-    @_[ map { (split)[-1] } sort @x ];
+    sort { lc( ::deaccentsort($a) ) cmp lc( ::deaccentsort($b) ) or $a cmp $b; } @_;
 }
 
-## Fast length sort with secondary natural sort - wants an array
+#
+# Sorts an array of strings by length then string, handling case and accents intelligently
+# Sorting is first by length, then string sorting is case-insensitive and ignores accents,
+# except for "identical" words which are sorted according to normal sort order.
+# Also note trailing asterisks (used to flag suspects) are stripped from length calculation.
+# e.g. Y, y, Z, z, Ab ****, ab ****, ABc, Abc, AxY, Axy, etc.
 sub natural_sort_length {
-    $_->[2] =~ s/(\d+(,\d+)*)/pack 'aNa*', 0, length $1, $1/eg
-      for ( my @x = map { [ length noast($_), $_, lc deaccentsort $_ ] } @_ );
-    map { $_->[1] } sort { $b->[0] <=> $a->[0] or $a->[2] cmp $b->[2] } @x;
+    sort {
+             length( noast($a) ) <=> length( noast($b) )
+          or lc( ::deaccentsort($a) ) cmp lc( ::deaccentsort($b) )
+          or $a cmp $b;
+    } @_;
 }
 
-## Fast freqency sort with secondary natural sort - wants a hash reference
+#
+# Given a ref to a hash containing a number (e.g. word frequency), sorts the keys,
+# first by number, then string sorting is case-insensitive and ignores accents,
+# except for "identical" words which are sorted according to normal sort order,
+# e.g. 1 ABc, 1 Abc, 1 AxY, 1 Axy, 2 Ab, 2 ab,  etc.
 sub natural_sort_freq {
-    $_->[2] =~ s/(\d+(,\d+)*)/pack 'aNa*', 0, length $1, $1/eg
-      for (
-        my @x =
-        map { [ $_[0]->{$_}, $_, lc deaccentsort $_ ] } keys %{ $_[0] }
-      );
-    map { $_->[1] } sort { $b->[0] <=> $a->[0] or $a->[2] cmp $b->[2] } @x;
+    sort {
+             $_[0]->{$a} <=> $_[0]->{$b}
+          or lc( ::deaccentsort($a) ) cmp lc( ::deaccentsort($b) )
+          or $a cmp $b;
+    } keys %{ $_[0] };
 }
 
 ## No Asterisks

--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -1153,8 +1153,7 @@ sub harmonicspop {
         $::lglobal{hlistbox}->delete( '0', 'end' );
         $::lglobal{hlistbox}->insert( 'end', "$wc 1st order harmonics for $active." );
     }
-    foreach my $word ( sort { ::deaccentsort( lc $a ) cmp ::deaccentsort( lc $b ) }
-        ( keys %{ $::lglobal{harmonic} } ) ) {
+    foreach my $word ( ::natural_sort_alpha( keys %{ $::lglobal{harmonic} } ) ) {
         $line = sprintf( "%-8d %s", $::lglobal{seenwords}->{$word}, $word );    # Print to the file
         $::lglobal{hlistbox}->insert( 'end', $line );
     }
@@ -1255,8 +1254,6 @@ sub sortanddisplaywords {
                     }
                 ) unless length($firstletter) > 1;
             }
-
-            #$::lglobal{regexpentry}->Tk::bind( '<Key-'.$firstletter.'>' => '' );
         }
     } elsif ( $::alpha_sort eq 'l' ) {    # Sorted by word length
         for ( ::natural_sort_length( keys %$href ) ) {

--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -305,7 +305,7 @@ sub wordfrequency {
             }
         );
         $::lglobal{wclistbox}->eventAdd( '<<find>>' => '<Double-Button-1>', '<Return>' );
-        $::lglobal{wclistbox}->bind(    # FIXME: This needs to go in GC code.
+        $::lglobal{wclistbox}->bind(
             '<<find>>',
             sub {
                 my ($sword) = $::lglobal{wclistbox}->get( $::lglobal{wclistbox}->curselection );
@@ -401,10 +401,11 @@ sub wordfrequency {
                     -initialfile => 'wordfreq.txt'
                 );
 
-                #FIXME not UTF-8 compatible
                 if ( defined($name) and length($name) ) {
                     open( my $save, ">", "$name" );
-                    print $save join "\n", $::lglobal{wclistbox}->get( '0', 'end' );
+                    my $list = join "\n", $::lglobal{wclistbox}->get( '0', 'end' );
+                    utf8::encode($list) if ::currentfileisunicode();
+                    print $save $list;
                 }
             }
         );
@@ -417,15 +418,16 @@ sub wordfrequency {
                     -initialfile => 'wordlist.txt'
                 );
 
-                #FIXME not UTF-8 compatible
                 if ( defined($name) and length($name) ) {
-                    my $count = $::lglobal{wclistbox}->index('end');
+                    my $unicode = ::currentfileisunicode();
+                    my $count   = $::lglobal{wclistbox}->index('end');
                     open( my $save, ">", "$name" );
                     for ( 1 .. $count ) {
                         my $word = $::lglobal{wclistbox}->get($_);
                         if ( ( defined $word ) && ( length $word ) ) {
                             $word =~ s/^\d+\s+//;
                             $word =~ s/\s+\*{4}\s*$//;
+                            utf8::encode($word) if $unicode;
                             print $save $word, "\n";
                         }
                     }


### PR DESCRIPTION
Two commits:

1. Make Save and Export Word Frequency list utf8-safe

Ctrl-s saves, and Ctrl-x exports, the word frequency list, but without utf8-encoding.
This led to `wide character in print` errors.

Now encodes each line before writing.

Fixes #333 

2. Improve alphabetical sorting for Word Frequency lists

Sorting was done using words converted to lower case and de-accented. This meant
that words which were identical apart from case/accents would appear in a random
order in the Word Frequency lists.

Now the sorts do the same sort as before, but if the keys are identical when
compared lowercase/de-accented, then they are compared with true case and
accents. So `The` will always precede `the` and `thé`, etc.

This will also aid regression testing in case of future changes to Word Frequency
code since the order of the output is well-defined.

Fixes #334