### PR TITLE
Tidy up after MR #328

### DIFF
--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -281,6 +281,25 @@ sub keybindings {
     keybind( '<Control-KeyPress-3>',           sub { ::gotobookmark('3'); } );
     keybind( '<Control-KeyPress-4>',           sub { ::gotobookmark('4'); } );
     keybind( '<Control-KeyPress-5>',           sub { ::gotobookmark('5'); } );
+
+    # Necessary to create a dummy Entry widget so Entry class bindings get set up or
+    # the binding below will be overwritten when the first Entry gets created later
+    my $de = $top->Entry();
+    $de->destroy();
+
+    # Override Paste binding, so that Entry widgets delete any selected text
+    # in the field, just like happens in the main textwindow
+    $textwindow->MainWindow->bind(
+        'Tk::Entry',
+        '<<Paste>>' => sub {    # Taken from Tk::clipboardPaste (where delete is commented out)
+            my $w = shift;
+            $w->deleteSelected;
+
+            # Basic eval exception handling to avoid error if nothing in clipboard
+            eval { $w->insert( "insert", $::textwindow->clipboardGet ); };
+            $w->SeeInsert if $w->can('SeeInsert');
+        }
+    );
 }
 
 # Bind a key-combination to a sub allowing for capslock on/off.

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1636,7 +1636,7 @@ sub searchpopup {
     if ( length $searchterm ) {
         $::lglobal{searchentry}->delete( 0, 'end' );
         $::lglobal{searchentry}->insert( 'end', $searchterm );
-        $::lglobal{searchentry}->tagAdd( 'sel', 0, 'end' );
+        $::lglobal{searchentry}->selectionRange( 0, 'end' );
         update_sr_histories();
         searchtext('');
     }

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1614,7 +1614,12 @@ sub paste {
             my $start = pop @ranges;
             $textwindow->delete( $start, $end );
         }
-        my $text    = $textwindow->clipboardGet;
+
+        # Basic eval exception handling to avoid error if nothing in clipboard
+        my $text;
+        eval { $text = $textwindow->clipboardGet; };
+        $text = '' unless $text;
+
         my $lineend = $textwindow->get( 'insert', 'insert lineend' );
         my $length  = length $text;
         $length = length $lineend if ( length $lineend < length $text );


### PR DESCRIPTION
Most text entry fields in GG are Entry widgets, but the ones in the Search & Replace
dialog were historically Text widgets. #328 changed these to Entry widgets.

However, as noted in #97, paste behaviour is inconsistent between Text and Entry
widgets, specifically if the text in the field is selected, then the paste overwrites
the selection only in Text widgets, not Entry widgets.

This commit implements the same paste behaviour for Entry widgets. This is
necessary for the S&R dialog at least, but is actually useful in the many other
Entry widgets. It is standard Windows behaviour and pretty harmless on other
platforms.

Testing also revealed a call to non-existent method. Entry::tagAdd to set a selection
is replaced by Entry::selectionRange.

Finally, it is necessary to catch errors from clipboardGet when pasting. This is done
using eval {block}. This stops error output if pasting when there is either nothing in
the clipboard, or it is not a string. In addition to using eval in the new paste
routine, it has also been added to the main text window paste code which would
otherwise give an error when in Overstrike mode.

Fixes #97
Fixes #338