### PR TITLE
Improve readability of HTML when closing blockquotes

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1529,8 +1529,11 @@ sub html_wrapup {
     }
     $textwindow->ntinsert( 'end', "\n<\/body>\n<\/html>" );
 
-    ::named( '><p',  ">\n\n<p" );    # improve readability of code
-    ::named( '><hr', ">\n\n<hr" );
+    # improve readability of code
+    ::named( '><p',               ">\n\n<p" );
+    ::named( '><hr',              ">\n\n<hr" );
+    ::named( '</p></div>',        "</p>\n</div>" );
+    ::named( '</p></blockquote>', "</p>\n</blockquote>" );
 
     # Output poetry indent CSS.
     # Find end of CSS, then search back for end of last class definition

--- a/src/tests/testhtml1baseline.html
+++ b/src/tests/testhtml1baseline.html
@@ -26,7 +26,8 @@ Dear John,<br />
 
 <p>So happy to write this letter to you. So happy to write this letter to you.
 So happy to write this letter to you. So happy to write this letter to you.
-So happy to write this letter to you. So happy to write this letter to you.</p></div>
+So happy to write this letter to you. So happy to write this letter to you.</p>
+</div>
 
 
 </body>

--- a/src/tests/testhtml2baseline.html
+++ b/src/tests/testhtml2baseline.html
@@ -399,7 +399,8 @@ Method, Merchants Accompts, and the Mathematicks.</p>
 <p>He hopes that more thinking People will in no wise be discouraged from
 sending their children thither, on the account of the reports newly reviv'd,
 because these dancing Phaenomena's were never seen nor heard of in School
-Hours.</p></div></div>
+Hours.</p>
+</div></div>
 <p><span class="pagenum"><a id="Page_7"></a>[Pg 7]</span></p>
 <p>The advertisement was further amplified in its second appearance,
 in the issue of March 21-22, 1719:</p>
@@ -414,7 +415,8 @@ Navigation and other parts of the Mathematicks, with the use of the Globes
 and other Mathematical Instruments, by Samuel Grainger.</p>
 
 <p>They whose business won't permit 'em to attend the usual School Hours,
-shall be carefully attended and Instructed in the Evenings.</p></div>
+shall be carefully attended and Instructed in the Evenings.</p>
+</div>
 
 <p>R. F. Seybold<a id="FNanchor_4" href="#Footnote_4" class="fnanchor">[4]</a> has noted that: "In advertisements of 1753
 and 1754, John Lewis, of New York City, announced 'What is
@@ -462,7 +464,8 @@ Such Persons as would attain to the Knowledge of those <i>Instruments</i>; But
 Chiefly designed for the <i>Instruction</i> of the young <i>Gentlemen</i> at the <i>Academy</i> in
 Philadelphia. To which is added Rules for working all the Cases in Plain
 and Spherical Triangles without a Scheme. By <i>Theophilus Grew</i>, Mathematical
-Professor. Germantown, Printed by Christopher Sower, 1753.<a id="FNanchor_7" href="#Footnote_7" class="fnanchor">[7]</a></p></div>
+Professor. Germantown, Printed by Christopher Sower, 1753.<a id="FNanchor_7" href="#Footnote_7" class="fnanchor">[7]</a></p>
+</div>
 
 <p>Thus, the need for practical mathematical instruments for the
 surveyor and navigator became critical in proportion to the need
@@ -637,7 +640,8 @@ family, as an Apprentice to learn the Art and Mistery of making Clocks and
 Surveying Instruments. Any lad inclining to go an apprentice to the above
 Trade, the terms on which he will be taken may [be] known by enquiring of
 Mr. David Rittenhouse, in Philadelphia, or at the subscriber's house in
-Worcester township, Montgomery county. Benjamin Rittenhouse.</p></div>
+Worcester township, Montgomery county. Benjamin Rittenhouse.</p>
+</div>
 
 <p>[Illustration: Figure 6.&mdash;Astronomical clock made by David Rittenhouse
 <span class="pagenum"><a id="Page_16"></a>[Pg 16]</span>for his observatory at Norristown, Pa., and used by him for the
@@ -735,7 +739,8 @@ appeared in the Baltimore newspapers. The first one was in the
 
 <p>Ellicott's Upper Mills, April 4, 1778. Wanted, a person acquainted with the
 Clock-Making business, and able to work by directions. Such a person will
-meet with good encouragement by applying to Andrew Ellicott, sen.</p></div>
+meet with good encouragement by applying to Andrew Ellicott, sen.</p>
+</div>
 
 <p>The second advertisement, in the same vein, appeared in the May
 16, 1780, issue of the <i>Maryland Journal</i>:</p>
@@ -743,7 +748,8 @@ meet with good encouragement by applying to Andrew Ellicott, sen.</p></div>
 <div class="blockquot">
 
 <p>Good Encouragement will be given to either Clock or Mathematical instrument
-makers, by the subscriber, living in Baltimore-Town. Andrew Ellicott.</p></div>
+makers, by the subscriber, living in Baltimore-Town. Andrew Ellicott.</p>
+</div>
 
 
 <p>Owen Biddle</p>
@@ -912,7 +918,8 @@ Instruments, in Silver, Brass, or Ivory, at Reasonable Rates, at Mr. Rowland
 Houghton's Shop the north side of the Town Huse in Boston.</p>
 
 <p>N.B. Said Dabney, sets Loadstones to a greater Perfection than any
-heretofore.</p></div>
+heretofore.</p>
+</div>
 
 <p>Dabney's master, Jonathan Sisson (1694-1749) originally of
 Lincolnshire, with a shop in the Strand, London, was a well-known
@@ -932,7 +939,8 @@ with the following advertisement:</p>
 Street, Boston, on Monday, Tuesday and Thursday Evenings, from five to
 eight o'clock, for the Entertainment of the Curious, the Magic Lanthorn
 an Optick Machine, which exhibits a great Number of wonderful and surprising
-Figures, prodigious large, and vivid, at Half a Crown each, Old Tenor.</p></div>
+Figures, prodigious large, and vivid, at Half a Crown each, Old Tenor.</p>
+</div>
 <p><span class="pagenum"><a id="Page_28"></a>[Pg 28]</span></p>
 <p>In New York City, one of the earliest immigrant instrument
 makers was Charles Walpole, who established a shop at a corner in
@@ -978,7 +986,8 @@ instruments in a more curious manner than usual; which may be used in any
 weather without exception, small ditto which may be fixed on the end of a
 walking stick, and lengthened to a commodious height, gauging instruments
 as now in use, according to an act of assembly with all other mathematical
-instruments for sea or land, by wholesale or retail at reasonable rates.<a id="FNanchor_15" href="#Footnote_15" class="fnanchor">[15]</a></p></div>
+instruments for sea or land, by wholesale or retail at reasonable rates.<a id="FNanchor_15" href="#Footnote_15" class="fnanchor">[15]</a></p>
+</div>
 
 <p>Lamb had served an apprenticeship with Henry Carter, a
 mathematical  instrument maker in  London. In July 1724 he

--- a/src/tests/testhtml3baseline.html
+++ b/src/tests/testhtml3baseline.html
@@ -318,7 +318,8 @@ very handsomely once. I know I can count on your kindness to me.</p>
 
 <p>"Good-bye, and many many thanks&mdash;as Jack Lacy says&mdash;'f'r the manny
 booggy-rides, an' th' goom-candy, an' the boonches av malagy
-grrapes'!</p></div>
+grrapes'!</p>
+</div>
 
 <p>
 "Sincerely your friend,<br />
@@ -578,7 +579,8 @@ are not invariably all of these things at the same time.</p>
 
 <p>"Sincerely yours,</p>
 
-<p>"<span class="smcap">Richard Stanley Quarren</span>."</p></div>
+<p>"<span class="smcap">Richard Stanley Quarren</span>."</p>
+</div>
 
 <p>She answered him on the fourth week of her absence.</p>
 
@@ -729,7 +731,8 @@ you see. So I'm off.</p>
 
 <p>"Will you write to me again?</p>
 
-<p>"<span class="smcap">Strelsa Leeds</span>."</p></div>
+<p>"<span class="smcap">Strelsa Leeds</span>."</p>
+</div>
 
 <p>A week after Quarren had answered her letter O'Hara called his attention
 to a paragraph in a morning paper which hinted at an engagement between
@@ -2551,7 +2554,8 @@ that you will be at home to me?</p>
 
 <p>"Very sincerely yours,</p>
 
-<p>"<span class="smcap">Richard Stanley Quarren</span>."</p></div>
+<p>"<span class="smcap">Richard Stanley Quarren</span>."</p>
+</div>
 
 <p>He took this note to the nearest District Messenger Office; then
 returned to his room.</p>
@@ -3646,7 +3650,8 @@ and happier then than I think she ever will be again.</p>
 
 <p>"Your friend&mdash;if you wish&mdash;</p>
 
-<p>"<span class="smcap">Strelsa Leeds.</span>"</p></div>
+<p>"<span class="smcap">Strelsa Leeds.</span>"</p>
+</div>
 
 <p>He wrote her by return mail:</p>
 
@@ -3669,7 +3674,8 @@ this time for good and all.</p>
 
 <p>"Are you engaged to marry Sir Charles?</p>
 
-<p>"<span class="smcap">R. S. Quarren.</span>"</p></div>
+<p>"<span class="smcap">R. S. Quarren.</span>"</p>
+</div>
 
 <p><span class="pagenum"><a id="Page_226"></a>[Pg 226]</span></p>
 
@@ -3710,14 +3716,16 @@ drown.</p>
 <p>"P. S.&mdash;Lord Dankmere is here. He is insufferable. He told Mrs.
 Sprowl that you and he were going into the antique-picture
 business. You wouldn't think of<span class="pagenum"><a id="Page_227"></a>[Pg 227]</span> going into anything whatever with
-a man of that sort, would you? Or was it merely a British jest?"</p></div>
+a man of that sort, would you? Or was it merely a British jest?"</p>
+</div>
 
 <p>He wrote at once:</p>
 
 <div class="blockquot">
 
 <p>"I have your letter and will keep it a week before replying.
-But&mdash;are you engaged?"</p></div>
+But&mdash;are you engaged?"</p>
+</div>
 
 <p>She answered:</p>
 
@@ -3727,7 +3735,8 @@ But&mdash;are you engaged?"</p></div>
 Sprowl, to Sir Charles. You may take your choice if you are
 determined to have me engaged to somebody. No doubt you think my
 being engaged would make our future friendship safer. I'll attend
-to it immediately if you wish me to."</p></div>
+to it immediately if you wish me to."</p>
+</div>
 
 <p>Evidently she was in a gay and contrary humour when she wrote so
 flippantly to him. And he replied in kind and quite as lightly. Then, at
@@ -4353,7 +4362,8 @@ letter, don't be very unkind to me. I know what I am&mdash;and I vaguely
 surmise what I shall lose by being so. But I have no courage for
 anything else.</p>
 
-<p>"<span class="smcap">Strelsa Leeds.</span>"</p></div>
+<p>"<span class="smcap">Strelsa Leeds.</span>"</p>
+</div>
 
 <p>That was the letter she wrote to Quarren; and he read it standing by his
 desk while several noisy workmen were covering every available inch of
@@ -4416,7 +4426,8 @@ Wycherly:</p>
 
 <p>"May I remind you that you asked me to Witch-Hollow?</p>
 
-<p><span class="smcap">Quarren.</span>"</p></div>
+<p><span class="smcap">Quarren.</span>"</p>
+</div>
 
 <p>The following morning after the workmen had departed, he and Dankmere
 stood contemplating the trans<span class="pagenum"><a id="Page_254"></a>[Pg 254]</span>formations wrought in the office, back
@@ -4582,7 +4593,8 @@ an answer to his telegram.</p>
 
 <p>"Come up to Witch-Hollow to-morrow.</p>
 
-<p>"<span class="smcap">Marie Wycherly.</span>"</p></div>
+<p>"<span class="smcap">Marie Wycherly.</span>"</p>
+</div>
 
 <p>He could not leave until he had planned for work to go on during his
 absence. First he arranged with Valasco to identify as nearly as
@@ -4775,7 +4787,8 @@ score of estates in the auction mart which must soon pass from some
 of the bluest-blooded nobles in Great Britain to men whose fortunes
 have grown in the past few years from the humblest beginnings, a
 fact which itself cannot fail to change both the tone and
-constitution of town and country society."</p></div>
+constitution of town and country society."</p>
+</div>
 
 <p>Quarren read every column, grimly, to the end, wincing when he
 encountered some casual reference to himself and his recent social
@@ -8385,7 +8398,8 @@ misunderstandings.</p>
 <p>"Please don't let any come between us, will you? Somehow, lately, I
 find myself looking on you as a distant but solid and almost
 peaceful refuge for my harried thoughts. And I'm so very, very
-tired of being hunted.</p></div>
+tired of being hunted.</p>
+</div>
 
 <p>
 "<span class="smcap">Strelsa.</span>"<br />
@@ -8574,7 +8588,8 @@ ancestors will look down approvingly at you from the wall; and all
 our little world will know that the loveliest and best of all the
 greater world is break<span class="pagenum"><a id="Page_387"></a>[Pg 387]</span>ing bread with us under our roof, and that
 one for once, unlike man's dealings with your celestial sisters,
-our entertainment of you will not be wholly unawares.</p></div>
+our entertainment of you will not be wholly unawares.</p>
+</div>
 
 
 <p>
@@ -9343,7 +9358,8 @@ vague, warm dream, safe from anything real.</p>
 
 <p>"Meanwhile, without aim, without hope, without even desire to
 escape my destiny, I am holding out because you ask it. To what
-end, my friend? Can you tell me?"</p></div>
+end, my friend? Can you tell me?"</p>
+</div>
 
 <p>One morning Molly came into her room greatly perturbed, and Strelsa,
 still in bed, laid aside the New Testament which she had been reading,
@@ -9750,7 +9766,8 @@ orthodoxy&mdash;but just as you discover it for yourself in the
 histories of men and women&mdash;of saint and sinner&mdash;and, above all, in
 the matchless life of Him who understood them all.</p>
 
-<p>"<i>Non tu corpus eras sine pectore!</i>"</p></div>
+<p>"<i>Non tu corpus eras sine pectore!</i>"</p>
+</div>
 
 <p>Lying there, remembering his letter almost word for word, and where it
 now lay among printed pages incomprehensible to her except by the
@@ -11635,7 +11652,8 @@ chintzed and made livable and lovable.</p>
 <p>"When?&mdash;please.</p>
 
 <p>"Your friend and comrade,
-<span class="smcap">Strelsa</span>."</p></div>
+<span class="smcap">Strelsa</span>."</p>
+</div>
 
 <p><span class="pagenum"><a id="Page_481"></a>[Pg 481]</span></p>
 
@@ -11644,7 +11662,8 @@ chintzed and made livable and lovable.</p>
 <div class="blockquot">
 
 <p>"I'll come the moment I can. Look for me any day this week. Letter
-follows."</p></div>
+follows."</p>
+</div>
 
 <p>Then he wrote her a long letter, and was still at it when Jessie Vining
 went to lunch and when Dankmere got onto his little legs and strolled
@@ -12011,7 +12030,8 @@ promised to observe to the letter.</p>
 <p>"Unavoidably detained in town. Hope to be up next week. Am crazy to
 see your house and its new owner.</p>
 
-<p>R. S. Q."</p></div>
+<p>R. S. Q."</p>
+</div>
 
 <p>Dankmere at the other end of the telephone hung up the receiver, looked
 carefully around him to be certain that Jessie Vining was still in the

--- a/src/tests/testhtml5baseline.html
+++ b/src/tests/testhtml5baseline.html
@@ -123,7 +123,8 @@ N. Y.
 <div class="blockquot">
 
 <p>A daring Express Robbery.&mdash;Mr. Pinkerton appealed to.&mdash;Cane-brakes and
-cane-fed People.&mdash;Annoying delays and Amateur Detectives.                          9</p></div>
+cane-fed People.&mdash;Annoying delays and Amateur Detectives.                          9</p>
+</div>
 
 <p class="center">CHAPTER II.
 </p>
@@ -132,7 +133,8 @@ cane-fed People.&mdash;Annoying delays and Amateur Detectives.                  
 
 <p>Difficulties.&mdash;Blind Trails and False Scents.&mdash;A Series of Illustrations showing
 the Number of Officious People and Confidence Men that often seek
-Notoriety and Profit through important Detective Operations.                      21</p></div>
+Notoriety and Profit through important Detective Operations.                      21</p>
+</div>
 
 <p class="center">CHAPTER III.
 </p>
@@ -141,7 +143,8 @@ Notoriety and Profit through important Detective Operations.                    
 
 <p>"Old Hicks," a drunken Planter, is entertained by a Hunting-Party.&mdash;Lester's
 Landing.&mdash;Its Grocery-Store and Mysterious Merchants.&mdash;A dangerous
-Situation.&mdash;The unfortunate Escape of Two of the Robbers.                         32</p></div>
+Situation.&mdash;The unfortunate Escape of Two of the Robbers.                         32</p>
+</div>
 
 <p class="center">CHAPTER IV.
 </p>
@@ -150,14 +153,16 @@ Situation.&mdash;The unfortunate Escape of Two of the Robbers.                  
 
 <p>The Captured Ruffians are desired for Guides, but dare not join in the
 Search for the Outlaws.&mdash;One of the Robbers is Taken, but subsequently
-Escapes from the Amateur Detectives.&mdash;Another Clue suddenly fails.                44</p></div>
+Escapes from the Amateur Detectives.&mdash;Another Clue suddenly fails.                44</p>
+</div>
 
 <p class="center">CHAPTER V.
 </p>
 
 <div class="blockquot">
 
-<p>A Rich Lead Struck at Last.                                                       50</p></div>
+<p>A Rich Lead Struck at Last.                                                       50</p>
+</div>
 
 <p class="center">CHAPTER VI.
 </p>
@@ -168,14 +173,16 @@ Escapes from the Amateur Detectives.&mdash;Another Clue suddenly fails.         
 never be taken Alive."&mdash;Another Unfortunate Blunder by Amateur Detectives.&mdash;An
 interesting Fate intended for the Detectives.&mdash;William A.
 Pinkerton captures the Murderer of a Negro in Union City, proving "a
-very good Fellow&mdash;for a Yankee."                                                  56</p></div>
+very good Fellow&mdash;for a Yankee."                                                  56</p>
+</div>
 
 <p class="center">CHAPTER VII.
 </p>
 
 <div class="blockquot">
 
-<p>The Scene of Action transferred to Missouri.&mdash;The Chase becoming Hot.             68</p></div>
+<p>The Scene of Action transferred to Missouri.&mdash;The Chase becoming Hot.             68</p>
+</div>
 
 <p class="center">CHAPTER VIII.
 </p>
@@ -183,7 +190,8 @@ very good Fellow&mdash;for a Yankee."                                           
 <div class="blockquot">
 
 <p>A determined Party of Horsemen.&mdash;The Outlaws surrounded and the Birds
-caged.&mdash;A Parley.&mdash;The burning Cabin.&mdash;Its Occupants finally surrender.           80</p></div>
+caged.&mdash;A Parley.&mdash;The burning Cabin.&mdash;Its Occupants finally surrender.           80</p>
+</div>
 
 <p class="center">CHAPTER IX.
 </p>
@@ -192,7 +200,8 @@ caged.&mdash;A Parley.&mdash;The burning Cabin.&mdash;Its Occupants finally surr
 
 <p>Barton's Confession.&mdash;The Express Robberies, and the Outlaw's subsequent
 Experiences fully set forth therein.&mdash;A Clue that had been suddenly
-dropped taken up with so much Profit.                                             91</p></div>
+dropped taken up with so much Profit.                                             91</p>
+</div>
 
 <p class="center">CHAPTER X.
 </p>
@@ -200,7 +209,8 @@ dropped taken up with so much Profit.                                           
 <div class="blockquot">
 
 <p>A terrible Struggle for Life or Death upon the Transfer-boat "Illinois."&mdash;"Overboard!"&mdash;One
-less Desperado.&mdash;Fourth and Last Robber taken.                                   104</p></div>
+less Desperado.&mdash;Fourth and Last Robber taken.                                   104</p>
+</div>
 
 <p class="center">CHAPTER XI.
 </p>
@@ -209,7 +219,8 @@ less Desperado.&mdash;Fourth and Last Robber taken.                             
 
 <p>The last Scene in the Drama approaching.&mdash;A new Character appears.&mdash;The
 Citizens of Union City suddenly seem to have important business on
-hand.&mdash;The Vigilantes and their Work.&mdash;The End.                                  114</p></div>
+hand.&mdash;The Vigilantes and their Work.&mdash;The End.                                  114</p>
+</div>
 
 
 <p class="center">DON PEDRO AND THE DETECTIVES.</p>
@@ -221,7 +232,8 @@ hand.&mdash;The Vigilantes and their Work.&mdash;The End.                       
 
 <p>A fraudulent Scheme contemplated.&mdash;A dashing Peruvian Don and Donna.&mdash;A
 regal Forger.&mdash;Mr. Pinkerton engaged by Senator Muirhead to unveil
-the mystery of his Life.                                                         125</p></div>
+the mystery of his Life.                                                         125</p>
+</div>
 
 <p class="center">CHAPTER II.
 </p>
@@ -232,7 +244,8 @@ the mystery of his Life.                                                        
 also arrive at Gloster.&mdash;Mr. Pinkerton, as a Laborer, anxious for a Job,
 inspects the Morita Mansion.                                                     143</p>
 
-<p><span class="pagenum"><a id="Page_5"></a>[Pg 5]</span></p></div>
+<p><span class="pagenum"><a id="Page_5"></a>[Pg 5]</span></p>
+</div>
 
 <p class="center">CHAPTER III.
 </p>
@@ -243,7 +256,8 @@ inspects the Morita Mansion.                                                    
 Pedro.&mdash;Diamond fields and droll Americans.&mdash;A pompous Judge in an
 unfortunate Predicament.&mdash;The grand Reception closes with a happy
 Arrangement that the gay Señor and Señora shall dine with Mr. Pinkerton's
-Detectives on the next evening.                                                  159</p></div>
+Detectives on the next evening.                                                  159</p>
+</div>
 
 <p class="center">CHAPTER IV.
 </p>
@@ -252,7 +266,8 @@ Detectives on the next evening.                                                 
 
 <p>Madame Sevier and Her Work.&mdash;Unaccountable Coquettishness between
 Man and Wife.&mdash;A Startling Scheme, Illustrating the Rashness of
-American Business Men and the Supreme Assurance of Don Pedro.                    170</p></div>
+American Business Men and the Supreme Assurance of Don Pedro.                    170</p>
+</div>
 
 <p class="center">CHAPTER V.
 </p>
@@ -261,7 +276,8 @@ American Business Men and the Supreme Assurance of Don Pedro.                   
 
 <p>The third Detective is made welcome at Don Pedro's.&mdash;The Señor is paid the
 first half-million dollars from the great Diamond Company.&mdash;How Don
-Pedro is "working" his diamond mines.                                            189</p></div>
+Pedro is "working" his diamond mines.                                            189</p>
+</div>
 
 <p class="center">CHAPTER VI.
 </p>
@@ -270,7 +286,8 @@ Pedro is "working" his diamond mines.                                           
 
 <p>An unexpected Meeting and a startling Recognition. An old friend somewhat
 disturbs the Equanimity of Don Pedro. The Detectives fix their
-Attention upon Pietro Bernardi.                                                  205</p></div>
+Attention upon Pietro Bernardi.                                                  205</p>
+</div>
 
 <p class="center">CHAPTER VII.
 </p>
@@ -278,7 +295,8 @@ Attention upon Pietro Bernardi.                                                 
 <div class="blockquot">
 
 <p>Pietro Bernardi and the Detective become warm Friends.&mdash;A Tête-à-tête
-worth one thousand dollars.                                                      219</p></div>
+worth one thousand dollars.                                                      219</p>
+</div>
 
 <p class="center">CHAPTER VIII.
 </p>
@@ -287,7 +305,8 @@ worth one thousand dollars.                                                     
 
 <p>Don Pedro anxious for Pietro Bernardi's absence.&mdash;"Coppering the Jack
 and playing the Ace and Queen open."&mdash;Bernardi Quieted, and he subsequently
-departs richer by five thousand dollars.                                         232</p></div>
+departs richer by five thousand dollars.                                         232</p>
+</div>
 
 <p class="center">CHAPTER IX.
 </p>
@@ -297,7 +316,8 @@ departs richer by five thousand dollars.                                        
 <p>Important Information from the Peruvian Government.&mdash;Arrival In Gloster
 of the Peruvian Minister and Consul.&mdash;In Consultation.&mdash;"Robbing Peter
 to pay Paul."&mdash;Mr. Pinkerton's Card is presented.&mdash;Juan Sanchez, I arrest
-you, and you are my Prisoner.&mdash;Mr. Pinkerton not "For Sale."                     249</p></div>
+you, and you are my Prisoner.&mdash;Mr. Pinkerton not "For Sale."                     249</p>
+</div>
 
 <p class="center">CHAPTER X.
 </p>
@@ -307,7 +327,8 @@ you, and you are my Prisoner.&mdash;Mr. Pinkerton not "For Sale."               
 <p>The Fête Champêtre.&mdash;A grand Carnival.&mdash;The disappointed married Lover.&mdash;A
 vain Request.&mdash;Unmasked!&mdash;An indignant Deacon.&mdash;Don Pedro taken
 to Peru in a man-of-war, where he is convicted and sentenced to fifteen
-years Imprisonment.                                                              265</p></div>
+years Imprisonment.                                                              265</p>
+</div>
 
 
 <p class="center">THE POISONER AND THE DETECTIVES.</p>
@@ -320,7 +341,8 @@ years Imprisonment.                                                             
 <p>Mr. Pinkerton at a Water-cure becomes interested in a Couple, one of whom
 subsequently causes the Detective Operation from which this Story is
 written.&mdash;A wealthy ship-owner and his son.&mdash;The son "Found dead."&mdash;Mr.
-Pinkerton secured to solve the Mystery.&mdash;Chicago after the Fire.                 283</p></div>
+Pinkerton secured to solve the Mystery.&mdash;Chicago after the Fire.                 283</p>
+</div>
 
 <p class="center">CHAPTER II.
 </p>
@@ -329,7 +351,8 @@ Pinkerton secured to solve the Mystery.&mdash;Chicago after the Fire.           
 
 <p>The Detectives at work.&mdash;Mrs. Sanford described.&mdash;Charlie, the Policeman.&mdash;Mrs.
 Sanford develops Interest in Government Bonds.&mdash;Chicago Relief
-and Aid Benefits.&mdash;Mrs. Sanford's Story of Trafton's Death.                      298</p></div>
+and Aid Benefits.&mdash;Mrs. Sanford's Story of Trafton's Death.                      298</p>
+</div>
 
 <p class="center">CHAPTER III.
 </p>
@@ -339,7 +362,8 @@ and Aid Benefits.&mdash;Mrs. Sanford's Story of Trafton's Death.                
 <p>The dangerous Side of the Woman's Character.&mdash;Robert A. Pinkerton as
 Adamson, the drunken, but wealthy Stranger, has a violent Struggle to
 escape from Mrs. Sanford, and is afterwards robbed.&mdash;Detective Ingham
-arrested, but very shortly liberated.                                            319</p></div>
+arrested, but very shortly liberated.                                            319</p>
+</div>
 
 <p class="center">CHAPTER IV.
 </p>
@@ -348,7 +372,8 @@ arrested, but very shortly liberated.                                           
 
 <p>Connecting Links.&mdash;Mrs. Sanford's Ability as an Imitator of Actors.&mdash;One
 Detective tears himself away from her, and another takes his Place.&mdash;Mrs.
-Sanford's mind frequently burdened with the subject of Murder.                   340</p></div>
+Sanford's mind frequently burdened with the subject of Murder.                   340</p>
+</div>
 
 <p class="center">CHAPTER V.
 </p>
@@ -359,7 +384,8 @@ Sanford's mind frequently burdened with the subject of Murder.                  
 are seen and their Numbers taken by the Detectives.&mdash;Mrs. Sanford arrested.&mdash;She
 is found guilty of "Involuntary Manslaughter," and sentenced
 to the Illinois Penitentiary for five years.&mdash;Mr. Pinkerton's
-Theory of the Manner in which Trafton was murdered                               356</p></div>
+Theory of the Manner in which Trafton was murdered                               356</p>
+</div>
 
 <p><span class="pagenum"><a id="Page_6"></a>[Pg 6]</span></p>
 
@@ -442,7 +468,8 @@ F/</p>
 
 <p><i>A daring Express Robbery.&mdash;Mr. Pinkerton appealed
 to.&mdash;Cane-brakes and cane-fed People.&mdash;Annoying
-Delays and Amateur Detectives.</i></p></div>
+Delays and Amateur Detectives.</i></p>
+</div>
 
 
 <p>The southern and border states, since the close
@@ -838,7 +865,8 @@ interference.</p>
 <p><i>Difficulties.&mdash;Blind Trails and False Scents.&mdash;A Series
 of Illustrations showing the Number of Officious
 People and Confidence Men that often seek Notoriety
-and Profit through important Detective Operations.</i></p></div>
+and Profit through important Detective Operations.</i></p>
+</div>
 
 
 <p>The art of detecting crime cannot be learned
@@ -1225,7 +1253,8 @@ were always a source of great annoyance and embarrassment.</p>
 Hunting-party.&mdash;Lester's Landing.&mdash;Its Grocery-store
 and Mysterious Merchants.&mdash;A dangerous
 Situation and a desperate Encounter.&mdash;The unfortunate
-Escape of Two of the Robbers.</i></p></div>
+Escape of Two of the Robbers.</i></p>
+</div>
 
 
 <p>One of the most direct sources of information
@@ -1646,7 +1675,8 @@ clothes and grazed his flesh.</p>
 not join in the Search for the Outlaws.&mdash;One of
 the Robbers is Taken, but subsequently Escapes from
 the Amateur Detectives.&mdash;Another Clue suddenly
-Fails.</i></p></div>
+Fails.</i></p>
+</div>
 
 
 <p>Having searched the whole place, and satisfied
@@ -1836,7 +1866,8 @@ was the result.</p>
 
 <div class="blockquot">
 
-<p><i>A Rich Lead Struck at Last.</i></p></div>
+<p><i>A Rich Lead Struck at Last.</i></p>
+</div>
 
 
 <p>William was quite sure, from the reputation
@@ -2051,7 +2082,8 @@ interesting Fate intended for the Detectives.&mdash;William
 A. Pinkerton captures the Murderer of a Negro
 in Union City, proving "a very good Fellow&mdash;for
 a Yankee."&mdash;An Unfortunate Publication.&mdash;Nigger-Wool
-Swamp and its Outlaws.</i></p></div>
+Swamp and its Outlaws.</i></p>
+</div>
 
 
 <p>The more William thought about it, the more
@@ -2506,7 +2538,8 @@ time.</p>
 </p>
 
 <p>"M. F. sends her love to all of the family. Excuse
-my bad writing and bad spelling."</p></div>
+my bad writing and bad spelling."</p>
+</div>
 
 <p>It was evident that Mrs. Farrington had previously
 written to her cousin informing him of
@@ -2885,7 +2918,8 @@ was only delayed a day or two at most.</p>
 <p><i>A determined Party of Horsemen.&mdash;The Outlaws surrounded
 and the Birds caged.&mdash;A Parley.&mdash;An
 affecting Scene.&mdash;The burning Cabin.&mdash;Its Occupants
-finally surrender.</i></p></div>
+finally surrender.</i></p>
+</div>
 
 
 <p>While the telegrams were flying back and
@@ -3264,7 +3298,8 @@ exactly as it was taken down from Barton's lips.</p>
 Outlaws' subsequent Experiences fully set forth therein.&mdash;A
 Clue that had been suddenly dropped taken
 up with so much Profit, that, after a desperate Struggle,
-another Desperado is Captured.</i></p></div>
+another Desperado is Captured.</i></p>
+</div>
 
 
 <p>"I am twenty-two years of age," said Barton,
@@ -3701,7 +3736,8 @@ for Cairo.</p>
 
 <p><i>A terrible Struggle for Life or Death upon the Transfer-boat
 "Illinois."&mdash;"Overboard!"&mdash;One less Desperado.&mdash;The
-Fourth and Last Robber taken.</i></p></div>
+Fourth and Last Robber taken.</i></p>
+</div>
 
 
 <p>After Barton had made his confession
@@ -4039,7 +4075,8 @@ appears.&mdash;The Citizens of Union City suddenly
 seem to have important business on hand.&mdash;The
 Vigilantes and their Work.&mdash;Their Bullets and Judge
 Lynch administer a quietus to Levi Farrington and
-David Towler.&mdash;The End.</i></p></div>
+David Towler.&mdash;The End.</i></p>
+</div>
 
 
 <p>The last scene in this drama seemed about to
@@ -4376,7 +4413,8 @@ Don and Donna.&mdash;A Regal Forger.&mdash;Mr.
 Pinkerton engaged by Senator Muirhead to unveil
 the Mystery of his Life.&mdash;The Don and Donna
 Morito arrive at Gloster.&mdash;"Personnel" of Gloster's
-"First Families."</i></p></div>
+"First Families."</i></p>
+</div>
 
 
 <p>The history of crimes against prosperity is of
@@ -4989,7 +5027,8 @@ Pinkerton, as a Laborer, anxious for a Job,
 inspects the Morito Mansion.&mdash;A Tender Scene,
 resulting in Profit to the fascinating Señora.&mdash;Madame
 Sevier is installed as a Guest at Don
-Pedro's.</i></p></div>
+Pedro's.</i></p>
+</div>
 
 
 <p>My first action in this affair was to detail a
@@ -5552,7 +5591,8 @@ droll Americans.&mdash;A pompous Judge in an unfortunate
 Predicament.&mdash;The grand Reception closes
 with the happy Arrangement that the gay Señor
 and Señora shall dine with Mr. Pinkerton's Detectives
-on the next evening.</i></p></div>
+on the next evening.</i></p>
+</div>
 
 
 <p>The day of the reception was unusually pleasant,
@@ -5923,7 +5963,8 @@ American Business Men and the Supreme Assurance
 of Don Pedro.&mdash;Disaster approaching the
 Gloster Capitalists.&mdash;Other Suspicions Aroused.&mdash;The
 Story of Mr. Warne, English Diplomatic
-Agent.&mdash;A New Move.</i></p></div>
+Agent.&mdash;A New Move.</i></p>
+</div>
 
 
 <p>Madame Sevier began her work of reform
@@ -6577,7 +6618,8 @@ Señor is paid the first half-million dollars from
 the great Diamond Company.&mdash;How Don Pedro is
 "working" his Diamond Mines.&mdash;Very suspicious
 preparations.&mdash;The Don describes his proposed Fête
-Champêtre.</i></p></div>
+Champêtre.</i></p>
+</div>
 
 
 <p>One evening, as the members of the Morito
@@ -7154,7 +7196,8 @@ startling Recognition.&mdash;An old Friend somewhat
 disturbs the Equanimity of Don Pedro.&mdash;The Detectives
 fix their Attention upon Pietro Bernardi.&mdash;Pietro
 and his unpalatable Reminiscences.&mdash;The
-Donna shows Spirit.</i></p></div>
+Donna shows Spirit.</i></p>
+</div>
 
 
 <p>"Early one forenoon Salter was called to the
@@ -7690,7 +7733,8 @@ the island to receive the guests on the day of the
 
 <p><i>Pietro Bernardi and the Detective become Warm
 Friends.&mdash;A "Tête-à-Tête" worth One Thousand
-Dollars.</i></p></div>
+Dollars.</i></p>
+</div>
 
 
 <p>When Pietro Bernardi left the Morito residence,
@@ -8167,7 +8211,8 @@ the Jack and Playing the Ace and
 Queen open."&mdash;A Gambler that could not be Bought.&mdash;Splendid
 Winnings.&mdash;Diamond cutting Diamond.&mdash;Bernardi
 quieted, and he subsequently departs
-richer by five thousand dollars.</i></p></div>
+richer by five thousand dollars.</i></p>
+</div>
 
 
 <p>At eleven o'clock, Newton and Bernardi again
@@ -8789,7 +8834,8 @@ and Consul.&mdash;In Consultation.&mdash;"Robbing Peter
 to pay Paul."&mdash;Mr. Pinkerton's card is presented.&mdash;Juan
 Sanchez, I arrest you, and you are my Prisoner.&mdash;Mr.
 Pinkerton not "For Sale."&mdash;A Dramatic
-Scene.&mdash;The Bubble burst.</i></p></div></div>
+Scene.&mdash;The Bubble burst.</i></p>
+</div></div>
 
 
 <p>Several days now sped by with no fresh developments,
@@ -9379,7 +9425,8 @@ Demands.&mdash;An Indignant Deacon.&mdash;Don Pedro
 taken to Peru in a Man-of-War, where he is Convicted
 and Sentenced to Fifteen Years' Imprisonment.&mdash;But
 the Donna manages to Satisfy her
-Affections in a quiet way in New York.</i></p></div>
+Affections in a quiet way in New York.</i></p>
+</div>
 
 
 <p>To the great delight of hundreds of people in
@@ -10009,7 +10056,8 @@ Operation from which this Story is written.&mdash;A
 wealthy Ship-Owner and his Son.&mdash;The Son
 "found dead."&mdash;A Woman that knows too much
 and too little by turns.&mdash;Mr. Pinkerton secured to
-solve the Mystery.&mdash;Chicago after the Great Fire.</i></p></div>
+solve the Mystery.&mdash;Chicago after the Great Fire.</i></p>
+</div>
 
 
 <p>During the summer of 1870, I was spending
@@ -11310,7 +11358,8 @@ Stranger.&mdash;A "funny" Game of Cards.&mdash;The
 drunken Stranger has a violent Struggle to escape
 from Mrs. Sanford, and is afterwards robbed&mdash;according
 to the Papers.&mdash;Detective Ingham arrested,
-but very shortly liberated.</i></p></div>
+but very shortly liberated.</i></p>
+</div>
 
 
 <p>It has already been observed by the reader
@@ -11663,7 +11712,8 @@ company. He describes the stranger as a tall
 slender man, with black side-whiskers, giving a
 sufficiently minute description of him to afford
 the police a valuable clue, and it is likely that the
-highwayman will soon be overhauled."</p></div>
+highwayman will soon be overhauled."</p>
+</div>
 
 <p>About noon of the day that the above was published,
 Ingham went to call upon Mrs. Sanford,
@@ -11817,7 +11867,8 @@ how much money Adamson had, but it must
 have been in the neighborhood of $1,000, or the
 man who took it would not have made such a
 munificent offer to have the fact of the theft
-kept secret."</p></div>
+kept secret."</p>
+</div>
 
 <p>In accordance with my instructions, Ingham
 went to Mrs. Sanford's house about noon on
@@ -12139,7 +12190,8 @@ of Actors.&mdash;One Detective tears himself away
 from her, and another takes his Place.&mdash;Mrs. Sanford's
 mind frequently burdened with the Subject of
 Murder.&mdash;New Evidence appearing.&mdash;A Peep at the
-stolen Bonds.&mdash;The Shrewdness of the Murderess.</i></p></div>
+stolen Bonds.&mdash;The Shrewdness of the Murderess.</i></p>
+</div>
 
 
 <p>Ingham did not return to Mrs. Sanford's until
@@ -12747,7 +12799,8 @@ is found guilty of "Involuntary Manslaughter" and
 sentenced to the Illinois Penitentiary for five years.&mdash;Misdirected
 Philanthropy, and its Reward.&mdash;Mr.
 Pinkerton's Theory of the Manner in which Trafton
-was Murdered.</i></p></div>
+was Murdered.</i></p>
+</div>
 
 
 <p>Having discussed my plan with my superintendent,


### PR DESCRIPTION
Add a newline between the ending `</p>` and the `</div>` or `</blockquote>`

FIxes #219. 
