### PR TITLE
Provide redesigned HTML Markup dialog

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -135,8 +135,6 @@ our $globalspellpath        = q{};
 our $globalviewerpath       = q{};
 our $globalprojectdirectory = q{};
 our @gsopt;
-our $htmldiventry           = ' class="i2"';
-our $htmlspanentry          = ' class="i2"';
 our $highlightcolor         = '#a08dfc';
 our $history_size           = 20;
 our $ignoreversions         = "none";                      # Don't ignore any updates by default
@@ -212,6 +210,11 @@ our @replace_history;
 our @search_history;
 our @sopt = ( 0, 0, 0, 0, 0 );    # default is not whole word search
 our @wfsearchopt;
+
+# html markup dialog
+our @htmlentry = ('') x 4;        # class/attributes for each div, span, i button
+our @htmlentryhistory;            # single shared history list htmlentry
+our %htmlentryattribhash;         # class/attributes for each element button
 
 our %htmllabels;
 our %convertcharsdisplay;

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -867,8 +867,7 @@ EOM
             qw/alpha_sort activecolor auto_page_marks auto_show_images autobackup autosave autosaveinterval bkgcolor
             blocklmargin blockrmargin bold_char cssvalidationlevel defaultindent donotcenterpagemarkers epubpercentoverride failedsearch
             font_char fontname fontsize fontweight geometry
-            gesperrt_char globalaspellmode highlightcolor history_size
-            htmldiventry htmlspanentry ignoreversionnumber
+            gesperrt_char globalaspellmode highlightcolor history_size ignoreversionnumber
             intelligentWF ignoreversions italic_char jeebiesmode lastversioncheck lastversionrun lmargin
             multisearchsize multiterm nobell nohighlights projectfileslocation notoolbar oldspellchecklayout poetrylmargin projectfileslocation
             recentfile_size rmargin rmargindiff rwhyphenspace sc_char scannos_highlighted spellcheckwithenchant stayontop toolside
@@ -916,6 +915,7 @@ EOM
         print $save_handle '@mygcview = (';
         for (@::mygcview) { print $save_handle "$_," }
         print $save_handle (");\n\n");
+
         print $save_handle ("\@search_history = (\n");
         my @array = @::search_history;
         for my $index (@array) {
@@ -923,6 +923,7 @@ EOM
             print $save_handle qq/\t"$index",\n/;
         }
         print $save_handle ");\n\n";
+
         print $save_handle ("\@replace_history = (\n");
         @array = @::replace_history;
         for my $index (@array) {
@@ -930,11 +931,33 @@ EOM
             print $save_handle qq/\t"$index",\n/;
         }
         print $save_handle ");\n\n";
+
         print $save_handle ("\@multidicts = (\n");
         for my $index (@::multidicts) {
             print $save_handle qq/\t"$index",\n/;
         }
-        print $save_handle ");\n\n1;\n";
+        print $save_handle ");\n\n";
+
+        print $save_handle ("\@htmlentry = (\n");
+        for (@::htmlentry) {
+            print $save_handle "\t'", ::escape_problems($_), "',\n";
+        }
+        print $save_handle ");\n\n";
+
+        print $save_handle ("\@htmlentryhistory = (\n");
+        for (@::htmlentryhistory) {
+            print $save_handle "\t'", ::escape_problems($_), "',\n";
+        }
+        print $save_handle ");\n\n";
+
+        for ( keys %::htmlentryattribhash ) {
+            my $val = ::escape_problems( $::htmlentryattribhash{$_} );
+            print $save_handle "\$htmlentryattribhash{$_}", ' ' x ( 8 - length $_ ), "= '$val';\n";
+        }
+        print $save_handle "\n\n";
+
+        # Final line
+        print $save_handle "1;\n";
     }
 }
 

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -2333,11 +2333,11 @@ sub htmlmarkpopup {
 
         for (
             qw/
-            em    strong i   b       big small
-            h1    h2     h3  h4      h5  h6
-            table tr     td  ol      ul  li
-            sup   sub    ins del     q   cite
-            p     hr     br  blkquot pre nbsp
+            em    strong i   b     big small
+            h1    h2     h3  h4    h5  h6
+            table tr     td  ol    ul  li
+            sup   sub    ins del   q   cite
+            p     hr     br  blkq  pre nbsp
             /
         ) {
             $col = $inc % 6;
@@ -2406,7 +2406,7 @@ sub htmlmarkpopup {
         my @hbuttons = (
             [ 'Internal Link', 'ilink' ],
             [ 'External Link', 'elink' ],
-            [ 'Named anchor',  'anchor' ],
+            [ 'Anchor',        'anchor' ],
             [ 'Image',         'img' ],
         );
 
@@ -2542,6 +2542,7 @@ sub htmlmarkpopup {
 
 #
 # Configure Mouse-3 and Ctrl/Meta Mouse-1 to pop a dialog to set class/attributes for given button
+# Also, if button has attributes set, append a plus sign to its button label
 sub markupbindconfig {
     my $w   = shift;
     my $typ = shift;
@@ -2557,6 +2558,8 @@ sub markupbindconfig {
     # meaning we can break out of callbacks later before class callback is called
     my @tags = $w->bindtags;
     $w->bindtags( [ @tags[ 1, 0, 2, 3 ] ] );
+
+    markupconfiglabel( $w, $typ );    # Adjust label to show presence of class/attributes
 }
 
 #
@@ -2581,8 +2584,25 @@ sub markupconfig {
         'Class name or attributes: '
     );
 
+    markupconfiglabel( $w, $typ );                  # Adjust label to show presence of class/attributes
+
     # stop class callback being called - possible due to binding reordering in markupbindconfig
     $w->break;
+}
+
+#
+# Configure given widget's label to have a plus sign appended (or not) if class name/attributes set
+sub markupconfiglabel {
+    my $w   = shift;
+    my $typ = shift;
+
+    my $label = $w->cget( -text );
+    if ( $::htmlentryattribhash{$typ} ) {
+        $label =~ s/$/+/;
+    } else {
+        $label =~ s/\+$//;
+    }
+    $w->configure( -text => $label );
 }
 
 #
@@ -2619,7 +2639,7 @@ sub markup {
     my $thisblockend   = $end;
     my $selection;
 
-    $mark = "blockquote" if $mark eq "blkquot";    # shortened form for button label
+    $mark = "blockquote" if $mark eq "blkq";    # shortened form for button label
 
     if ( $mark eq 'br' ) {
         my ( $lsr, $lsc, $ler, $lec, $step );

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -5,9 +5,8 @@ use warnings;
 BEGIN {
     use Exporter();
     our ( @ISA, @EXPORT );
-    @ISA = qw(Exporter);
-    @EXPORT =
-      qw(&update_sr_histories &add_search_history &searchtext &search_history &reg_check &getnextscanno &updatesearchlabels
+    @ISA    = qw(Exporter);
+    @EXPORT = qw(&update_sr_histories &searchtext &reg_check &getnextscanno &updatesearchlabels
       &isvalid &swapterms &findascanno &reghint &replaceeval &replace &replaceall
       &searchfromstartifnew &searchoptset &searchpopup &stealthscanno &find_proofer_comment
       &find_asterisks &find_transliterations &nextblock &orphanedbrackets &orphanedmarkup &searchsize
@@ -16,25 +15,9 @@ BEGIN {
 
 # Update both the search and replace histories from their dialog fields
 sub update_sr_histories {
-    add_search_history( $::lglobal{searchentry}->get,  \@::search_history );
-    add_search_history( $::lglobal{replaceentry}->get, \@::replace_history );
-}
-
-# Add given term to either the search or replace history
-sub add_search_history {
-    my ( $term, $history_array_ref ) = @_;
-
-    # do not add during a scannos check nor if term is empty string
-    return if $::scannosearch or $term eq '';
-
-    my @temparray = @$history_array_ref;
-    @$history_array_ref = ();
-    push @$history_array_ref, $term;
-    for (@temparray) {
-        next if $_ eq $term;
-        push @$history_array_ref, $_;
-        last if @$history_array_ref >= $::history_size;
-    }
+    return if $::scannosearch;
+    ::add_entry_history( $::lglobal{searchentry}->get,  \@::search_history );
+    ::add_entry_history( $::lglobal{replaceentry}->get, \@::replace_history );
 }
 
 sub searchtext {
@@ -342,31 +325,6 @@ BEGIN {    # restrict scope of $countlastterm
             $::lglobal{searchnumlabel}->configure( -text => "" ) if defined $::lglobal{searchpop};
         }
     }
-}
-
-sub search_history {
-    my ( $widget, $history_array_ref ) = @_;
-    my $menu = $widget->Menu( -title => 'History', -tearoff => 0 );
-    $menu->command(
-        -label   => 'Clear History',
-        -command => sub { @$history_array_ref = (); ::savesettings(); },
-    );
-    $menu->separator;
-    for my $item (@$history_array_ref) {
-        $menu->command(
-            -label   => $item,
-            -command => [ sub { load_hist_term( $widget, $_[0] ) }, $item ],
-        );
-    }
-    my $x = $widget->rootx;
-    my $y = $widget->rooty + $widget->height;
-    $menu->post( $x, $y );
-}
-
-sub load_hist_term {
-    my ( $widget, $term ) = @_;
-    $widget->delete( '1.0', 'end' );
-    $widget->insert( 'end', $term );
 }
 
 # Set search entry box to red/black text if invalid/valid search term
@@ -1228,7 +1186,7 @@ sub searchpopup {
         $sf11->Button(
             -activebackground => $::activecolor,
             -command          => sub {
-                search_history( $::lglobal{searchentry}, \@::search_history );
+                ::entry_history( $::lglobal{searchentry}, \@::search_history );
             },
             -image  => $::lglobal{hist_img},
             -width  => 9,
@@ -1409,7 +1367,7 @@ sub searchpopup {
         $sf12->Button(
             -activebackground => $::activecolor,
             -command          => sub {
-                search_history( $::lglobal{replaceentry}, \@::replace_history );
+                ::entry_history( $::lglobal{replaceentry}, \@::replace_history );
             },
             -image  => $::lglobal{hist_img},
             -width  => 9,
@@ -1738,7 +1696,6 @@ sub searchaddterms {
             -command          => sub {
                 update_sr_histories();
                 replace( $::lglobal{$replaceentry}->get );
-                add_search_history( $::lglobal{$replaceentry}->get, \@::replace_history );
             },
             -text  => 'Replace',
             -width => 6
@@ -1764,7 +1721,7 @@ sub searchaddterms {
         $msref->[$_]->Button(
             -activebackground => $::activecolor,
             -command          => sub {
-                search_history( $::lglobal{$replaceentry}, \@::replace_history );
+                ::entry_history( $::lglobal{$replaceentry}, \@::replace_history );
             },
             -image  => $::lglobal{hist_img},
             -width  => 9,

--- a/src/lib/Guiguts/StatusBar.pm
+++ b/src/lib/Guiguts/StatusBar.pm
@@ -720,7 +720,7 @@ sub gotoline {
                 }
             }
         );
-        gotocommonsetup( 'gotolinepop', 'line_number', 'Enter line number: ', '' );
+        ::dialogboxcommonsetup( 'gotolinepop', \$::lglobal{line_number}, 'Enter line number: ' );
     }
 }
 
@@ -770,7 +770,7 @@ sub gotopage {
                 }
             }
         );
-        gotocommonsetup( 'gotopagpop', 'lastpage', 'Enter image number: ', '' );
+        ::dialogboxcommonsetup( 'gotopagpop', \$::lglobal{lastpage}, 'Enter image number: ' );
     }
 }
 
@@ -814,40 +814,8 @@ sub gotolabel {
                 }
             }
         );
-        gotocommonsetup( 'gotolabpop', 'lastlabel', 'Enter label: ', 'Pg ' );
+        ::dialogboxcommonsetup( 'gotolabpop', \$::lglobal{lastlabel}, 'Enter label: ', 'Pg ' );
     }
-}
-
-# Perform operations common to the "goto" dialogs,
-# including setting Escape key and window manager close button to invoke cancel
-sub gotocommonsetup {
-    my $dlg     = shift;             # dialog key in lglobal
-    my $var     = shift;             # variable key in lglobal
-    my $prompt  = shift;             # prompt for label in dialog
-    my $default = shift;             # default value for label (e.g. "Pg " in gotopage)
-    my $len     = length $default;
-    ::initialize_popup_without_deletebinding($dlg);
-    $::lglobal{$dlg}->resizable( 'no', 'no' );
-    $::lglobal{$dlg}
-      ->Tk::bind( '<Key-KP_Enter>' => sub { $::lglobal{$dlg}->Subwidget('B_OK')->invoke; } );
-    $::lglobal{$dlg}
-      ->Tk::bind( '<Escape>' => sub { $::lglobal{$dlg}->Subwidget('B_Cancel')->invoke; } );
-    $::lglobal{$dlg}
-      ->protocol( 'WM_DELETE_WINDOW' => sub { $::lglobal{$dlg}->Subwidget('B_Cancel')->invoke; } );
-    my $frame = $::lglobal{$dlg}->Frame->pack( -fill => 'x' );
-    $frame->Label( -text => $prompt )->pack( -side => 'left' );
-    $::lglobal{$var} = $default unless $::lglobal{$var};
-    my $entry = $frame->Entry(
-        -background   => $::bkgcolor,
-        -width        => 25,
-        -textvariable => \$::lglobal{$var}
-    )->pack( -side => 'left', -fill => 'x' );
-    $::lglobal{$dlg}->Advertise( entry => $entry );
-    $::lglobal{$dlg}->Popup;
-    $::lglobal{$dlg}->Subwidget('entry')->focus;
-    $::lglobal{$dlg}->Subwidget('entry')->selectionRange( $len, 'end' );
-    $::lglobal{$dlg}->Subwidget('entry')->icursor($len);    # place cursor at end of default text
-    $::lglobal{$dlg}->Wait;
 }
 
 1;


### PR DESCRIPTION
1. A few obsolete buttons removed
2. Other buttons re-ordered for more consistency
3. Top rows of buttons are now configurable: Mouse-3 or Ctrl/Meta-Mouse-1 pops
a small dialog to type in either a classname or some attribute styling. Subsequent
clicks will continue to include this additional HTML in the markup inserted.
4. Next section contains div, span and i buttons with text fields for additional
attributes. Currently 4 such rows.
5. Fields in point 4 have a history pulldown menu. Code commonised to provide
generic history for an entry widget - also used in S&R dialog.
6. The Internal link, External link and Named Anchor can be similarly configured
to include a class or other attributes.
7. Code for small dialog box with entry field used for config has been commonised -
very similar code was used for the Goto Page & related dialogs.
8. All the config and the history is saved in the setting.rc file between runs.

Fixes #96
Fixes #120