### PR TITLE
Stop bookloupe errors reappearing in the error list window

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -130,6 +130,8 @@ sub errorcheckpop_up {
             my $yy = $::lglobal{errorchecklistbox}->pointery - $::lglobal{errorchecklistbox}->rooty;
             my $idx = $::lglobal{errorchecklistbox}->index("\@$xx,$yy");
             $::lglobal{errorchecklistbox}->activate($idx);
+            $textwindow->markUnset( $::errors{ $::lglobal{errorchecklistbox}->get('active') } );
+            undef $::errors{ $::lglobal{errorchecklistbox}->get('active') };
             $::lglobal{errorchecklistbox}->selectionClear( 0, 'end' );
             $::lglobal{errorchecklistbox}->delete('active');
             $::lglobal{errorchecklistbox}->selectionSet('active');


### PR DESCRIPTION
When errors reported by bookloupe are right-clicked, they are removed from the list.
However, if the view options were then changed, removed error lines reappeared
in the list

Oversight when commonising the code for all the different error checks. Because
bookloupe has the View Options, its error list can be refreshed, so the error mark
needs undefining when the error is removed from the list.

Fixes #349