### PR TITLE
Don't skip first scanno when auto-advance is on by default

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1757,7 +1757,7 @@ sub stealthscanno {
         ::wordfrequencybuildwordlist($textwindow);
         searchpopup();
         getnextscanno();
-        searchtext();
+        searchtext() unless $::lglobal{regaa};    # getnextscanno has already done a search if auto-advance
     }
     $::lglobal{doscannos} = 0;
 }


### PR DESCRIPTION
When autoadvance is on for scannos, program advances through scannos until it
reaches a scanno pattern that is found in the file.
When the dialog is first popped, it also used to search for a scanno matching the
current scanno. Previously this did not matter because auto-advance was turned off
every time a new Stealth Scanno operation was done.
However, #318 turned autoadvance on by default meaning the very first pattern
that had a match did a search twice. This either skipped a potential error, or if there
was only one error of that type, it appeared as though there were none, as reported
by #355.

Fixes #355
Now does not do (second) search when dialog is popped if auto-advance is on.