### PR TITLE
Fix Greek dialog being zero-sized on Macs

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -687,7 +687,7 @@ sub initialize {
     $::positionhash{gotolinepop}      = '+400+400'        unless $::positionhash{gotolinepop};
     $::positionhash{gotopagpop}       = '+400+400'        unless $::positionhash{gotopagpop};
     $::geometryhash{gcviewoptspop}    = '+264+72'         unless $::geometryhash{gcviewoptspop};
-    $::positionhash{grpop}            = '+144+153'        unless $::positionhash{grpop};
+    $::geometryhash{grpop}            = '700x500+100+100' unless $::geometryhash{grpop};
     $::positionhash{guesspgmarkerpop} = '+10+10'          unless $::positionhash{guesspgmarkerpop};
     $::positionhash{hilitepop}        = '+150+150'        unless $::positionhash{hilitepop};
     $::positionhash{hintpop}          = '+150+150'        unless $::positionhash{hintpop};


### PR DESCRIPTION
The geometry reported by `$::lglobal{grpop}->geometry;` appears incorrect.
It shows width & height of 50x8 which are the width and height of the scrolled
text widget contained in a frame contained in grpop, when it is expected to
return the pixel width & height of the grpop dialog.

Whether this is a bug or not, and whether it is related to the Mac size issue, changing
from using positionhash to geometryhash fixed a similar issue in #204, so it's worth
a try.

Hopefully will fix #362
