### PR TITLE
Improve Unicode dialog

### DIFF
--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -136,26 +136,19 @@ sub doutfbuttons {
             my $msg = "Dec. $ord, Hex. " . sprintf( "%04X", $ord ) . ", $cname";
 
             # Use label instead of button since it takes less space
-            my $w = $::lglobal{utfframe}->Label(
-                -activebackground   => $::activecolor,
-                -text               => $text,
-                -font               => 'unicode',
-                -relief             => 'flat',
-                -borderwidth        => 0,
-                -background         => $::bkgcolor,
+            my $w = $::lglobal{utfframe}->Button(
+                -activebackground => $::activecolor,
+                -text             => $text,
+                -font             => 'unicode',
+                -relief           => 'flat',
+                -borderwidth      => 0,
+                -background       => $::bkgcolor,
+                -command => sub { insertit( $::lglobal{uoutp} eq 'h' ? "&#$ord;" : $text ); },
                 -highlightthickness => 0,
                 -width              => 1,
             )->grid( -row => $y, -column => $x );
 
-            # Show label active when cursor enters
-            $w->bind( '<Enter>', sub { $w->configure( -background => $::activecolor ); } );
-            $w->bind( '<Leave>', sub { $w->configure( -background => $::bkgcolor ); } );
-
-            # Manually bind command to be executed when clicked
-            $w->bind( '<ButtonRelease-1>',
-                sub { insertit( $::lglobal{uoutp} eq 'h' ? "&#$ord;" : $text ); } );
-
-            # Also bind Mouse-3 to copy character to clipboard
+            # Bind Mouse-3 to copy character to clipboard
             $w->bind(
                 '<ButtonPress-3>',
                 sub {

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -717,7 +717,7 @@ sub initialize {
     $::positionhash{tblfxpop}         = '+120+120'        unless $::positionhash{tblfxpop};
     $::positionhash{txtconvpop}       = '+82+131'         unless $::positionhash{txtconvpop};
     $::positionhash{utfentrypop}      = '+191+132'        unless $::positionhash{utfentrypop};
-    $::geometryhash{utfpop}           = '+46+46'          unless $::geometryhash{utfpop};
+    $::geometryhash{utfpop}           = '420x315+46+46'   unless $::geometryhash{utfpop};
     $::geometryhash{utfsearchpop}     = '550x450+53+87'   unless $::geometryhash{utfsearchpop};
     $::geometryhash{versionbox}       = '300x250+80+80'   unless $::geometryhash{versionbox};
     $::geometryhash{wfpop}            = '+365+63'         unless $::geometryhash{wfpop};


### PR DESCRIPTION
Use labels instead of buttons since they take less space.
Reorganise long top line of widgets into 2 rows, so dialog can be narrower.
Other minor code restructuring, including speeding up creation of dialog by
removing unnecessary update every time a button was added.

Fixes #364 - note no problems with geometry in this dialog