### PR TITLE
Improve HTML pagenum markup

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -925,6 +925,7 @@ sub initialize {
     $::lglobal{ordmaxlength}       = 1;
     $::lglobal{pageanch}           = 1;                           # HTML convert - add page anchors
     $::lglobal{pagecmt}            = 0;                           # HTML convert - page markers as comments
+    $::lglobal{pageskipco}         = 1;                           # HTML convert - skip coincident page markers
     $::lglobal{poetrynumbers}      = 0;                           # HTML convert - find & format poetry line numbers
     $::lglobal{regaa}              = 1;                           # Auto-advance stealth scannos
     $::lglobal{seepagenums}        = 0;

--- a/src/tests/testhtml2baseline.html
+++ b/src/tests/testhtml2baseline.html
@@ -1,5 +1,5 @@
 <body>
-<p><span class="pagenum"><a id="Page_i"></a>[Pg i]</span></p><h1>SMITHSONIAN
+<p><span class="pagenum" id="Page_i">[Pg i]</span></p><h1>SMITHSONIAN
 INSTITUTION</h1>
 
 <p class="center">[Illustration]</p>
@@ -16,7 +16,7 @@ BULLETIN 231</p>
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_ii"></a>[Pg ii]</span></p>
+<p><span class="pagenum" id="Page_ii">[Pg ii]</span></p>
 <h2 class="nobreak" id="Publications_of_the_United_States_National_Museum">Publications of the United States National Museum</h2>
 </div>
 
@@ -66,10 +66,10 @@ National Herbarium</i>.</p>
 <p class="center">For sale by the Superintendent of Documents, U.S. Government Printing Office
 Washington, D.C., 20402&mdash;Price $1.00 (Paper Cover)
 </p>
-<p><span class="pagenum"><a id="Page_iii"></a>[Pg iii]<br /><a id="Page_iv"></a>[Pg iv]</span></p>
+<p><span class="pagenum" id="Page_iv">[Pg iv]</span></p>
 <p>[Illustration: Frontispiece.&mdash;"Washington as a Surveyor." Engraving reproduced from
 Washington Irving's <i>Life of George Washington</i> (New York: 1857, vol. 1).]</p>
-<p><span class="pagenum"><a id="Page_v"></a>[Pg v]</span></p>
+<p><span class="pagenum" id="Page_v">[Pg v]</span></p>
 
 
 
@@ -90,7 +90,7 @@ and Civil Engineering</i></p>
 
 <p class="center">WASHINGTON, 1964</p>
 
-<p><span class="pagenum"><a id="Page_vi"></a>[Pg vi]<br /><a id="Page_vii"></a>[Pg vii]</span></p>
+<p><span class="pagenum" id="Page_vii">[Pg vii]</span></p>
 
 <p class="center">Contents
 </p>
@@ -131,7 +131,7 @@ Preface                                                 xi
         Delaware                                    54
         Maryland and Virginia                       54
         Pennsylvania                                58
-<span class="pagenum"><a id="Page_viii"></a>[Pg viii]</span>
+<span class="pagenum" id="Page_viii">[Pg viii]</span>
 <span class="smcap">Instruments of Wood</span>                                     65
     The Use of Wood                                   65
     Surviving Instruments                             69
@@ -167,7 +167,7 @@ Bibliography                                           172
 
 Index                                                  177
 </pre>
-<span class="pagenum"><a id="Page_ix"></a>[Pg ix]</span>
+<span class="pagenum" id="Page_ix">[Pg ix]</span>
 
 <hr class="chap" />
 
@@ -194,7 +194,7 @@ New York.</p>
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_x"></a>[Pg x]<br /><a id="Page_xi"></a>[Pg xi]</span></p>
+<p><span class="pagenum" id="Page_xi">[Pg xi]</span></p>
 <h2 class="nobreak" id="Preface">Preface</h2>
 </div>
 
@@ -239,7 +239,7 @@ consideration. In addition, such a study would require the compilation
 of an inventory of all surviving instruments in private and
 public collections, and a correlation of all the data that could be
 assembled from these sources.</p>
-<p><span class="pagenum"><a id="Page_xii"></a>[Pg xii]</span></p>
+<p><span class="pagenum" id="Page_xii">[Pg xii]</span></p>
 <p>The present study attempts only in part to accomplish this aim,
 being no more than a preliminary compilation of the scientific
 instruments known to have been used during the first two centuries
@@ -256,7 +256,7 @@ on the subject from sources not previously available or known.</p>
 <p>
 <i>February 1, 1964</i>  S.A.B.<br />
 </p>
-<p><span class="pagenum"><a id="Page_xiii"></a>[Pg xiii]</span></p>
+<p><span class="pagenum" id="Page_xiii">[Pg xiii]</span></p>
 <p class="center">EARLY AMERICAN
 SCIENTIFIC
 INSTRUMENTS</p>
@@ -267,7 +267,7 @@ INSTRUMENTS</p>
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_3"></a>[Pg 3]<br /><a id="Page_xiv"></a>[Pg xiv]</span></p>
+<p><span class="pagenum" id="Page_3">[Pg xiv]</span></p>
 <h2 class="nobreak" id="The_Tools_of_Science"><i>The Tools of Science</i></h2>
 </div>
 
@@ -306,7 +306,7 @@ the instruments themselves reveal that a considerable number of
 the instruments available and used in the Colonies before 1800
 were of native production. Apparently, relatively few instrument
 makers immigrated to the American continent before the end of the
-Revolutionary War. Later, with the beginning of the 19th century,<span class="pagenum"><a id="Page_4"></a>[Pg 4]</span>
+Revolutionary War. Later, with the beginning of the 19th century,<span class="pagenum" id="Page_4">[Pg 4]</span>
 makers of and dealers in instruments in England and France
 became aware of the growing new market, and emigrated in numbers
 to establish shops in the major cities of commerce in the
@@ -349,7 +349,7 @@ that the rule was owned and used by Nathaniel Footes, surveyor
 of Springfield, Massachusetts. Nathaniel Footes, believed to have
 been originally from Salem, subsequently moved from Springfield
 to Wethersfield, Conn. The instrument was later owned and used
-in Connecticut not later than the early 19th century<a id="FNanchor_3" href="#Footnote_3" class="fnanchor">[3]</a> by the<span class="pagenum"><a id="Page_5"></a>[Pg 5]<br /><a id="Page_6"></a>[Pg 6]</span> forbears
+in Connecticut not later than the early 19th century<a id="FNanchor_3" href="#Footnote_3" class="fnanchor">[3]</a> by the<span class="pagenum" id="Page_6">[Pg 6]</span> forbears
 of Mr. Newton C. Brainard of Hartford, Connecticut. If
 records relating to Willis as a resident of the New England colonies
 can be recovered, it may then be possible to establish whether he
@@ -401,7 +401,7 @@ sending their children thither, on the account of the reports newly reviv'd,
 because these dancing Phaenomena's were never seen nor heard of in School
 Hours.</p>
 </div></div>
-<p><span class="pagenum"><a id="Page_7"></a>[Pg 7]</span></p>
+<p><span class="pagenum" id="Page_7">[Pg 7]</span></p>
 <p>The advertisement was further amplified in its second appearance,
 in the issue of March 21-22, 1719:</p>
 
@@ -447,7 +447,7 @@ of boundary lines a prime issue in the everyday life of colonial
 homes."</p>
 
 <p>At the same time there was interest in the other aspects of the
-<span class="pagenum"><a id="Page_8"></a>[Pg 8]</span>mathematical sciences. As early as 1743, for instance, a Harvard
+<span class="pagenum" id="Page_8">[Pg 8]</span>mathematical sciences. As early as 1743, for instance, a Harvard
 mathematician named Nathan Prince advertised in Boston that
 if he were given "suitable Encouragement" he would establish a
 school to teach "Geography and Astronomy, With the Use of the
@@ -492,7 +492,7 @@ men, or "mathematical practitioners," of the period.</p>
 
 <p>One may well ask, where did these native craftsmen acquire the
 knowledge that enabled them to produce so skillfully the accurate
-and often delicate mathematical instruments? There were a<span class="pagenum"><a id="Page_9"></a>[Pg 9]<br /><a id="Page_10"></a>[Pg 10]</span>
+and often delicate mathematical instruments? There were a<span class="pagenum" id="Page_10">[Pg 10]</span>
 number of possible sources for this knowledge. The first source
 lies in England, where some of these craftsmen could have studied
 or served apprenticeships. After completing their apprenticeship
@@ -542,7 +542,7 @@ to prove it.</p>
 <p>Another important influence on early American instrument-making
 which must be noted was that of the clockmaker as an
 artisan. A comprehensive study of surviving instruments and
-related records has revealed that only a few of the many cl<span class="pagenum"><a id="Page_11"></a>[Pg 11]</span>ockmakers
+related records has revealed that only a few of the many cl<span class="pagenum" id="Page_11">[Pg 11]</span>ockmakers
 working in the American Colonies in the 18th century made
 mathematical instruments. Yet, a large proportion of the surviving
 surveying and nautical instruments produced before 1800 were
@@ -557,11 +557,11 @@ family, whose clockmaking traditions began early in the 17th century
 the observation of the transit of Venus in 1769. Brass, 33-1/2-in. tube on a 25-in.
 axis, with an aperture of 1-3/4 in. and a focal length of 32 in. Photo courtesy
 the American Philosophical Society.]</p>
-<p><span class="pagenum"><a id="Page_12"></a>[Pg 12]</span></p>
+<p><span class="pagenum" id="Page_12">[Pg 12]</span></p>
 <p>[Illustration: Figure 4.&mdash;Surveying compass marked "Potts and Rittenhouse." Believed to be
 the work of David Rittenhouse in partnership with Thomas Potts. Photo
 courtesy the American Philosophical Society.]</p>
-<p><span class="pagenum"><a id="Page_13"></a>[Pg 13]</span></p>
+<p><span class="pagenum" id="Page_13">[Pg 13]</span></p>
 <p>Finally, one must not overlook the fact that examples of English
 and other European instruments were available in the Colonies,
 and that at least some of the early colonial makers undoubtedly
@@ -593,13 +593,13 @@ beginning of the 19th century. Since instruments are not items
 which would ordinarily be deliberately discarded or destroyed, or
 melted down for the recovery of the metal, this small percentage
 of survival presents a puzzle which has not been resolved.</p>
-<p><span class="pagenum"><a id="Page_14"></a>[Pg 14]</span></p>
+<p><span class="pagenum" id="Page_14">[Pg 14]</span></p>
 <p>[Illustration: Figure 5.&mdash;David Rittenhouse. Engraving from portrait by Charles Wilson Peale.]</p>
 
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_15"></a>[Pg 15]</span></p>
+<p><span class="pagenum" id="Page_15">[Pg 15]</span></p>
 <h2 class="nobreak" id="The_Mathematical_Practitioners"><i>The Mathematical Practitioners</i></h2>
 </div>
 
@@ -644,7 +644,7 @@ Worcester township, Montgomery county. Benjamin Rittenhouse.</p>
 </div>
 
 <p>[Illustration: Figure 6.&mdash;Astronomical clock made by David Rittenhouse
-<span class="pagenum"><a id="Page_16"></a>[Pg 16]</span>for his observatory at Norristown, Pa., and used by him for the
+<span class="pagenum" id="Page_16">[Pg 16]</span>for his observatory at Norristown, Pa., and used by him for the
 observation of the transit of Venus in 1769. Unembellished
 pine case 83-1/2 in. high, 13-1/4 in. wide at the waist with a
 silvered brass dial 10-5/8 in. diameter. Photo courtesy the
@@ -660,9 +660,9 @@ was made by John Folwell.]</p>
 <p>[Illustration: Figure 8.&mdash;Brass surveying compass inscribed "Made by
 Benjamin Rittenhouse, 1787." Photo courtesy Ohio State
 Museum, Columbus, Ohio.]</p>
-<p><span class="pagenum"><a id="Page_17"></a>[Pg 17]<br /><a id="Page_18"></a>[Pg 18]</span></p>
+<p><span class="pagenum" id="Page_18">[Pg 18]</span></p>
 <p>[Illustration: Figure 9.&mdash;Portrait of Andrew Ellicott (1754-1820) by unknown artist.]</p>
-<p><span class="pagenum"><a id="Page_19"></a>[Pg 19]</span></p>
+<p><span class="pagenum" id="Page_19">[Pg 19]</span></p>
 
 <p>Andrew Ellicott</p>
 
@@ -711,7 +711,7 @@ he was engaged for the major part of the following year.</p>
 <p>In 1815 President Madison appointed Ellicott professor of
 mathematics at West Point, with the rank of major. This is an
 appointment he kept until his death in 1820. It was interrupted
-in 1817 when the Government required his services as astronomer<span class="pagenum"><a id="Page_20"></a>[Pg 20]<br /><a id="Page_21"></a>[Pg 21]</span>
+in 1817 when the Government required his services as astronomer<span class="pagenum" id="Page_21">[Pg 21]</span>
 to locate a portion of the United States-Canadian boundary in
 accordance with the fifth article of the Treaty of Ghent.</p>
 
@@ -772,7 +772,7 @@ repentance, he was permitted to rejoin the Society of Friends.</p>
 the American Philosophical Society for the observation of the
 transit of Venus. With Joel Baily he was sent to Cape Henlopen,
 Delaware, with a large reflecting telescope borrowed from the
-Library Company. The expedition was described in the <i>Trans<span class="pagenum"><a id="Page_22"></a>[Pg 22]</span>actions
+Library Company. The expedition was described in the <i>Trans<span class="pagenum" id="Page_22">[Pg 22]</span>actions
 of the American Philosophical Society</i> in 1771 in an article entitled
 "An Account of the Transit of Venus, over the Sun's Disk, as
 observed near Cape Henlopen, on Delaware Bay, June 3rd, 1769
@@ -815,7 +815,7 @@ Andrew's cousin, as a subject of possible interest. Apparently
 George Ellicott turned it over to the Honorable James McHenry
 of Baltimore, who in turned submitted it to the Philadelphia firm
 of Goddard &amp; Angell, who published it (fig. 13). Banneker mailed
-a copy of his <i>Benjamin Banneker's Pennsylvania, Delaware, Vir<span class="pagenum"><a id="Page_23"></a>[Pg 23]<br /><a id="Page_24"></a>[Pg 24]</span>ginia
+a copy of his <i>Benjamin Banneker's Pennsylvania, Delaware, Vir<span class="pagenum" id="Page_24">[Pg 24]</span>ginia
 And Maryland Almanac and Ephemeris For the Year of Our
 Lord, 1792</i> to Thomas Jefferson, who was so impressed with it
 that he forwarded it to the Marquis de Condorcet, secretary of the
@@ -859,7 +859,7 @@ Philosophical Society.</p>
 
 <p>Another noteworthy mathematical practitioner of the period was
 the Reverend John Prince (1751-1836) of Salem, Massachusetts.
-The son of a hatter and mechanic, Prince studied natural phil<span class="pagenum"><a id="Page_25"></a>[Pg 25]<br /><a id="Page_26"></a>[Pg 26]</span>osophy
+The son of a hatter and mechanic, Prince studied natural phil<span class="pagenum" id="Page_26">[Pg 26]</span>osophy
 under John Winthrop at Harvard and received his B.A.
 degree in 1776. He was a student of divinity under Samuel
 Williams and was ordained in 1779 at the First Church in Salem.
@@ -890,7 +890,7 @@ some for his pupils and some for others."<a id="FNanchor_14" href="#Footnote_14"
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_27"></a>[Pg 27]</span></p><h2 class="nobreak" id="Instruments_of_Metal">Instruments of Metal</h2>
+<p><span class="pagenum" id="Page_27">[Pg 27]</span></p><h2 class="nobreak" id="Instruments_of_Metal">Instruments of Metal</h2>
 </div>
 
 
@@ -941,7 +941,7 @@ eight o'clock, for the Entertainment of the Curious, the Magic Lanthorn
 an Optick Machine, which exhibits a great Number of wonderful and surprising
 Figures, prodigious large, and vivid, at Half a Crown each, Old Tenor.</p>
 </div>
-<p><span class="pagenum"><a id="Page_28"></a>[Pg 28]</span></p>
+<p><span class="pagenum" id="Page_28">[Pg 28]</span></p>
 <p>In New York City, one of the earliest immigrant instrument
 makers was Charles Walpole, who established a shop at a corner in
 Wall Street, according to a notice in the May 26, 1746, issue of the
@@ -991,7 +991,7 @@ instruments for sea or land, by wholesale or retail at reasonable rates.<a id="F
 
 <p>Lamb had served an apprenticeship with Henry Carter, a
 mathematical  instrument maker in  London. In July 1724 he
-became an accomplice of Jack Sheppard, a notorious burglar<span class="pagenum"><a id="Page_29"></a>[Pg 29]</span>, and
+became an accomplice of Jack Sheppard, a notorious burglar<span class="pagenum" id="Page_29">[Pg 29]</span>, and
 was arrested and sentenced to the gallows in 1724. As he was
 awaiting execution on the gallows at Tyburn, his sentence was
 commuted to transportation to Virginia for a period of seven
@@ -1059,7 +1059,7 @@ Historical Society.</p>
 Research, Bulletin 31</i> (University of Illinois, 1925), p. 28.</p>
 
 </div>
-<p><span class="pagenum"><a id="Page_30"></a>[Pg 30]</span></p>
+<p><span class="pagenum" id="Page_30">[Pg 30]</span></p>
 <div class="footnote">
 
 <p><a id="Footnote_5" href="#FNanchor_5" class="label">[5]</a> <span class="smcap">H. H. Schoen</span>, "The Making of Maps and Charts," <i>Ninth Yearbook of the
@@ -1149,7 +1149,7 @@ of General John Lamb</i> (Albany: Munsell, 1850); <span class="smcap">Silvio A. 
 Review</i> (New Haven: Walker-Rackliffe, 1958), pp. 71, 84.</p>
 
 </div>
-<p><span class="pagenum"><a id="Page_31"></a>[Pg 31]</span></p>
+<p><span class="pagenum" id="Page_31">[Pg 31]</span></p>
 
 
 <p>Index</p>

--- a/src/tests/testhtml3baseline.html
+++ b/src/tests/testhtml3baseline.html
@@ -1,5 +1,5 @@
 <body>
-<p><span class="pagenum"><a id="Page_1"></a>[Pg 1]<br /><a id="Page_2"></a>[Pg 2]</span></p>
+<p><span class="pagenum" id="Page_2">[Pg 2]</span></p>
 
 <p>
 
@@ -28,7 +28,7 @@
 
 
 
-<p><span class="pagenum"><a id="Page_3"></a>[Pg 3]</span></p>
+<p><span class="pagenum" id="Page_3">[Pg 3]</span></p>
 <h1>THE STREETS OF ASCALON</h1>
 
 
@@ -88,12 +88,12 @@ Hide and Seek in Forest-Land<br />
 <p class="center"><span class="smcap">D. APPLETON AND COMPANY, New York</span>
 </p>
 
-<p><span class="pagenum"><a id="Page_4"></a>[Pg 4]<br /><a id="Page_5"></a>[Pg 5]</span></p>
+<p><span class="pagenum" id="Page_5">[Pg 5]</span></p>
 
 <p>[Illustration: "She excused the witness and turned her back to the
 looking-glass."]</p>
 
-<p><span class="pagenum"><a id="Page_6"></a>[Pg 6]</span></p>
+<p><span class="pagenum" id="Page_6">[Pg 6]</span></p>
 
 
 
@@ -124,7 +124,7 @@ Richard Quarren, Esq<sup>r.</sup>{e.}</i></p>
 
 <p class="center">1912</p>
 
-<p><span class="pagenum"><a id="Page_7"></a>[Pg 7]</span></p>
+<p><span class="pagenum" id="Page_7">[Pg 7]</span></p>
 
 
 
@@ -142,7 +142,7 @@ Richard Quarren, Esq<sup>r.</sup>{e.}</i></p>
 <p class="center">Printed in the United States of America
 </p>
 
-<p><span class="pagenum"><a id="Page_8"></a>[Pg 8]</span></p>
+<p><span class="pagenum" id="Page_8">[Pg 8]</span></p>
 
 
 
@@ -155,7 +155,7 @@ Richard Quarren, Esq<sup>r.</sup>{e.}</i></p>
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_9"></a>[Pg 9]<br /><a id="Page_10"></a>[Pg 10]</span></p>
+<p><span class="pagenum" id="Page_10">[Pg 10]</span></p>
 
 <h2 class="nobreak" id="LIST_OF_ILLUSTRATIONS">LIST OF ILLUSTRATIONS</h2>
 </div>
@@ -191,7 +191,7 @@ Richard Quarren, Esq<sup>r.</sup>{e.}</i></p>
 <br />
 <span style="margin-left: 1em;">"'Never mind geography, child; tell me about</span><br />
 <span style="margin-left: 1em;">the men!'"&nbsp; &nbsp; &nbsp; 116-117</span><br />
-<span class="pagenum"><a id="Page_11"></a>[Pg 11]</span><br />
+<span class="pagenum" id="Page_11">[Pg 11]</span><br />
 <span style="margin-left: 1em;">"Strelsa, curled up on a divan ... listened to</span><br />
 <span style="margin-left: 1em;">his departure with quiet satisfaction"&nbsp; &nbsp; &nbsp; 126-127</span><br />
 <br />
@@ -227,7 +227,7 @@ Richard Quarren, Esq<sup>r.</sup>{e.}</i></p>
 <br />
 <span style="margin-left: 1em;">"She came about noon&mdash;a pale young girl, very</span><br />
 <span style="margin-left: 1em;">slim in her limp black gown"&nbsp; &nbsp; &nbsp; 280-281</span><br />
-<span class="pagenum"><a id="Page_12"></a>[Pg 12]</span><br />
+<span class="pagenum" id="Page_12">[Pg 12]</span><br />
 <span style="margin-left: 1em;">Jessie Vining&nbsp; &nbsp; &nbsp; 290-291</span><br />
 <br />
 <span style="margin-left: 1em;">"'In the evenings sometimes Miss Vining remains</span><br />
@@ -249,14 +249,14 @@ Richard Quarren, Esq<sup>r.</sup>{e.}</i></p>
 <span style="margin-left: 1em;">feebly"&nbsp; &nbsp; &nbsp; 424-425</span><br />
 </p>
 
-<p><span class="pagenum"><a id="Page_13"></a>[Pg 13]</span></p>
+<p><span class="pagenum" id="Page_13">[Pg 13]</span></p>
 
 
 <p class="center">"<i>Tell it not in Gath, publish it not
 in the streets of Ascalon.</i>"
 </p>
 
-<p><span class="pagenum"><a id="Page_14"></a>[Pg 14]</span></p>
+<p><span class="pagenum" id="Page_14">[Pg 14]</span></p>
 
 <p>THE STREETS OF ASCALON</p>
 
@@ -268,7 +268,7 @@ in the streets of Ascalon.</i>"
 </div>
 
 
-<p><span class="pagenum"><a id="Page_15"></a>[Pg 15]<br /><a id="Page_16"></a>[Pg 16]<br /><a id="Page_17"></a>[Pg 17]<br /><a id="Page_18"></a>[Pg 18]<br /><a id="Page_19"></a>[Pg 19]<br /><a id="Page_20"></a>[Pg 20]<br /><a id="Page_21"></a>[Pg 21]<br /><a id="Page_22"></a>[Pg 22]<br /><a id="Page_23"></a>[Pg 23]<br /><a id="Page_24"></a>[Pg 24]<br /><a id="Page_25"></a>[Pg 25]<br /><a id="Page_26"></a>[Pg 26]<br /><a id="Page_27"></a>[Pg 27]<br /><a id="Page_28"></a>[Pg 28]<br /><a id="Page_29"></a>[Pg 29]<br /><a id="Page_30"></a>[Pg 30]<br /><a id="Page_31"></a>[Pg 31]<br /><a id="Page_32"></a>[Pg 32]<br /><a id="Page_33"></a>[Pg 33]<br /><a id="Page_34"></a>[Pg 34]<br /><a id="Page_35"></a>[Pg 35]<br /><a id="Page_36"></a>[Pg 36]<br /><a id="Page_37"></a>[Pg 37]<br /><a id="Page_38"></a>[Pg 38]<br /><a id="Page_39"></a>[Pg 39]<br /><a id="Page_40"></a>[Pg 40]<br /><a id="Page_41"></a>[Pg 41]<br /><a id="Page_42"></a>[Pg 42]<br /><a id="Page_43"></a>[Pg 43]<br /><a id="Page_44"></a>[Pg 44]<br /><a id="Page_45"></a>[Pg 45]<br /><a id="Page_46"></a>[Pg 46]<br /><a id="Page_47"></a>[Pg 47]<br /><a id="Page_48"></a>[Pg 48]<br /><a id="Page_49"></a>[Pg 49]<br /><a id="Page_50"></a>[Pg 50]<br /><a id="Page_51"></a>[Pg 51]<br /><a id="Page_52"></a>[Pg 52]<br /><a id="Page_53"></a>[Pg 53]<br /><a id="Page_54"></a>[Pg 54]<br /><a id="Page_55"></a>[Pg 55]<br /><a id="Page_56"></a>[Pg 56]<br /><a id="Page_57"></a>[Pg 57]<br /><a id="Page_58"></a>[Pg 58]<br /><a id="Page_59"></a>[Pg 59]<br /><a id="Page_60"></a>[Pg 60]<br /><a id="Page_61"></a>[Pg 61]<br /><a id="Page_62"></a>[Pg 62]<br /><a id="Page_63"></a>[Pg 63]<br /><a id="Page_64"></a>[Pg 64]<br /><a id="Page_65"></a>[Pg 65]<br /><a id="Page_66"></a>[Pg 66]<br /><a id="Page_67"></a>[Pg 67]<br /><a id="Page_68"></a>[Pg 68]<br /><a id="Page_69"></a>[Pg 69]<br /><a id="Page_70"></a>[Pg 70]<br /><a id="Page_71"></a>[Pg 71]<br /><a id="Page_72"></a>[Pg 72]<br /><a id="Page_73"></a>[Pg 73]<br /><a id="Page_74"></a>[Pg 74]<br /><a id="Page_75"></a>[Pg 75]<br /><a id="Page_76"></a>[Pg 76]<br /><a id="Page_77"></a>[Pg 77]<br /><a id="Page_78"></a>[Pg 78]<br /><a id="Page_79"></a>[Pg 79]<br /><a id="Page_80"></a>[Pg 80]<br /><a id="Page_81"></a>[Pg 81]<br /><a id="Page_82"></a>[Pg 82]<br /><a id="Page_83"></a>[Pg 83]<br /><a id="Page_84"></a>[Pg 84]<br /><a id="Page_85"></a>[Pg 85]<br /><a id="Page_86"></a>[Pg 86]<br /><a id="Page_87"></a>[Pg 87]<br /><a id="Page_88"></a>[Pg 88]<br /><a id="Page_89"></a>[Pg 89]<br /><a id="Page_90"></a>[Pg 90]<br /><a id="Page_91"></a>[Pg 91]<br /><a id="Page_92"></a>[Pg 92]<br /><a id="Page_93"></a>[Pg 93]<br /><a id="Page_94"></a>[Pg 94]<br /><a id="Page_95"></a>[Pg 95]<br /><a id="Page_96"></a>[Pg 96]<br /><a id="Page_97"></a>[Pg 97]<br /><a id="Page_98"></a>[Pg 98]<br /><a id="Page_99"></a>[Pg 99]<br /><a id="Page_100"></a>[Pg 100]<br /><a id="Page_101"></a>[Pg 101]<br /><a id="Page_102"></a>[Pg 102]<br /><a id="Page_103"></a>[Pg 103]<br /><a id="Page_104"></a>[Pg 104]<br /><a id="Page_105"></a>[Pg 105]<br /><a id="Page_106"></a>[Pg 106]<br /><a id="Page_107"></a>[Pg 107]<br /><a id="Page_108"></a>[Pg 108]<br /><a id="Page_109"></a>[Pg 109]<br /><a id="Page_110"></a>[Pg 110]<br /><a id="Page_111"></a>[Pg 111]<br /><a id="Page_112"></a>[Pg 112]<br /><a id="Page_113"></a>[Pg 113]<br /><a id="Page_114"></a>[Pg 114]<br /><a id="Page_115"></a>[Pg 115]</span></p>
+<p><span class="pagenum" id="Page_115">[Pg 115]</span></p>
 
 <p>The next night a note was delivered to him, written from the Wycherlys'
 car, "Wind-Flower."</p>
@@ -282,7 +282,7 @@ car, "Wind-Flower."</p>
 <p>"Why did you not come back to say good-bye? You spoke of doing so.
 I'm afraid Chrysos Lacy is responsible.</p>
 
-<p><span class="pagenum"><a id="Page_116"></a>[Pg 116]</span></p>
+<p><span class="pagenum" id="Page_116">[Pg 116]</span></p>
 
 <p>"The dance at the Van Dynes was very jolly. I am exceedingly sorry
 you were not there. Thank you for the flowers and bon-bons that
@@ -327,7 +327,7 @@ grrapes'!</p>
 "<span class="smcap">Strelsa Leeds</span>."<br />
 </p>
 
-<p><span class="pagenum"><a id="Page_117"></a>[Pg 117]</span></p>
+<p><span class="pagenum" id="Page_117">[Pg 117]</span></p>
 
 <p>That same day Sir Charles Mallison arrived in New York and went directly
 to Mrs. Sprowl's house. Their interview was rather brief but loudly
@@ -373,12 +373,12 @@ Charles."</p>
 which sometimes characterised her.... "And now what do you propose to do
 with the rest of 'em? Dawdle away your time?"</p>
 
-<p><span class="pagenum"><a id="Page_118"></a>[Pg 118]<br /><a id="Page_119"></a>[Pg 119]</span></p>
+<p><span class="pagenum" id="Page_119">[Pg 119]</span></p>
 
 <p>[Illustration: "'Is&mdash;Mrs. Leeds&mdash;well?' he ventured at length, reddening
 again."]</p>
 
-<p><span class="pagenum"><a id="Page_120"></a>[Pg 120]<br /><a id="Page_121"></a>[Pg 121]<br /><a id="Page_122"></a>[Pg 122]</span></p>
+<p><span class="pagenum" id="Page_122">[Pg 122]</span></p>
 
 <p>"Face my fate," he admitted touching his moustache and fearfully
 embarrassed.</p>
@@ -413,7 +413,7 @@ sober-faced man of forty-five whom she was serving with all the craft
 and insolence and brutality and generosity that was in her&mdash;it was the
 son of a dead man who had been much to her. How much nobody in these
 days gossiped about any longer, for it was a long time ago, a long, long
-time ago that she had made her curtsey to<span class="pagenum"><a id="Page_123"></a>[Pg 123]</span> a young queen and a prince
+time ago that she had made her curtsey to<span class="pagenum" id="Page_123">[Pg 123]</span> a young queen and a prince
 consort. And Sir Charles's father had died at Majuba Hill.</p>
 
 <p>"There's a wretched little knock-kneed peer on the cards," she observed;
@@ -438,7 +438,7 @@ you a letter to her in the morning."</p>
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_124"></a>[Pg 124]</span></p>
+<p><span class="pagenum" id="Page_124">[Pg 124]</span></p>
 
 <h2 class="nobreak" id="CHAPTER_IV">CHAPTER IV</h2>
 </div>
@@ -469,7 +469,7 @@ people have jollied him rather cruelly.</p>
 <p>"The Sarnoffs on the other hand are modest and nice people&mdash;the
 Prince is a yellow, dried-up Asiatic who is making a collection of
 parasites&mdash;a shrewd, kindly, and clever little scientist. His wife
-is a charming girl, intellectual but deliciously feminine. She was<span class="pagenum"><a id="Page_125"></a>[Pg 125]</span>
+is a charming girl, intellectual but deliciously feminine. She was<span class="pagenum" id="Page_125">[Pg 125]</span>
 Cynthia Challis before her marriage, and always a most attractive
 and engaging personality. They dined with us at the Legation on
 Thursday.</p>
@@ -501,7 +501,7 @@ scribbling lunatic who doesn't know what he's writing, and that she
 washes her fat and gem-laden hands of him henceforth.</p>
 
 <p>"Poor Karl! He's already thirty-seven; he's written fifteen books,
-no one of which, he tells me, ever before<span class="pagenum"><a id="Page_126"></a>[Pg 126]</span> stirred up anybody's
+no one of which, he tells me, ever before<span class="pagenum" id="Page_126">[Pg 126]</span> stirred up anybody's
 interest. But this newest novel, 'The Real Thing,' has already gone
 into three editions in two weeks&mdash;whatever that actually means&mdash;and
 still the re-orders are pouring in, and his publishers are madly
@@ -532,7 +532,7 @@ they permit nobody to mistake the supposed tribute which they are
 entirely self-persuaded that the novelist has offered to them.</p>
 
 <p>"And these phases of 'The Real Thing' are fretting and mortifying
-Karl to the verge of distraction. He<span class="pagenum"><a id="Page_127"></a>[Pg 127]</span> awakes to find himself not
+Karl to the verge of distraction. He<span class="pagenum" id="Page_127">[Pg 127]</span> awakes to find himself not
 famous but notorious&mdash;not criticised for his workmanship, good or
 bad, but gabbled about because some ludicrous old Uncle Foozle
 pretends to discover a similarity between Karl's episodes and
@@ -566,7 +566,7 @@ answer by underlining your request.</p>
 
 <p>"Proud and flattered by your generous interest I hasten to inform
 you that I am leading the same useful, serious, profitable,
-purposeful, ambitious, and en<span class="pagenum"><a id="Page_128"></a>[Pg 128]</span>nobling life which I was leading when
+purposeful, ambitious, and en<span class="pagenum" id="Page_128">[Pg 128]</span>nobling life which I was leading when
 I first met you. Such a laudable existence makes for one's
 self-respect; and, happy in that consciousness, undisturbed by
 journalistic accusations concerning marmosets and vulgarity, I
@@ -602,7 +602,7 @@ acquaintance.</p>
 I'd like to talk to you about it, some day. Mr. Westguard's intense
 bitterness confuses me a little, and seems almost to paralyse any
 critical judgment I may possess. A crusade in fiction has always
-seemed to me but a sterile effort. To do a thing is fine;<span class="pagenum"><a id="Page_129"></a>[Pg 129]</span> to talk
+seemed to me but a sterile effort. To do a thing is fine;<span class="pagenum" id="Page_129">[Pg 129]</span> to talk
 about it in fiction a far less admirable performance&mdash;like the
 small boy, safe in the window, who defies his enemy with out-thrust
 tongue.</p>
@@ -636,7 +636,7 @@ wholesome scourging now and then, but somehow, it seems to me, that
 it could be done less bitterly and with better grace than Mr.
 Westguard does it in his book. The lash, swung from within, and
 applied with judgment and discrimination, ought to do a more
-thorough and convincing piece of work than a<span class="pagenum"><a id="Page_130"></a>[Pg 130]</span> knout allied with the
+thorough and convincing piece of work than a<span class="pagenum" id="Page_130">[Pg 130]</span> knout allied with the
 clubs of the proletariat, hitting at every head in sight.</p>
 
 <p>"Let the prophets and sybils, the augurs and oracles of the <i>Hoi
@@ -669,7 +669,7 @@ rubbish, or that I am flattered by letters from a nobody?</p>
 
 <p>"What do you suppose there is attractive about you, Mr. Quarren&mdash;if
 you really do amount to as little as you pretend? I've seen
-handsomer men, monsieur,<span class="pagenum"><a id="Page_131"></a>[Pg 131]</span> wealthier men, more intelligent men; men
+handsomer men, monsieur,<span class="pagenum" id="Page_131">[Pg 131]</span> wealthier men, more intelligent men; men
 more experienced, men of far greater talents and attainments.</p>
 
 <p>"Why do you suppose that I sit here in the Southern sunshine
@@ -704,7 +704,7 @@ commodity at me?</p>
 
 <p>"To be asked to marry a man no longer distresses me. I am all over
 the romantic idea of being sorry for wealthy amateurs who make me a
-plain business propo<span class="pagenum"><a id="Page_132"></a>[Pg 132]</span>sition, offering to invest a fortune in my
+plain business propo<span class="pagenum" id="Page_132">[Pg 132]</span>sition, offering to invest a fortune in my
 good looks. To amateurs, connoisseurs, and collectors, there is no
 such thing as a fixed market value to anything. An object of art is
 worth what it can be bought for. I don't yet know how much I am
@@ -743,7 +743,7 @@ world at large believed the contrary.</p>
 
 <p>Southern news also revealed the interesting item that the yacht,
 <i>Yulan</i>, belonging to Mrs. Sprowl's hatchet-faced nephew, Langly Sprowl,
-had sailed from<span class="pagenum"><a id="Page_133"></a>[Pg 133]</span> Miami for the West Indies with the owner and Mrs. Leeds
+had sailed from<span class="pagenum" id="Page_133">[Pg 133]</span> Miami for the West Indies with the owner and Mrs. Leeds
 and Sir Charles Mallison among the guests.</p>
 
 <p>The <i>Yulan</i> had not as fragrant a reputation as its exotic name might
@@ -777,7 +777,7 @@ personally conducted him all over Tappan-Zee Park on the Hudson, through
 mud and slush in a skidding touring car, with the result that the man
 had become a pioneer and had promised to purchase a building site.</p>
 
-<p>So Quarren came back to the Legation that after<span class="pagenum"><a id="Page_134"></a>[Pg 134]<br /><a id="Page_135"></a>[Pg 135]<br /><a id="Page_136"></a>[Pg 136]</span>noon feeling almost
+<p>So Quarren came back to the Legation that after<span class="pagenum" id="Page_136">[Pg 136]</span>noon feeling almost
 buoyant, and discovered Westguard in all kinds of temper, smoking a huge
 faïence pipe which he always did when angry, and which had become known
 as "The Weather-breeder."</p>
@@ -817,7 +817,7 @@ make a decent and honourable living!"</p>
 <p>"Do those reasons prevent my having a message to deliver?" roared
 Westguard.</p>
 
-<p><span class="pagenum"><a id="Page_137"></a>[Pg 137]</span></p>
+<p><span class="pagenum" id="Page_137">[Pg 137]</span></p>
 
 <p>"No, they exist in spite of it. You'd write anyway, whether or not you
 believed you had a message to deliver. You've written some fifteen
@@ -855,7 +855,7 @@ that he does collect one."</p>
 <p>"Exactly," nodded Quarren. "Get your people, then keep 'em interested
 and unsuspecting while you inject 'em full of thinks."</p>
 
-<p><span class="pagenum"><a id="Page_138"></a>[Pg 138]</span></p>
+<p><span class="pagenum" id="Page_138">[Pg 138]</span></p>
 
 <p>Westguard smoked and pondered; but presently his lips became stern and
 compressed.</p>
@@ -890,7 +890,7 @@ that they get there with their burden."</p>
 don't&mdash;for you use them ignobly, when you do not utterly neglect
 them&mdash;&mdash;"</p>
 
-<p>"I've a light and superficial talent for entertaining<span class="pagenum"><a id="Page_139"></a>[Pg 139]</span> people; I've
+<p>"I've a light and superficial talent for entertaining<span class="pagenum" id="Page_139">[Pg 139]</span> people; I've
 nimble legs, and possess a low order of intelligence known as 'tact.'
 What more have I?"</p>
 
@@ -923,7 +923,7 @@ account of me; fewer scandals.</p>
 advise&mdash;sometimes I plan and execute; even take the initiative and
 interfere&mdash;as when a foolish boy at the Cataract Club, last week, locked
 himself into the bath-room with an automatic revolver and a case of
-half-drunken fright. I had to be very careful;<span class="pagenum"><a id="Page_140"></a>[Pg 140]</span> I expected to hear that
+half-drunken fright. I had to be very careful;<span class="pagenum" id="Page_140">[Pg 140]</span> I expected to hear that
 drumming fusillade at any moment.</p>
 
 <p>"But I talked to him, through the keyhole: and at last he opened the
@@ -961,7 +961,7 @@ satisfaction&mdash;"my aunt bellowing so that her footmen actually fled, and
 I doing the cool and haughty, and letting her bellow her bally head
 off."</p>
 
-<p><span class="pagenum"><a id="Page_141"></a>[Pg 141]</span></p>
+<p><span class="pagenum" id="Page_141">[Pg 141]</span></p>
 
 <p>"You and she have exchanged civilities before," said Quarren, smiling.</p>
 
@@ -1000,7 +1000,7 @@ self-respecting exercise of my profession&mdash;" His voice ended in a
 gurgling growl. Then, as though the recollections of his injuries at the
 hands of his aunt still stung him, he reared up in his chair:</p>
 
-<p><span class="pagenum"><a id="Page_142"></a>[Pg 142]</span></p>
+<p><span class="pagenum" id="Page_142">[Pg 142]</span></p>
 
 <p>"Chrysos Lacy," he roared, "is a sweet, innocent girl&mdash;not a bale of
 fashionable merchandise! Besides," he added in a modified tone, "I was
@@ -1037,7 +1037,7 @@ to suggest it to her. You know, after all, Mrs. Leeds may have ideas of
 her own."</p>
 
 <p>"Probably she has," admitted Westguard, sulkily. "I don't imagine she'd
-care for a man of my sort. Why<span class="pagenum"><a id="Page_143"></a>[Pg 143]</span> do you suppose she went off on that
+care for a man of my sort. Why<span class="pagenum" id="Page_143">[Pg 143]</span> do you suppose she went off on that
 cruise with Langly Sprowl?"</p>
 
 <p>Quarren said, gravely: "I have no idea what reasons Mrs. Leeds has for
@@ -1081,7 +1081,7 @@ my cousin. And he knows I think so."</p>
 <p>A few minutes later O'Hara sauntered in. He had been riding in the Park
 and his boots and spurs were shockingly muddy.</p>
 
-<p><span class="pagenum"><a id="Page_144"></a>[Pg 144]</span></p>
+<p><span class="pagenum" id="Page_144">[Pg 144]</span></p>
 
 <p>"Who is this Sir Charles Mallison, anyway?" he asked, using the decanter
 and then squirting his glass full of carbonic. "Is it true that he's
@@ -1118,7 +1118,7 @@ only," said Quarren.</p>
 
 <p>"Why? Aren't there plenty of scandalous&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_145"></a>[Pg 145]</span></p>
+<p><span class="pagenum" id="Page_145">[Pg 145]</span></p>
 
 <p>"Plenty. But no more than in any other set or coterie; not as many as
 there are among more ignorant people. Virtue far outbalances vice among
@@ -1160,7 +1160,7 @@ enough to let her go?"</p>
 
 <p>"Get out, you old Roundhead!" said Quarren, laughing. He rose, laid his
 hand lightly on Westguard's shoulder in passing, and went upstairs to
-his room, where he wrote a long letter to Strelsa; and then<span class="pagenum"><a id="Page_146"></a>[Pg 146]</span> destroyed
+his room, where he wrote a long letter to Strelsa; and then<span class="pagenum" id="Page_146">[Pg 146]</span> destroyed
 it. Then he lay down, covering his boyish head with his arms.</p>
 
 <p>When Lacy came in he saw him lying on the bed, and thought he was
@@ -1168,7 +1168,7 @@ asleep.</p>
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_147"></a>[Pg 147]</span></p>
+<p><span class="pagenum" id="Page_147">[Pg 147]</span></p>
 
 <h2 class="nobreak" id="CHAPTER_V">CHAPTER V</h2>
 </div>
@@ -1198,7 +1198,7 @@ features showed it.</p>
 <p>But nervous exhaustion alone could not account for the subtle change in
 her expression. Eyes and lips were still sweet, even in repose, but
 there was now a jaded charm about them&mdash;something unspoiled had
-dis<span class="pagenum"><a id="Page_148"></a>[Pg 148]</span>appeared from them&mdash;something of that fearlessness which vanishes
+dis<span class="pagenum" id="Page_148">[Pg 148]</span>appeared from them&mdash;something of that fearlessness which vanishes
 after too close and too constant contact with the world of men.</p>
 
 <p>Evidently her mind was quite as weary as her body, though even to
@@ -1229,7 +1229,7 @@ Sprowl.</p>
 others&mdash;sometimes alone with him on deck&mdash;and never quite understood how
 it came about so constantly.</p>
 
-<p><span class="pagenum"><a id="Page_149"></a>[Pg 149]</span></p>
+<p><span class="pagenum" id="Page_149">[Pg 149]</span></p>
 
 <p>As for Sprowl he made love to her from the first; and he was a trim,
 carefully groomed and volubly animated young man, full of information,
@@ -1262,7 +1262,7 @@ she found wholesome laughter a good defence; but there was an
 under-current of intelligent, relentless vigour in his attack which
 presently sobered her. And she vaguely realised that he was a man who
 knew what he wanted. A talk with Molly Wycherly sobered her still more;
-and she<span class="pagenum"><a id="Page_150"></a>[Pg 150]</span> avoided him as politely as she could. But, being her host, it
+and she<span class="pagenum" id="Page_150">[Pg 150]</span> avoided him as politely as she could. But, being her host, it
 was impossible to keep clear of him. Besides there was about him a
 certain unwholesome fascination, even for her. No matter how bad a man's
 record may be, few women doubt their ability to make it a better one.</p>
@@ -1298,7 +1298,7 @@ out."</p>
 <p>"I don't intend to.... How inconsistent you are, Molly. You&mdash;and
 everybody else&mdash;believe him to be the most magnificent match in&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_151"></a>[Pg 151]</span></p>
+<p><span class="pagenum" id="Page_151">[Pg 151]</span></p>
 
 <p>"If position and wealth is all you care for, yes. I didn't suppose you'd
 come to that."</p>
@@ -1331,7 +1331,7 @@ unwholesome fascination. And a mind fatigued is no longer wholesome.</p>
 <p>Then, too, there was always Sir Charles Mallison to turn to for a
 refreshing moral bath. Safety of soul lay in his vicinity; she felt
 confidence in the world wherever he traversed it. With him she relaxed
-and rested; there was repose for her in his silences; strength<span class="pagenum"><a id="Page_152"></a>[Pg 152]</span> for her
+and rested; there was repose for her in his silences; strength<span class="pagenum" id="Page_152">[Pg 152]</span> for her
 when he spoke; and a serene comradeship which no hint of sentiment had
 ever vexed.</p>
 
@@ -1362,7 +1362,7 @@ and all the while thinking to herself impatiently; "Baby! Fool! Little
 ninny! Imbecile!" while she listened, fat bejewelled hands folded, small
 green eyes shining in the expanse of powdered and painted fat.</p>
 
-<p><span class="pagenum"><a id="Page_153"></a>[Pg 153]</span></p>
+<p><span class="pagenum" id="Page_153">[Pg 153]</span></p>
 
 <p>After a while she could endure it no longer, and she said with a wheeze
 of good-natured disdain:</p>
@@ -1403,12 +1403,12 @@ be tolerated anywhere, I suppose.... How did you like Sir Charles?"</p>
 
 <p>"Why not adore him entirely?"</p>
 
-<p><span class="pagenum"><a id="Page_154"></a>[Pg 154]<br /><a id="Page_155"></a>[Pg 155]</span></p>
+<p><span class="pagenum" id="Page_155">[Pg 155]</span></p>
 
 <p>[Illustration: "'Never mind geography, child; tell me about the
 men!'"]</p>
 
-<p><span class="pagenum"><a id="Page_156"></a>[Pg 156]<br /><a id="Page_157"></a>[Pg 157]<br /><a id="Page_158"></a>[Pg 158]</span></p>
+<p><span class="pagenum" id="Page_158">[Pg 158]</span></p>
 
 <p>Strelsa laughed frankly: "He hasn't asked me to, for one reason.
 Besides&mdash;&mdash;"</p>
@@ -1448,7 +1448,7 @@ any chance of a check from higher sources.</p>
 pleasantly. "Come; let's discuss the matter like sensible women. Shall
 we?"</p>
 
-<p>Many people would not have disregarded such a<span class="pagenum"><a id="Page_159"></a>[Pg 159]</span> wish. Strelsa flushed and
+<p>Many people would not have disregarded such a<span class="pagenum" id="Page_159">[Pg 159]</span> wish. Strelsa flushed and
 lifted her purple-gray eyes to meet the little green ones scanning her
 slyly.</p>
 
@@ -1486,7 +1486,7 @@ that little whelp!"</p>
 voice, Strelsa sat dumb, wincing under the blows of sound, not knowing
 how to escape.</p>
 
-<p>"I'm fond of you!" shrieked the old lady&mdash;"I can<span class="pagenum"><a id="Page_160"></a>[Pg 160]</span> be of use to you and I
+<p>"I'm fond of you!" shrieked the old lady&mdash;"I can<span class="pagenum" id="Page_160">[Pg 160]</span> be of use to you and I
 want to be. That's why I asked you to tea! I want to make you happy&mdash;and
 Sir Charles, too! What the devil do you suppose there is in it for me
 except to oblige hi&mdash;you both?"</p>
@@ -1530,7 +1530,7 @@ intentions of this excited old lady; and she answered in a low voice:</p>
 
 <p>"You&mdash;has that boy had the impudence&mdash;damn him&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_161"></a>[Pg 161]</span></p>
+<p><span class="pagenum" id="Page_161">[Pg 161]</span></p>
 
 <p>Strelsa sprang to her feet.</p>
 
@@ -1573,7 +1573,7 @@ panting.</p>
 <p>"I only wanted to be good to you, Strelsa. I'm just an old fool I
 suppose&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_162"></a>[Pg 162]</span></p>
+<p><span class="pagenum" id="Page_162">[Pg 162]</span></p>
 
 <p>"Oh, please don't&mdash;&mdash;"</p>
 
@@ -1608,7 +1608,7 @@ with good-natured contempt. "He undertakes the duties, obligations, and
 details of a useful man in the greater household, which make him
 acceptable to us; and I'm bound to say that he does 'em very well. But
 outside of that he's a nobody. And I'll tell you just what he'll turn
-into; shall I? Society's<span class="pagenum"><a id="Page_163"></a>[Pg 163]</span> third chief bottlewasher in succession. We had
+into; shall I? Society's<span class="pagenum" id="Page_163">[Pg 163]</span> third chief bottlewasher in succession. We had
 one, who evolved us. He's dead. We have another. He's still talking.
 When he ultimately evaporates into infinity Ricky will be his natural
 successor. Do you want that kind of a husband?"</p>
@@ -1642,7 +1642,7 @@ ready for trouble, her small green eyes fairly snapping.</p>
 nothing for servants' opinions. Their greeting was perfunctory; their
 inquiries civil. Then there ensued a short silence.</p>
 
-<p><span class="pagenum"><a id="Page_164"></a>[Pg 164]</span></p>
+<p><span class="pagenum" id="Page_164">[Pg 164]</span></p>
 
 <p>"Which way did Mrs. Leeds go?" he asked, busily twisting his long
 moustache.</p>
@@ -1684,7 +1684,7 @@ pertinacity and an indifference to what she had said, absolutely stony.</p>
 
 <p>"I said that I was considering nothing in particular. We are friends."</p>
 
-<p><span class="pagenum"><a id="Page_165"></a>[Pg 165]</span></p>
+<p><span class="pagenum" id="Page_165">[Pg 165]</span></p>
 
 <p>"Keep away from her! Do you understand?"</p>
 
@@ -1719,7 +1719,7 @@ whispers of servants; and these ceased presently.</p>
 <p>All alone, amid the lighted magnificence of the vast room sat the old
 woman hunched in her chair, bloodless, motionless as a mass of dead
 flesh. Even the spark in her eyes was gone, the lids closed, the gross
-lower lip pendulous. Later two maids, being summoned, accom<span class="pagenum"><a id="Page_166"></a>[Pg 166]</span>panied her
+lower lip pendulous. Later two maids, being summoned, accom<span class="pagenum" id="Page_166">[Pg 166]</span>panied her
 to her boudoir, and were dismissed. Her social secretary, a pretty girl,
 came and left with instructions to cancel invitations for the evening.</p>
 
@@ -1754,7 +1754,7 @@ her. She decided that she was not to be at home to anybody.</p>
 
 <p>Langly Sprowl called about six, and was sent away. Strelsa, curled up on
 a divan, could hear the staccato racket that his powerful racing-car
-made in the street<span class="pagenum"><a id="Page_167"></a>[Pg 167]</span> outside. The informality of her recent host aboard
+made in the street<span class="pagenum" id="Page_167">[Pg 167]</span> outside. The informality of her recent host aboard
 the <i>Yulan</i> did not entirely please her. She listened to his departure
 with quiet satisfaction.</p>
 
@@ -1791,12 +1791,12 @@ said to me just now?"</p>
 <p>She laughed: "It happened to be a few minutes before eight. How did you
 know that? I believe you did speak to me in my dream. Did you?"</p>
 
-<p><span class="pagenum"><a id="Page_168"></a>[Pg 168]</span></p>
+<p><span class="pagenum" id="Page_168">[Pg 168]</span></p>
 
 <p>[Illustration: "Strelsa, curled upon a divan ... listened to his
 departure with quiet satisfaction."]</p>
 
-<p><span class="pagenum"><a id="Page_169"></a>[Pg 169]<br /><a id="Page_170"></a>[Pg 170]</span></p>
+<p><span class="pagenum" id="Page_170">[Pg 170]</span></p>
 
 <p>"I did."</p>
 
@@ -1845,7 +1845,7 @@ off in a rage. You are the only man in the world to whom I'm at home
 even over the telephone, and if that doesn't settle your status with me,
 what does?... Are you well, Mr. Quarren?"</p>
 
-<p><span class="pagenum"><a id="Page_171"></a>[Pg 171]</span></p>
+<p><span class="pagenum" id="Page_171">[Pg 171]</span></p>
 
 <p>"Thank you, perfectly. I called you up to ask you about yourself."</p>
 
@@ -1894,12 +1894,12 @@ share a solitary dinner with me. Do I want you?"</p>
 
 <p>"I'll start now! Good&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_172"></a>[Pg 172]<br /><a id="Page_173"></a>[Pg 173]</span></p>
+<p><span class="pagenum" id="Page_173">[Pg 173]</span></p>
 
 <p>[Illustration: "'Do you remember our first toast?' he asked,
 smiling."]</p>
 
-<p><span class="pagenum"><a id="Page_174"></a>[Pg 174]<br /><a id="Page_175"></a>[Pg 175]<br /><a id="Page_176"></a>[Pg 176]</span></p>
+<p><span class="pagenum" id="Page_176">[Pg 176]</span></p>
 
 <p>"Wait! I haven't decided. Really I'm simply stupid with the accumulated
 fatigues of two months' frivolity. Do you mind my being stupid?"</p>
@@ -1941,7 +1941,7 @@ quite as audacious:</p>
 
 <p>"I am drinking that same toast again&mdash;after many days," she said.</p>
 
-<p><span class="pagenum"><a id="Page_177"></a>[Pg 177]</span></p>
+<p><span class="pagenum" id="Page_177">[Pg 177]</span></p>
 
 <p>"With all that it entails?"</p>
 
@@ -1986,7 +1986,7 @@ under level brows, looking across the table at him.</p>
 
 <p>"I think you are even more beautiful than you were."</p>
 
-<p>She laughed gaily and continued her dinner. "I<span class="pagenum"><a id="Page_178"></a>[Pg 178]</span> <i>had</i> to drag that out
+<p>She laughed gaily and continued her dinner. "I<span class="pagenum" id="Page_178">[Pg 178]</span> <i>had</i> to drag that out
 of you, poor boy. But you see I'm uneasy; because imprudence <i>is</i>
 stamping the horrid imprint of maturity on me very rapidly; and I'm
 beginning to keep a more jealous eye on my suitors. You <i>were</i> one. Do
@@ -2026,7 +2026,7 @@ lightly on her hip.</p>
 marble fireplace and blow delicate rings of smoke at her own reflection
 in the mirror.</p>
 
-<p><span class="pagenum"><a id="Page_179"></a>[Pg 179]</span></p>
+<p><span class="pagenum" id="Page_179">[Pg 179]</span></p>
 
 <p>He stood a little distance behind her, watching her, and she nodded
 affably to him in the glass:</p>
@@ -2068,7 +2068,7 @@ fire. She seated herself on a sofa and bent toward the blaze, her
 dimpled elbows denting her silken knees, her chin balanced between
 forefinger and thumb.</p>
 
-<p><span class="pagenum"><a id="Page_180"></a>[Pg 180]</span></p>
+<p><span class="pagenum" id="Page_180">[Pg 180]</span></p>
 
 <p>Presently she said, not looking at him: "Somehow, I've changed. I'm not
 the woman you knew. I'm beginning to realise it. It seems absurd: it was
@@ -2099,7 +2099,7 @@ forehead. Certainly it was very pleasant to see him again&mdash;agreeable to
 be with him&mdash;not exactly restful, perhaps, but distinctly agreeable&mdash;for
 even in the frequent silences that had crept in between them there was
 no invitation to repose of mind. On the contrary, she was perfectly
-conscious of a reserve force now awaking&mdash;of <span class="pagenum"><a id="Page_181"></a>[Pg 181]</span> a growing sense of
+conscious of a reserve force now awaking&mdash;of <span class="pagenum" id="Page_181">[Pg 181]</span> a growing sense of
 freshness within her; of physical renewal, of unsuspected latent vigour.</p>
 
 <p>"Are you attempting to go to sleep, Mr. Quarren?" she inquired at last.</p>
@@ -2143,7 +2143,7 @@ hard. To-day I can survey, unmoved, many, many things which I could not
 even look at yesterday. But it makes life more interesting. Don't you
 think so?"</p>
 
-<p><span class="pagenum"><a id="Page_182"></a>[Pg 182]</span></p>
+<p><span class="pagenum" id="Page_182">[Pg 182]</span></p>
 
 <p>"Do you, Mrs. Leeds?"</p>
 
@@ -2190,7 +2190,7 @@ them," he said lightly.</p>
 
 <p>"What else?" she asked, furious.</p>
 
-<p><span class="pagenum"><a id="Page_183"></a>[Pg 183]</span></p>
+<p><span class="pagenum" id="Page_183">[Pg 183]</span></p>
 
 <p>"I take out the unfledged for a social airing; I exercise the mature; I
 smooth the plumage of the aged; I apply first aid to the socially
@@ -2224,7 +2224,7 @@ been interesting, from the very first&mdash;more so than many men&mdash;more tha
 most men. And now you admit to me what kind of a man you really are. If
 I believe it, what am I to think of myself? Can you tell me?"</p>
 
-<p><span class="pagenum"><a id="Page_184"></a>[Pg 184]</span></p>
+<p><span class="pagenum" id="Page_184">[Pg 184]</span></p>
 
 <p>Flushed, exasperated by she knew not what, and more and more in earnest
 every moment, she leaned forward looking at him, her right hand
@@ -2267,7 +2267,7 @@ unmanageable man's vices!&mdash;than to say <i>that</i> of you!"</p>
 
 <p>"Could you ever care?"</p>
 
-<p><span class="pagenum"><a id="Page_185"></a>[Pg 185]</span></p>
+<p><span class="pagenum" id="Page_185">[Pg 185]</span></p>
 
 <p>"No," she said, nervously.</p>
 
@@ -2316,7 +2316,7 @@ unconsciously and passed her finger tips over his fur collar.</p>
 <p>"No, you funny man. I'm never ill. But it's odd how burning hot I seem
 to be&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_186"></a>[Pg 186]</span></p>
+<p><span class="pagenum" id="Page_186">[Pg 186]</span></p>
 
 <p>She looked down at her fingers which still lay loosely across his.</p>
 
@@ -2350,7 +2350,7 @@ look at him, now.</p>
 
 <p>Sight and hearing sealed against him; pale, expressionless, she stood
 there awaiting his departure. And presently he opened the iron and glass
-door; a flurry<span class="pagenum"><a id="Page_187"></a>[Pg 187]</span> of icy air swept her; she heard the metallic snap of the
+door; a flurry<span class="pagenum" id="Page_187">[Pg 187]</span> of icy air swept her; she heard the metallic snap of the
 spring lock, and opened her heavy eyes.</p>
 
 <p>Deadly tired she turned and ascended the stairs to her bedroom and
@@ -2383,7 +2383,7 @@ passion; incredulous that it could ever touch her; out of nothing had
 sprung the lower menace, full armed, threatening her&mdash;out of a moment's
 lassitude, a touch of a man's hand, and his lips on hers! And now all
 her life was already behind her&mdash;childhood, girlhood, wifehood&mdash;all,
-all<span class="pagenum"><a id="Page_188"></a>[Pg 188]</span> behind her now; and she, a stranger even to herself, alone on an
+all<span class="pagenum" id="Page_188">[Pg 188]</span> behind her now; and she, a stranger even to herself, alone on an
 unknown road; an unknown world before her.</p>
 
 <p>With every instinct inherent and self-inculcated, instincts of modesty,
@@ -2409,7 +2409,7 @@ of Gath and in the sinful streets of Ascalon.</p>
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_189"></a>[Pg 189]</span></p>
+<p><span class="pagenum" id="Page_189">[Pg 189]</span></p>
 
 <h2 class="nobreak" id="CHAPTER_VI">CHAPTER VI</h2>
 </div>
@@ -2435,7 +2435,7 @@ his book by the thousands and reading it for the story, exclusively.</p>
 <p>His aunt had cast him off; to him she was the overfed embodiment of
 society, so it pleased him to consider the rupture as one between
 society and himself. It tasted of martyrdom, and now his own public had
-vulgarly gone back on him according to his ideals: nobody<span class="pagenum"><a id="Page_190"></a>[Pg 190]</span> cared for his
+vulgarly gone back on him according to his ideals: nobody<span class="pagenum" id="Page_190">[Pg 190]</span> cared for his
 economics, his social evils, his moral philosophy; only what he
 considered the unworthy part of his book was eagerly absorbed and
 discussed. The proletariat had grossly betrayed him; a hermit's
@@ -2470,7 +2470,7 @@ successful. Barent Van Dyne made a dub of himself."</p>
 
 <p>"Practically."</p>
 
-<p><span class="pagenum"><a id="Page_191"></a>[Pg 191]</span></p>
+<p><span class="pagenum" id="Page_191">[Pg 191]</span></p>
 
 <p>"Why?" asked O'Hara, looking up blankly.</p>
 
@@ -2506,7 +2506,7 @@ himself into seclusion.</p>
 <p>Quarren also pushed back his chair, preparing to rise.</p>
 
 <p>"Doin' anythin'?" inquired O'Hara, desiring to be kind. "Young Calahan
-and the Harlem Mutt have it<span class="pagenum"><a id="Page_192"></a>[Pg 192]</span> out at the Cataract Club to-night," he
+and the Harlem Mutt have it<span class="pagenum" id="Page_192">[Pg 192]</span> out at the Cataract Club to-night," he
 added persuasively.</p>
 
 <p>"Another time, thanks," said Quarren: "I've letters to write."</p>
@@ -2547,7 +2547,7 @@ endurance now. And at last he weakened, and wrote to her once more:</p>
 <p>"I feel sure that your failure to answer my note of last week was
 unintentional.</p>
 
-<p><span class="pagenum"><a id="Page_193"></a>[Pg 193]</span></p>
+<p><span class="pagenum" id="Page_193">[Pg 193]</span></p>
 
 <p>"Some day, when you have a moment, would you write me a line saying
 that you will be at home to me?</p>
@@ -2590,7 +2590,7 @@ Strelsa Leeds face to face. She said, coolly amiable:</p>
 <p>"Is it good policy for a young man to drop out of sight? Our world
 forgets over-night."</p>
 
-<p>He laughed: "Something similar has been intimated<span class="pagenum"><a id="Page_194"></a>[Pg 194]</span> to me by others&mdash;but
+<p>He laughed: "Something similar has been intimated<span class="pagenum" id="Page_194">[Pg 194]</span> to me by others&mdash;but
 less gently. I'm afraid I've offended some people."</p>
 
 <p>"Oh, so you have already been disciplined?"</p>
@@ -2630,7 +2630,7 @@ perhaps obtain it?"</p>
 <p>Her face flushed. "I have nothing to forgive you, Mr. Quarren," she said
 with decision.</p>
 
-<p><span class="pagenum"><a id="Page_195"></a>[Pg 195]</span></p>
+<p><span class="pagenum" id="Page_195">[Pg 195]</span></p>
 
 <p>"Do you mean that?"</p>
 
@@ -2669,7 +2669,7 @@ more. And she'd better not play too confidently with Ricky. You can
 usually forecast what a wild animal will do, never how a trained one is
 going to behave."</p>
 
-<p>"Such scandal!" laughed Chrysos Lacy. "How<span class="pagenum"><a id="Page_196"></a>[Pg 196]</span> many of us can afford to
+<p>"Such scandal!" laughed Chrysos Lacy. "How<span class="pagenum" id="Page_196">[Pg 196]</span> many of us can afford to
 turn our backs to the rest of the cage even for an instant? Sir Charles,
 I simply don't dare to go away. Otherwise I'd purchase several of those
 glittering articles yonder&mdash;whatever they are. Do you happen to know?"</p>
@@ -2704,7 +2704,7 @@ from the trigger. I know enough to do that."</p>
 
 <p>He supposed that she also was jesting, and her fastidious handling of
 the weapon amused him. And when she asked him if it was safe to carry in
-her muff, he<span class="pagenum"><a id="Page_197"></a>[Pg 197]</span> assured her very gravely that she might venture to do so.
+her muff, he<span class="pagenum" id="Page_197">[Pg 197]</span> assured her very gravely that she might venture to do so.
 "Turn it loose on the first burglar," he added, "and his regeneration
 will begin in all the forty-nine odours of sanctity."</p>
 
@@ -2734,7 +2734,7 @@ heretofore impalpable&mdash;and, in spirit, with delicate fingers, she
 gathered up instinctively those intangible threads with which man is
 guided as surely as though driven in chains of steel.</p>
 
-<p><span class="pagenum"><a id="Page_198"></a>[Pg 198]</span></p>
+<p><span class="pagenum" id="Page_198">[Pg 198]</span></p>
 
 <p>And all the while she was aware of Quarren's boyish head bending almost
 too near to Cyrille Caldera's over the trays of antique jewels; and all
@@ -2764,7 +2764,7 @@ No; because from the beginning&mdash;even before he had unmasked&mdash;she had
 been sensible of an interest in him different from any interest she had
 ever before felt for any man.</p>
 
-<p>This uncompromisingly honest answer silenced her<span class="pagenum"><a id="Page_199"></a>[Pg 199]</span> mentally for some
+<p>This uncompromisingly honest answer silenced her<span class="pagenum" id="Page_199">[Pg 199]</span> mentally for some
 moments; then she lifted her resolute gray eyes to the eyes of the
 mirrored witness:</p>
 
@@ -2797,7 +2797,7 @@ confusion here&mdash;<i>was</i> Quarren on trial? Or was she herself?</p>
 <p>This threatened to become a serious question; she strove to think
 clearly, to reason; but only evoked the pale, amused face of Quarren
 from inner and chaotic consciousness until the visualisation remained
-fixed, de<span class="pagenum"><a id="Page_200"></a>[Pg 200]</span>fying obliteration. And she accepted the mental spectre for
+fixed, de<span class="pagenum" id="Page_200">[Pg 200]</span>fying obliteration. And she accepted the mental spectre for
 the witness box.</p>
 
 <p>"Ricky," she said, "do you really love me?"</p>
@@ -2832,7 +2832,7 @@ temptation.... Into the one temptation I have never before known,
 Ricky&mdash;and which, in my complacency and pride I never dreamed that I
 should encounter.</p>
 
-<p><span class="pagenum"><a id="Page_201"></a>[Pg 201]</span></p>
+<p><span class="pagenum" id="Page_201">[Pg 201]</span></p>
 
 <p>"And it is coming to that!... A girl must be honest with herself or all
 life is only the same smiling lie. I'm ashamed to be honest, Ricky; but
@@ -2864,7 +2864,7 @@ unprecedented defiance of two summonses to the hazardous presence of
 Mrs. Sprowl, he obeyed a third subpœna, and presented himself with an
 air of cheerful confidence that instantly enraged her.</p>
 
-<p><span class="pagenum"><a id="Page_202"></a>[Pg 202]</span></p>
+<p><span class="pagenum" id="Page_202">[Pg 202]</span></p>
 
 <p>The old lady lay abed with nothing more compromising than a toothache;
 Quarren was conducted to the inner shrine; she glared at him hideously
@@ -2906,7 +2906,7 @@ warning; that is the airy purport of my discourse, Mrs. Sprowl."</p>
 
 <p>"Yes, I think so," he said, wearily.</p>
 
-<p><span class="pagenum"><a id="Page_203"></a>[Pg 203]</span></p>
+<p><span class="pagenum" id="Page_203">[Pg 203]</span></p>
 
 <p>"Well, then, what the devil <i>are</i> you saying?"</p>
 
@@ -2943,7 +2943,7 @@ genius for making it endurable to you all. So you welcomed me very
 warmly; and you have been very kind to me.... But, somewhere or
 other&mdash;in some forgotten corner of me&mdash;an odd and old-fashioned idea
 awoke the other day.... I think perhaps it awoke when you reminded me
-that to serve<span class="pagenum"><a id="Page_204"></a>[Pg 204]</span> you was one thing and to marry among you something very
+that to serve<span class="pagenum" id="Page_204">[Pg 204]</span> you was one thing and to marry among you something very
 different."</p>
 
 <p>"Ricky! Do you want to drive me to the yelling verge of distraction? I
@@ -2979,7 +2979,7 @@ do."</p>
 
 <p>"The devil you do," said the old lady.</p>
 
-<p><span class="pagenum"><a id="Page_205"></a>[Pg 205]</span></p>
+<p><span class="pagenum" id="Page_205">[Pg 205]</span></p>
 
 <p>"It's a curious fact," he insisted, smiling.</p>
 
@@ -3023,7 +3023,7 @@ incredulously.</p>
 
 <p>"I think you know better."</p>
 
-<p>"No, I don't!" she snapped. "I know men and<span class="pagenum"><a id="Page_206"></a>[Pg 206]</span> women; that's all I know.
+<p>"No, I don't!" she snapped. "I know men and<span class="pagenum" id="Page_206">[Pg 206]</span> women; that's all I know.
 And as you're one of the two species I don't expect anything celestial
 from you.... And you'd better go, now."</p>
 
@@ -3040,7 +3040,7 @@ your funny unreal world.... You're so humanly bad."</p>
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_207"></a>[Pg 207]</span></p>
+<p><span class="pagenum" id="Page_207">[Pg 207]</span></p>
 
 <h2 class="nobreak" id="CHAPTER_VII">CHAPTER VII</h2>
 </div>
@@ -3069,7 +3069,7 @@ Caldera was to finance for him.</p>
 
 <p>Recently, however, that suave young man had smilingly denied making any
 such promise to anybody; which surprised and disconcerted Quarren who
-had no money with which to build sewers, roads, and electric<span class="pagenum"><a id="Page_208"></a>[Pg 208]</span> plants.
+had no money with which to build sewers, roads, and electric<span class="pagenum" id="Page_208">[Pg 208]</span> plants.
 And he began to realise how carelessly he had drifted into the
 enterprise&mdash;how carelessly he had drifted into everything and past
 everything for the last five years.</p>
@@ -3100,7 +3100,7 @@ moments now for business or for sleep. Neither bothered him excessively.</p>
 <p>He wrote no more notes to Strelsa Leeds&mdash;that is, he posted no more,
 however many he may have composed. Rumours from the inner temple
 concerning her and Langly Sprowl and Sir Charles Mallison drifted out
-into the real world every day or so. But he<span class="pagenum"><a id="Page_209"></a>[Pg 209]</span> never went back to the
+into the real world every day or so. But he<span class="pagenum" id="Page_209">[Pg 209]</span> never went back to the
 temple to verify them. That life was ended for him. Sometimes, sitting
 alone at his desk, he fancied that he could almost hear the far laughter
 of the temple revels, and the humming of the drones. But the roar of the
@@ -3131,7 +3131,7 @@ on the temple dome is peeling off; and the laughter is dying out, and
 the hum of the drones sounds drowsy like unreal voices heard in summer
 dreams.</p>
 
-<p>"It is the passing of an imbecile society," declaimed<span class="pagenum"><a id="Page_210"></a>[Pg 210]</span> Westguard&mdash;"the
+<p>"It is the passing of an imbecile society," declaimed<span class="pagenum" id="Page_210">[Pg 210]</span> Westguard&mdash;"the
 dying sounds of its meaningless noise&mdash;the first omens of a silence
 which foretells annihilation. Out of chaos will gradually emerge the
 elements of a real society&mdash;the splendid social and intellectual
@@ -3167,7 +3167,7 @@ Lacy, impudently.</p>
 sitting up on the sofa where he had been sprawling; and laughter, loud
 and long, rattled the windows in the Irish Legation.</p>
 
-<p><span class="pagenum"><a id="Page_211"></a>[Pg 211]</span></p>
+<p><span class="pagenum" id="Page_211">[Pg 211]</span></p>
 
 <p>The May night was hot; a sickly breeze stirred the curtains at the open
 windows of Westguard's living room where the Legation was entertaining
@@ -3203,7 +3203,7 @@ earth is competent to write a book except an author, but I defy anybody
 to play my poker hands for me! Come on, Dankmere! Let's clean out this
 complacent crowd!"</p>
 
-<p>Lord Dankmere complied, and seated himself at the<span class="pagenum"><a id="Page_212"></a>[Pg 212]</span> table, anxiously
+<p>Lord Dankmere complied, and seated himself at the<span class="pagenum" id="Page_212">[Pg 212]</span> table, anxiously
 remarking to Quarren that he had come to America to acquire capital, not
 to spend it. Sir Charles laughed and dealt; Westguard drew five cards,
 attempted to bluff Quarren's full hand, and was scandalously routed.</p>
@@ -3240,7 +3240,7 @@ Quarren. Please give me the right one."</p>
 
 <p>"Which?"</p>
 
-<p><span class="pagenum"><a id="Page_213"></a>[Pg 213]</span></p>
+<p><span class="pagenum" id="Page_213">[Pg 213]</span></p>
 
 <p>"The Queen of Hearts."</p>
 
@@ -3281,7 +3281,7 @@ manage the company for you, Dankmere&mdash;&mdash;"</p>
 <p>"There'll be no next time," said Dankmere, scanning his cards. "I'm done
 for," he added, dramatically, letting his own ante go.</p>
 
-<p><span class="pagenum"><a id="Page_214"></a>[Pg 214]</span></p>
+<p><span class="pagenum" id="Page_214">[Pg 214]</span></p>
 
 <p>"You've lost your nerve," said Quarren, smiling.</p>
 
@@ -3325,7 +3325,7 @@ eyes fixed nonchalantly on space&mdash;his nimble little feet making no sound
 on the floor as he swung, swayed, and capered under the electric light
 timing his agile steps to his own singing.</p>
 
-<p>Loud applause greeted him; much hand-clapping<span class="pagenum"><a id="Page_215"></a>[Pg 215]</span> and cries of "Good old
+<p>Loud applause greeted him; much hand-clapping<span class="pagenum" id="Page_215">[Pg 215]</span> and cries of "Good old
 Dankmere! Three cheers for the British peerage!"</p>
 
 <p>Sir Charles looked slightly bored, sitting back in his chair and waiting
@@ -3370,7 +3370,7 @@ anything about pictures."</p>
 <p>"Don't you know their value?"</p>
 
 <p>"No, I don't. But I fancy the good ones were sold off long ago&mdash;twenty
-years ago I believe. There was<span class="pagenum"><a id="Page_216"></a>[Pg 216]</span> a sale&mdash;a lot of rubbish of sorts. I
+years ago I believe. There was<span class="pagenum" id="Page_216">[Pg 216]</span> a sale&mdash;a lot of rubbish of sorts. I
 took it for granted that Lister's people cleaned out everything worth
 taking."</p>
 
@@ -3412,7 +3412,7 @@ disastrously for him.</p>
 
 <p>"No; it doesn't matter much," said the boy indifferently.</p>
 
-<p><span class="pagenum"><a id="Page_217"></a>[Pg 217]</span></p>
+<p><span class="pagenum" id="Page_217">[Pg 217]</span></p>
 
 <p>"Many people are already on the wing," observed Lacy.</p>
 
@@ -3456,7 +3456,7 @@ to Quarren.</p>
 <p>"I'll drop in at your office, if I may, some morning," he said. "May I?"</p>
 
 <p>"It will give me both pleasure and diversion," said Quarren laughing.
-"There is not enough business in<span class="pagenum"><a id="Page_218"></a>[Pg 218]</span> my office to afford me either. Also
+"There is not enough business in<span class="pagenum" id="Page_218">[Pg 218]</span> my office to afford me either. Also
 you are welcome to send for those pictures and store them in my back
 parlour until you can find a purchaser."</p>
 
@@ -3495,7 +3495,7 @@ promised to ask you to come with me."</p>
 
 <p>"Where?"</p>
 
-<p><span class="pagenum"><a id="Page_219"></a>[Pg 219]</span></p>
+<p><span class="pagenum" id="Page_219">[Pg 219]</span></p>
 
 <p>"Mrs. Sprowl told me to bring you. You know how informal she is."</p>
 
@@ -3534,7 +3534,7 @@ he found the whole story there&mdash;a story to which he had become
 accustomed.</p>
 
 <p>But the next day, the papers repeated the news. And it remained, for the
-first time, uncontradicted by<span class="pagenum"><a id="Page_220"></a>[Pg 220]<br /><a id="Page_221"></a>[Pg 221]<br /><a id="Page_222"></a>[Pg 222]</span> anybody. All that morning he sat at his
+first time, uncontradicted by<span class="pagenum" id="Page_222">[Pg 222]</span> anybody. All that morning he sat at his
 desk staring at her picture, reproduced in half-tones on the first page
 of every newspaper in town&mdash;stared at it, and at the neighbouring
 likeness of Sir Charles in the uniform of his late regiment; read once
@@ -3567,7 +3567,7 @@ came upon a letter from her.</p>
 
 <p>For a while he merely gazed at it, incredulous of its reality.</p>
 
-<p><span class="pagenum"><a id="Page_223"></a>[Pg 223]</span></p>
+<p><span class="pagenum" id="Page_223">[Pg 223]</span></p>
 
 <p>Then he opened the envelope very deliberately and still, scarcely
 convinced, unfolded the scented sheaf of note-paper:</p>
@@ -3603,7 +3603,7 @@ make&mdash;except by my saying that I hope to see you again. Will you be
 content with that admission of guilt?</p>
 
 <p>"I meant to speak to you again that day at the Charity affair, only
-there were so many people bother<span class="pagenum"><a id="Page_224"></a>[Pg 224]</span>ing&mdash;and you seemed to be so
+there were so many people bother<span class="pagenum" id="Page_224">[Pg 224]</span>ing&mdash;and you seemed to be so
 delightfully preoccupied with that pretty Cyrille Caldera. I really
 had no decent opportunity to speak to you again without making her
 my mortal enemy&mdash;and you, too, perhaps.</p>
@@ -3635,7 +3635,7 @@ Do you think it odd or capricious of me to write to you? And are
 you perhaps irritated because of my manners which must have seemed
 to you discourteous&mdash;perhaps rude?</p>
 
-<p>"I know of course that you called on me; that you<span class="pagenum"><a id="Page_225"></a>[Pg 225]</span> telephoned; that
+<p>"I know of course that you called on me; that you<span class="pagenum" id="Page_225">[Pg 225]</span> telephoned; that
 you wrote to me; and that I made no response.</p>
 
 <p>"And I am going to make no explanation. Can your friendship, or
@@ -3677,7 +3677,7 @@ this time for good and all.</p>
 <p>"<span class="smcap">R. S. Quarren.</span>"</p>
 </div>
 
-<p><span class="pagenum"><a id="Page_226"></a>[Pg 226]</span></p>
+<p><span class="pagenum" id="Page_226">[Pg 226]</span></p>
 
 <p>By return mail came a note from her:</p>
 
@@ -3715,7 +3715,7 @@ drown.</p>
 
 <p>"P. S.&mdash;Lord Dankmere is here. He is insufferable. He told Mrs.
 Sprowl that you and he were going into the antique-picture
-business. You wouldn't think of<span class="pagenum"><a id="Page_227"></a>[Pg 227]</span> going into anything whatever with
+business. You wouldn't think of<span class="pagenum" id="Page_227">[Pg 227]</span> going into anything whatever with
 a man of that sort, would you? Or was it merely a British jest?"</p>
 </div>
 
@@ -3756,12 +3756,12 @@ delivered at the real-estate office of R. S. Quarren, littering his
 sleeping quarters and office and overflowing into the extension and
 backyard.</p>
 
-<p><span class="pagenum"><a id="Page_228"></a>[Pg 228]</span></p>
+<p><span class="pagenum" id="Page_228">[Pg 228]</span></p>
 
 <p>[Illustration: "All stacked up pell-mell in the back yard and regarded
 in amazement by the neighbours."]</p>
 
-<p><span class="pagenum"><a id="Page_229"></a>[Pg 229]<br /><a id="Page_230"></a>[Pg 230]</span></p>
+<p><span class="pagenum" id="Page_230">[Pg 230]</span></p>
 
 <p>It was the first of June and ordinarily hot when Lord Dankmere and
 Quarren, stripped to their shirts and armed with pincers, chisels and
@@ -3797,7 +3797,7 @@ Quarren&mdash;I mean what's your first impression?"</p>
 
 <p>"Certainly. They seem to be genuine enough as far as I can see."</p>
 
-<p><span class="pagenum"><a id="Page_231"></a>[Pg 231]</span></p>
+<p><span class="pagenum" id="Page_231">[Pg 231]</span></p>
 
 <p>"But are they otherwise any good?"</p>
 
@@ -3837,7 +3837,7 @@ office to await events.</p>
 
 <p>"Then, like a good fellow, help me sell these damned pictures. I haven't
 any money to offer you, Quarren, but if you'll be willing to hang the
-pictures around your<span class="pagenum"><a id="Page_232"></a>[Pg 232]</span> office here and in the back parlour and the
+pictures around your<span class="pagenum" id="Page_232">[Pg 232]</span> office here and in the back parlour and the
 extension, and if you'll talk the merry talk to the lunatics who may
 come in to look at 'em and tell 'em what the bally pictures are and fix
 the proper prices&mdash;why&mdash;why, I'll make any arrangement with you that you
@@ -3868,7 +3868,7 @@ a picture dealer."</p>
 
 <p>"What's the harm? Take a shot at it, old chap! A young man can't collect
 too many kinds of experience. Take me for example!&mdash;I've sold dogs and
-hunters on commission, gone shares in about every rotten<span class="pagenum"><a id="Page_233"></a>[Pg 233]</span> scheme anybody
+hunters on commission, gone shares in about every rotten<span class="pagenum" id="Page_233">[Pg 233]</span> scheme anybody
 ever suggested to me, financed a show, and acted in it&mdash;as you
 know&mdash;and, by gad!&mdash;here I am now a dealer in old masters! Be a good
 fellow and come in with me. What?"</p>
@@ -3908,7 +3908,7 @@ then."</p>
 
 <p>"A half!&mdash;by gad! There's a good fellow!"</p>
 
-<p><span class="pagenum"><a id="Page_234"></a>[Pg 234]</span></p>
+<p><span class="pagenum" id="Page_234">[Pg 234]</span></p>
 
 <p>"No; one-third is all I'll accept."</p>
 
@@ -3943,7 +3943,7 @@ you&mdash;&mdash;"</p>
 <p>"Oh, Ricky, I'm glad to see you! But I don't want to buy a house or sell
 one or anything. I'm very unhappy&mdash;and I'm glad to see you&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_235"></a>[Pg 235]</span></p>
+<p><span class="pagenum" id="Page_235">[Pg 235]</span></p>
 
 <p>She pressed his hand with both her gloved ones; he closed the door and
 returned to the office; and she seated herself on top of his desk.</p>
@@ -3981,7 +3981,7 @@ lawyers. But <i>I</i> think the chances are that her pretty house will be for
 sale before long.... Wouldn't it be too tragic if it came into your
 office&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_236"></a>[Pg 236]</span></p>
+<p><span class="pagenum" id="Page_236">[Pg 236]</span></p>
 
 <p>"Don't say such things, Molly," he said, bending his head over the desk
 and fumbling with his pen.</p>
@@ -4025,7 +4025,7 @@ Mrs. Sprowl."</p>
 <p>"Oh, I found a way around. I asked Mrs. Sprowl and Sir Charles at the
 same time."</p>
 
-<p><span class="pagenum"><a id="Page_237"></a>[Pg 237]</span></p>
+<p><span class="pagenum" id="Page_237">[Pg 237]</span></p>
 
 <p>"What do you mean?" he said, turning a colourless face to hers.</p>
 
@@ -4062,7 +4062,7 @@ to a crisis&mdash;I do, indeed."</p>
 
 <p>"You don't think Mrs. Leeds is engaged to Sprowl, do you?"</p>
 
-<p>"No.... I don't think so. Sometimes I don't know<span class="pagenum"><a id="Page_238"></a>[Pg 238]</span> what to think of
+<p>"No.... I don't think so. Sometimes I don't know<span class="pagenum" id="Page_238">[Pg 238]</span> what to think of
 Strelsa. I'm certain that she was not engaged to him four weeks ago when
 she was at Newport."</p>
 
@@ -4099,7 +4099,7 @@ whatever may be in me&mdash;so that I could speak to her as an equal and not
 as the court jester and favourite mountebank of the degenerate gang she
 travels with&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_239"></a>[Pg 239]</span></p>
+<p><span class="pagenum" id="Page_239">[Pg 239]</span></p>
 
 <p>"Ricky!"</p>
 
@@ -4145,7 +4145,7 @@ anything."</p>
 
 <p>"There's her husband as an asset."</p>
 
-<p><span class="pagenum"><a id="Page_240"></a>[Pg 240]</span></p>
+<p><span class="pagenum" id="Page_240">[Pg 240]</span></p>
 
 <p>"Oh, my dear, don't talk slush!"</p>
 
@@ -4181,7 +4181,7 @@ you can! Will you?"</p>
 <p>"That's ducky of you. You <i>are</i> a good sport, Ricky&mdash;and always were! Go
 on and marry her if you can. Other women have stood it.... And, I know
 it's vulgar and low and catty of me&mdash;but I'd love to see Mrs. Sprowl
-blow up&mdash;and see that hatchet-faced Langly<span class="pagenum"><a id="Page_241"></a>[Pg 241]</span> disappointed&mdash;yes, I would,
+blow up&mdash;and see that hatchet-faced Langly<span class="pagenum" id="Page_241">[Pg 241]</span> disappointed&mdash;yes, I would,
 and I don't care what you think! Their ancestors were common people, and
 Heaven knows why a Wycherly of Wycherly should be afraid of the
 descendants of Dutch rum smugglers!"</p>
@@ -4203,14 +4203,14 @@ you do!"</p>
 
 <p>"I hope so, too," he said with the ghost of a smile.</p>
 
-<p><span class="pagenum"><a id="Page_242"></a>[Pg 242]</span></p>
+<p><span class="pagenum" id="Page_242">[Pg 242]</span></p>
 
 <p>[Illustration: "A fortnight later Strelsa wrote to Quarren for the first
 time in nearly two months."]</p>
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_243"></a>[Pg 243]<br /><a id="Page_244"></a>[Pg 244]</span></p>
+<p><span class="pagenum" id="Page_244">[Pg 244]</span></p>
 
 <h2 class="nobreak" id="CHAPTER_VIII">CHAPTER VIII</h2>
 </div>
@@ -4245,7 +4245,7 @@ much&mdash;not nearly enough to live on.</p>
 to sit down and write you about it. I was horribly scared, and
 wanted you to know it.</p>
 
-<p>"I didn't yield to the impulse as you know&mdash;I can<span class="pagenum"><a id="Page_245"></a>[Pg 245]</span>not give you the
+<p>"I didn't yield to the impulse as you know&mdash;I can<span class="pagenum" id="Page_245">[Pg 245]</span>not give you the
 reasons why. They were merely intuitions at first; later they
 became reasons as my financial situation developed in all its
 annoying proportions.</p>
@@ -4279,7 +4279,7 @@ sorrow, so little of material ease and tranquility of mind.</p>
 <p>"I had been dreaming of a balanced and secure life with leisure to
 develop mental resources hitherto neglected. And your
 friendship&mdash;our new understanding&mdash;meant much of that part of life
-for me&mdash;more<span class="pagenum"><a id="Page_246"></a>[Pg 246]</span> than I realised&mdash;far more than you do. Can you
+for me&mdash;more<span class="pagenum" id="Page_246">[Pg 246]</span> than I realised&mdash;far more than you do. Can you
 understand how deep the hurt is?&mdash;deeper because now you will learn
 what a coward I really am and how selfishly I surrender to the
 menace of material destruction. I am in dire terror of it; I simply
@@ -4313,7 +4313,7 @@ and needy future.</p>
 
 <p>"All ideals, all desire for higher and better things&mdash;for a noble
 leisure and the quiet pleasures of self-development, have
-gone&mdash;vanished utterly. Fear sickens<span class="pagenum"><a id="Page_247"></a>[Pg 247]</span> me night and day&mdash;the same
+gone&mdash;vanished utterly. Fear sickens<span class="pagenum" id="Page_247">[Pg 247]</span> me night and day&mdash;the same
 dull dread that I have known so many, many years in my life&mdash;a
 blind horror of more unhappiness and pain after two years of
 silence&mdash;that breathless stillness which frightened wounded things
@@ -4347,12 +4347,12 @@ heel.</p>
 reasons entirely material, because I have no courage to ever again
 face adversity and unhappiness.</p>
 
-<p><span class="pagenum"><a id="Page_248"></a>[Pg 248]<br /><a id="Page_249"></a>[Pg 249]</span></p>
+<p><span class="pagenum" id="Page_249">[Pg 249]</span></p>
 
 <p>[Illustration: "'I say, Quarren&mdash;does this old lady hang next to
 the battered party in black?'"]</p>
 
-<p><span class="pagenum"><a id="Page_250"></a>[Pg 250]<br /><a id="Page_251"></a>[Pg 251]<br /><a id="Page_252"></a>[Pg 252]</span></p>
+<p><span class="pagenum" id="Page_252">[Pg 252]</span></p>
 
 <p>"You will not care to write to me; and you will not care to see me
 again.</p>
@@ -4391,7 +4391,7 @@ is it?"</p>
 
 <p>"I hope not," said the young fellow absently.</p>
 
-<p>"Egad! So do I." And to the workmen&mdash;"Phile<span class="pagenum"><a id="Page_253"></a>[Pg 253]</span>mon and Baucis by Rembrandt!
+<p>"Egad! So do I." And to the workmen&mdash;"Phile<span class="pagenum" id="Page_253">[Pg 253]</span>mon and Baucis by Rembrandt!
 Hang 'em up next to that Romney&mdash;over the Jan Steen ... Quarren?"</p>
 
 <p>"Yes?"</p>
@@ -4430,7 +4430,7 @@ Wycherly:</p>
 </div>
 
 <p>The following morning after the workmen had departed, he and Dankmere
-stood contemplating the trans<span class="pagenum"><a id="Page_254"></a>[Pg 254]</span>formations wrought in the office, back
+stood contemplating the trans<span class="pagenum" id="Page_254">[Pg 254]</span>formations wrought in the office, back
 parlour, and extension of Quarren's floor in the shabby old Lexington
 Avenue house.</p>
 
@@ -4463,7 +4463,7 @@ OLD MASTERS<br />
 <span class="smcap">Algernon Fayre, R. S. Quarren</span> &amp; Co.<br />
 </p>
 
-<p><span class="pagenum"><a id="Page_255"></a>[Pg 255]</span></p>
+<p><span class="pagenum" id="Page_255">[Pg 255]</span></p>
 
 <p>For Lord Dankmere, otherwise Algernon Cecil Clarence Fayre, Earl of
 Dankmere, had decided to dedicate to trade only a portion of his
@@ -4497,7 +4497,7 @@ ignorance did not dismay him.</p>
 
 <p>All his life he had cared for such things, been familiar with them, been
 curious to learn more, had read enough to understand something of the
-fascinating<span class="pagenum"><a id="Page_256"></a>[Pg 256]</span> problems now confronting him, had, in his hours of leisure,
+fascinating<span class="pagenum" id="Page_256">[Pg 256]</span> problems now confronting him, had, in his hours of leisure,
 familiarised himself with the best of art in the public and private
 galleries of the city.</p>
 
@@ -4527,7 +4527,7 @@ certain of what he dealt in.</p>
 <p>Then, too, his mind had long since invaded a future which day by day
 grew more alluring in its suggestions. He himself would learn the
 practical and manual art of restoration&mdash;learn how to clean, reline,
-revarnish; how to identify, how to dissect. Every thread of an<span class="pagenum"><a id="Page_257"></a>[Pg 257]</span> ancient
+revarnish; how to identify, how to dissect. Every thread of an<span class="pagenum" id="Page_257">[Pg 257]</span> ancient
 canvas should tell him a true story; every grain in an old panel. He
 would be chief surgeon in his hospital for old and decrepit
 masterpieces; he would "cradle" with his own hands&mdash;clear the opacity
@@ -4563,7 +4563,7 @@ understand?"</p>
 <p>"You funny Englishman&mdash;I believe you are.... And we'll make this thing
 go. Down comes my real-estate shingle; I'm a part of the Dankmere
 Galleries now. I'll rent the basement after our first sale and there
-you<span class="pagenum"><a id="Page_258"></a>[Pg 258]</span> and I will fuss and tinker and doctor and nurse any poor old
+you<span class="pagenum" id="Page_258">[Pg 258]</span> and I will fuss and tinker and doctor and nurse any poor old
 derelict of a picture back to its pristine beauty. What?"</p>
 
 <p>"Not I," said the little Earl. "All I'm good for is to furnish the
@@ -4601,7 +4601,7 @@ absence. First he arranged with Valasco to identify as nearly as
 possible, and to appraise, the French and Italian pictures. Then he made
 an arrangement with Van Boschoven for the Dutch and Flemish; secured
 Drayton-Quinn for the English; and warned Dankmere not to bother or
-interfere with these tempera<span class="pagenum"><a id="Page_259"></a>[Pg 259]</span>mental and irascible gentlemen while in
+interfere with these tempera<span class="pagenum" id="Page_259">[Pg 259]</span>mental and irascible gentlemen while in
 exercise of their professional duties.</p>
 
 <p>"Don't whistle, don't do abrupt skirt-dances, don't sing comic songs,
@@ -4637,7 +4637,7 @@ the picture painted&mdash;if you can believe his word."</p>
 could any living expert ever have seen an artist, who died two hundred
 years ago, paint anything?"</p>
 
-<p>"Right," said Quarren solemnly; "the point is<span class="pagenum"><a id="Page_260"></a>[Pg 260]</span> keenly taken. Ergo, there
+<p>"Right," said Quarren solemnly; "the point is<span class="pagenum" id="Page_260">[Pg 260]</span> keenly taken. Ergo, there
 <i>are</i> no real experts, only guessers. When Valasco <i>et al</i> finish their
 guessing, I'll guess how near they have guessed correctly. Good-bye....
 You <i>will</i> be good, won't you, Dankmere?"</p>
@@ -4675,7 +4675,7 @@ inspiration to complete his "Coster's Hornpipe."</p>
 
 <p>On the train Quarren bought the evening papers; and the first item that
 met his eye was a front-page column devoted to the Dankmere Galleries.
-Every paper<span class="pagenum"><a id="Page_261"></a>[Pg 261]</span> had broken out into glaring scare-heads announcing the
+Every paper<span class="pagenum" id="Page_261">[Pg 261]</span> had broken out into glaring scare-heads announcing the
 recent despoiling of Dankmere Tarns and the venture into trade of
 Algernon Cecil Clarence Fayre, tenth Earl of Dankmere. The majority of
 papers were facetious, one or two scathing, but the more respectable
@@ -4711,7 +4711,7 @@ at Attractive Prices!</p>
 "GAMBLING DID IT!<br />
 </p>
 
-<p>"Gambling usually lands the British Peer on his<span class="pagenum"><a id="Page_262"></a>[Pg 262]</span> aristocratic
+<p>"Gambling usually lands the British Peer on his<span class="pagenum" id="Page_262">[Pg 262]</span> aristocratic
 uppers. But in this case gambolling behind the footlights is
 responsible for the present display of the Dankmere family pictures
 in the converted real-estate offices of young Mr. Quarren of
@@ -4742,7 +4742,7 @@ the sale of some of his treasures.</p>
 hears, however, of only a few isolated cases. The number of private
 deals that are executed, week in, week out, between impoverished
 members of the highest nobility&mdash;some of them bound, like Lord
-Blith<span class="pagenum"><a id="Page_263"></a>[Pg 263]</span>erington and the Duke of Putney by close official ties to the
+Blith<span class="pagenum" id="Page_263">[Pg 263]</span>erington and the Duke of Putney by close official ties to the
 Court&mdash;and the agents of either new-rich Britishers or wealthy
 Americans has reached its maximum, and by degrees unentailed
 treasures and heirlooms are passing from owners of many centuries
@@ -4773,7 +4773,7 @@ society. The desire to acquire riches quickly seems to have taken
 hold of the erstwhile staid and conventional upper ten, just as it
 has seized upon the smart set. The recent booms in oil and rubber
 have had the effect of transferring many a comfortable rent roll
-from its own<span class="pagenum"><a id="Page_264"></a>[Pg 264]</span>er's bankers&mdash;milady's just as often as milord's&mdash;to
+from its own<span class="pagenum" id="Page_264">[Pg 264]</span>er's bankers&mdash;milady's just as often as milord's&mdash;to
 the chartered mortgagors of the financial world. The panic in
 America in 1907 showed to what extent the English nobility was
 interested, not only in gilt-edged securities, but also to what
@@ -4805,7 +4805,7 @@ pilasters.</p>
 
 <p>Most of the land remained wild&mdash;weed-grown pastures, hard-wood ridges,
 neglected orchards planted seventy years ago. Molly Wycherly had ordered
-a brand<span class="pagenum"><a id="Page_265"></a>[Pg 265]</span> new old-time garden to be made for her overlooking the wide,
+a brand<span class="pagenum" id="Page_265">[Pg 265]</span> new old-time garden to be made for her overlooking the wide,
 unruffled river; also a series of sylvan paths along the wooded shores
 of the hill-set lake which was inhabited by bass placed there by orders
 of her husband.</p>
@@ -4837,7 +4837,7 @@ Caldera's model dairies are behind that hill; and that leather-headed
 O'Hara has a bungalow somewhere&mdash;and there's a sort of Hunt Club, too,
 and a bum pack of Kiyi's&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_266"></a>[Pg 266]</span></p>
+<p><span class="pagenum" id="Page_266">[Pg 266]</span></p>
 
 <p>The wind tore most of his speech from his lips and whirled it out of
 earshot: Quarren caught a word now and then which interested him. It
@@ -4867,7 +4867,7 @@ Stinger monoplane, wings set as wickedly as an alert wasp's.</p>
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_267"></a>[Pg 267]</span></p>
+<p><span class="pagenum" id="Page_267">[Pg 267]</span></p>
 
 <h2 class="nobreak" id="CHAPTER_IX">CHAPTER IX</h2>
 </div>
@@ -4908,7 +4908,7 @@ nearly every day."</p>
 
 <p>"Do you believe that?"</p>
 
-<p>"Frankly, no. I'm much more afraid that Langly<span class="pagenum"><a id="Page_268"></a>[Pg 268]<br /><a id="Page_269"></a>[Pg 269]<br /><a id="Page_270"></a>[Pg 270]</span> has persuaded her into
+<p>"Frankly, no. I'm much more afraid that Langly<span class="pagenum" id="Page_270">[Pg 270]</span> has persuaded her into
 some sort of a tacit engagement.... I don't know what the child can be
 thinking of&mdash;unless the universal criticism of Langly Sprowl has
 convinced her of his martyrdom.... There'll be a pretty situation when
@@ -4943,7 +4943,7 @@ before your appearance adds another distressing jolt."</p>
 
 <p>"Has she had another shock recently?"</p>
 
-<p><span class="pagenum"><a id="Page_271"></a>[Pg 271]</span></p>
+<p><span class="pagenum" id="Page_271">[Pg 271]</span></p>
 
 <p>"A letter from her lawyers. There won't be anything at all left for
 her."</p>
@@ -4978,7 +4978,7 @@ lie down on the lawn, dead beat, and Quarren resumed his toilet.</p>
 
 <p>Half an hour later he emerged from his quarters wearing tennis flannels
 and screwing the stem into a new pipe which he had decided to break
-in&mdash;a tall, well-built, pleasant-eyed young fellow with the city pallor<span class="pagenum"><a id="Page_272"></a>[Pg 272]</span>
+in&mdash;a tall, well-built, pleasant-eyed young fellow with the city pallor<span class="pagenum" id="Page_272">[Pg 272]</span>
 blanching his skin and the breeze stirring his short blond hair.</p>
 
 <p>"Hello, old man!" he said affably to the fat setter, who thumped his
@@ -5008,7 +5008,7 @@ strangers. Only here and there a glimpse of familiar sweet-william or
 the faint perfume of lemon-verbena brought a friendly warmth into his
 heart; but, in hostile silence he passed by hydrangea and althea,
 syringa and preposterous canna, quietly detesting the rose garden where
-scores of frail and frivo<span class="pagenum"><a id="Page_273"></a>[Pg 273]</span>lous strangers nodded amid anæmic leaves, or
+scores of frail and frivo<span class="pagenum" id="Page_273">[Pg 273]</span>lous strangers nodded amid anæmic leaves, or
 where great, blatant, aniline-coloured blossoms bulged in the sun,
 seeming to repeat with every strapping bud their Metropolitan price per
 dozen.</p>
@@ -5041,12 +5041,12 @@ pale, Mrs. Leeds. Have they engaged you as the family phantom?"</p>
 saw the dusky purple hue deepen in them under the downward sweep of the
 lashes.</p>
 
-<p><span class="pagenum"><a id="Page_274"></a>[Pg 274]<br /><a id="Page_275"></a>[Pg 275]</span></p>
+<p><span class="pagenum" id="Page_275">[Pg 275]</span></p>
 
 <p>[Illustration: "So he took the lake path and presently rounded a sharp
 curve."]</p>
 
-<p><span class="pagenum"><a id="Page_276"></a>[Pg 276]<br /><a id="Page_277"></a>[Pg 277]<br /><a id="Page_278"></a>[Pg 278]</span></p>
+<p><span class="pagenum" id="Page_278">[Pg 278]</span></p>
 
 <p>He waited for her to speak, and she did not. Her remote gaze rested on
 the lake where the base of the rocks fell away sheer into limpid depths;
@@ -5095,7 +5095,7 @@ pocket.</p>
 
 <p>"Really, Mr. Quarren&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_279"></a>[Pg 279]</span></p>
+<p><span class="pagenum" id="Page_279">[Pg 279]</span></p>
 
 <p>"Don't you want me to?"</p>
 
@@ -5139,7 +5139,7 @@ me take you seriously?"</p>
 
 <p>"That in itself is tragic enough," she laughed.</p>
 
-<p><span class="pagenum"><a id="Page_280"></a>[Pg 280]</span></p>
+<p><span class="pagenum" id="Page_280">[Pg 280]</span></p>
 
 <p>"It really is," he said: "because it has come to a time when you have
 <i>got</i> to take me seriously."</p>
@@ -5176,7 +5176,7 @@ lend you some witch-hazel&mdash;&mdash;"</p>
 <p>"Witch-hazel from Witch-Hollow ought to accomplish all kinds of magic,"
 he said. "I'll be delighted to have you bind it up."</p>
 
-<p><span class="pagenum"><a id="Page_281"></a>[Pg 281]</span></p>
+<p><span class="pagenum" id="Page_281">[Pg 281]</span></p>
 
 <p>"I didn't offer to; I offered you merely the ingredients."</p>
 
@@ -5219,7 +5219,7 @@ she could not ignore his unwarranted freedom.</p>
 
 <p>She hesitated, watching his expression. Then:</p>
 
-<p><span class="pagenum"><a id="Page_282"></a>[Pg 282]</span></p>
+<p><span class="pagenum" id="Page_282">[Pg 282]</span></p>
 
 <p>"You say that you always think of me&mdash;that way. But I'm afraid that,
 even in your thoughts, the repetition of my name has scarcely accustomed
@@ -5267,7 +5267,7 @@ avoid it.</p>
 <p>"I&mdash;your friends&mdash;people are eternally dinning your name into my
 ears&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_283"></a>[Pg 283]</span></p>
+<p><span class="pagenum" id="Page_283">[Pg 283]</span></p>
 
 <p>"Please answer."</p>
 
@@ -5305,7 +5305,7 @@ impulse to withdraw her hand. Then, once more, and after all these
 months, the same strange sensation passed through her&mdash;a thrilling
 consciousness of his nearness.</p>
 
-<p>Absolutely motionless, confused yet every instinct<span class="pagenum"><a id="Page_284"></a>[Pg 284]</span> alert to his
+<p>Absolutely motionless, confused yet every instinct<span class="pagenum" id="Page_284">[Pg 284]</span> alert to his
 slightest word or movement, she sat there, gray eyes partly lowered.</p>
 
 <p>He neither spoke nor moved; his pleasant glance rested absently on her,
@@ -5350,7 +5350,7 @@ kind of a wall remain between us&mdash;&mdash;"</p>
 such a man as I am becoming, and ultimately will be, should not tell you
 that he cares&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_285"></a>[Pg 285]</span></p>
+<p><span class="pagenum" id="Page_285">[Pg 285]</span></p>
 
 <p>"Please&mdash;if you please&mdash;I had rather not&mdash;&mdash;"</p>
 
@@ -5393,7 +5393,7 @@ motionless, looking down at the still lake below.</p>
 
 <p>"What <i>is</i> the barrier?" he asked quietly.</p>
 
-<p><span class="pagenum"><a id="Page_286"></a>[Pg 286]</span></p>
+<p><span class="pagenum" id="Page_286">[Pg 286]</span></p>
 
 <p>"There is no barrier to your friendship&mdash;if you care to offer it, now
 that you know me."</p>
@@ -5433,7 +5433,7 @@ what she was saying.</p>
 <p>Perhaps he had expected it. For a few moments the smile on his face
 became fixed and white, then he said, cheerfully:</p>
 
-<p><span class="pagenum"><a id="Page_287"></a>[Pg 287]</span></p>
+<p><span class="pagenum" id="Page_287">[Pg 287]</span></p>
 
 <p>"I'm going to fight for you all the same."</p>
 
@@ -5478,7 +5478,7 @@ eyes&mdash;&mdash;"</p>
 
 <p>"Is it dead?"</p>
 
-<p><span class="pagenum"><a id="Page_288"></a>[Pg 288]</span></p>
+<p><span class="pagenum" id="Page_288">[Pg 288]</span></p>
 
 <p>"It never lived!"</p>
 
@@ -5522,7 +5522,7 @@ know what I want to say except that&mdash;that&mdash;&mdash;"</p>
 
 <p>"Yes."</p>
 
-<p><span class="pagenum"><a id="Page_289"></a>[Pg 289]</span></p>
+<p><span class="pagenum" id="Page_289">[Pg 289]</span></p>
 
 <p>"It means a great deal to me," she said.</p>
 
@@ -5575,7 +5575,7 @@ think I've done, very cleverly?"</p>
 way to North Linden. We can't possibly get back until dinner. But that's
 not all."</p>
 
-<p><span class="pagenum"><a id="Page_290"></a>[Pg 290]</span></p>
+<p><span class="pagenum" id="Page_290">[Pg 290]</span></p>
 
 <p>"What more, most wonderful of women?"</p>
 
@@ -5617,7 +5617,7 @@ late afternoon sunlight poured flooding the room with a ruddy glory.</p>
 <p>"I wonder if there's enough of this celestial radiance to make a new
 aureole for you?" he said.</p>
 
-<p><span class="pagenum"><a id="Page_291"></a>[Pg 291]</span></p>
+<p><span class="pagenum" id="Page_291">[Pg 291]</span></p>
 
 <p>"So my old one is worn out, is it?"</p>
 
@@ -5660,11 +5660,11 @@ Is sweeter far than liquid honey!"<br />
 <p>And so on through the bleating of his sheep and the gobbling of her
 turkeys until they could scarcely sing for laughing.</p>
 
-<p><span class="pagenum"><a id="Page_292"></a>[Pg 292]<br /><a id="Page_293"></a>[Pg 293]</span></p>
+<p><span class="pagenum" id="Page_293">[Pg 293]</span></p>
 
 <p>[Illustration: "'The old ones are best.' she commented."]</p>
 
-<p><span class="pagenum"><a id="Page_294"></a>[Pg 294]<br /><a id="Page_295"></a>[Pg 295]<br /><a id="Page_296"></a>[Pg 296]</span></p>
+<p><span class="pagenum" id="Page_296">[Pg 296]</span></p>
 
 <p>Then the mood of the absurd seized her; and she made him sing "Johnny
 Schmoker" with her until they could scarcely draw breath for the eternal
@@ -5710,7 +5710,7 @@ to do something silly."</p>
 <p>"Then I'll recite something very, very precious&mdash;subtly, intricately,
 and psychologically precious."</p>
 
-<p><span class="pagenum"><a id="Page_297"></a>[Pg 297]</span></p>
+<p><span class="pagenum" id="Page_297">[Pg 297]</span></p>
 
 <p>"Oh, please do!"</p>
 
@@ -5766,7 +5766,7 @@ Love."</p>
   </div>
 </div>
 </div>
-<p><span class="pagenum"><a id="Page_298"></a>[Pg 298]</span></p>
+<p><span class="pagenum" id="Page_298">[Pg 298]</span></p>
 <p>She pretended to be overcome by the tragic pathos of the poem:</p>
 
 <p>"I cannot bear it," she protested; "I can't endure the realism of that
@@ -5802,7 +5802,7 @@ it&mdash;&mdash;"</p>
 <p>"You must not! You understand why!... And don't&mdash;again! I am not&mdash;I do
 not choose to&mdash;to allow&mdash;endure&mdash;such&mdash;things&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_299"></a>[Pg 299]</span></p>
+<p><span class="pagenum" id="Page_299">[Pg 299]</span></p>
 
 <p>He still held her by one hand and she stood twisting at it and looking
 at him with cheeks still crimson and eyes still a little dazed.</p>
@@ -5839,7 +5839,7 @@ friendship&mdash;as long as I never swerve in it&mdash;as long as I hold you fir
 among my friends&mdash;first among men if you wish! More I cannot offer
 you&mdash;I will not! Now let me go!"</p>
 
-<p><span class="pagenum"><a id="Page_300"></a>[Pg 300]</span></p>
+<p><span class="pagenum" id="Page_300">[Pg 300]</span></p>
 
 <p>"Your <i>other</i> self, fighting me," he said, half to himself.</p>
 
@@ -5878,7 +5878,7 @@ under his cheeks.</p>
 
 <p>She stood dumb, still cold and rigid with repulsion from the swift and
 almost brutal contact. That time nothing in her had responded. Vaguely
-she felt that<span class="pagenum"><a id="Page_301"></a>[Pg 301]</span> what had been there was now dead&mdash;that she never could
+she felt that<span class="pagenum" id="Page_301">[Pg 301]</span> what had been there was now dead&mdash;that she never could
 respond again; that, from the lesser emotions, she was clean and free
 forever.</p>
 
@@ -5924,7 +5924,7 @@ more stinging her cheeks.</p>
 
 <p>"Yes, I'll ask it if you like."</p>
 
-<p><span class="pagenum"><a id="Page_302"></a>[Pg 302]</span></p>
+<p><span class="pagenum" id="Page_302">[Pg 302]</span></p>
 
 <p>To keep her composure became difficult:</p>
 
@@ -5975,7 +5975,7 @@ her lightly on the arm:</p>
 
 <p>"I ask your forgiveness," he said.</p>
 
-<p><span class="pagenum"><a id="Page_303"></a>[Pg 303]</span></p>
+<p><span class="pagenum" id="Page_303">[Pg 303]</span></p>
 
 <p>"It is granted, Mr. Quarren."</p>
 
@@ -6020,7 +6020,7 @@ rattling off more rag-time. "Where did you go, Langly?"</p>
 <p>"They're fine nags!" remonstrated Molly&mdash;"and I was perfectly sure that
 Langly would buy half a dozen."</p>
 
-<p>"Not I," said that hatchet-faced young man; and<span class="pagenum"><a id="Page_304"></a>[Pg 304]</span> into his sleek and
+<p>"Not I," said that hatchet-faced young man; and<span class="pagenum" id="Page_304">[Pg 304]</span> into his sleek and
 restless features came a glimmer of shrewdness&mdash;the sly thrift that
 lurks in the faces of those who bargain much and wisely in petty wares.
 It must have been a momentary ancestral gleam from his rum-smuggling
@@ -6059,7 +6059,7 @@ she were speaking an unfamiliar language.</p>
 
 <p>Wycherly, reckless enough anyway, balked a little at the proposition:</p>
 
-<p><span class="pagenum"><a id="Page_305"></a>[Pg 305]</span></p>
+<p><span class="pagenum" id="Page_305">[Pg 305]</span></p>
 
 <p>"That Stinger is too light and too tricky I'm afraid."</p>
 
@@ -6102,7 +6102,7 @@ and sinister dog turns when laughed at.</p>
 <p>Strelsa slipped clear of the piano and vanished, chased heavily by
 Wycherly.</p>
 
-<p>Molly said: "It's time to dress, good people.<span class="pagenum"><a id="Page_306"></a>[Pg 306]</span> Langly, your man is
+<p>Molly said: "It's time to dress, good people.<span class="pagenum" id="Page_306">[Pg 306]</span> Langly, your man is
 upstairs with your outfit. Come, Chrysos, dear&mdash;Rix, have you everything
 you want?" she added in a low voice as he stood aside for her to pass:
 "Have you <i>everything</i>, Ricky?"</p>
@@ -6148,7 +6148,7 @@ speak, twice, then jerked open his door and disappeared.</p>
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_307"></a>[Pg 307]</span></p>
+<p><span class="pagenum" id="Page_307">[Pg 307]</span></p>
 
 <h2 class="nobreak" id="CHAPTER_X">CHAPTER X</h2>
 </div>
@@ -6184,7 +6184,7 @@ are there."</p>
 
 <p>"Why not?"</p>
 
-<p><span class="pagenum"><a id="Page_308"></a>[Pg 308]</span></p>
+<p><span class="pagenum" id="Page_308">[Pg 308]</span></p>
 
 <p>"Because&mdash;the fact is&mdash;I believe I practically&mdash;so to speak&mdash;hit him."</p>
 
@@ -6225,7 +6225,7 @@ in 'Ancestors' next October&mdash;&mdash;"</p>
 
 <p>"No, no, no!"</p>
 
-<p><span class="pagenum"><a id="Page_309"></a>[Pg 309]</span></p>
+<p><span class="pagenum" id="Page_309">[Pg 309]</span></p>
 
 <p>"Right-o! I'll tell her at luncheon.... I say, Quarren: Karl Westguard
 wants the gallery to-night. May I let him have it?"</p>
@@ -6271,7 +6271,7 @@ strike you?"</p>
 
 <p>"Not over me," he said grimly; but added: "How do you know she did?"</p>
 
-<p>"Her maid told mine," admitted Molly shame<span class="pagenum"><a id="Page_310"></a>[Pg 310]</span>lessly. "Now if you are going
+<p>"Her maid told mine," admitted Molly shame<span class="pagenum" id="Page_310">[Pg 310]</span>lessly. "Now if you are going
 to criticise my channels of information I'll remind you that Richelieu
 himself&mdash;&mdash;"</p>
 
@@ -6307,7 +6307,7 @@ fastidious among us, the finer grained and more delicately nerved, are
 essentially reserved. Modesty, pride, a natural aloofness, are as much a
 part of many women as their noses and fingers&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_311"></a>[Pg 311]</span></p>
+<p><span class="pagenum" id="Page_311">[Pg 311]</span></p>
 
 <p>"What becomes of modesty and pride when a girl marries for money?" he
 asked coolly.</p>
@@ -6342,7 +6342,7 @@ civilisation&mdash;&mdash;"</p>
 
 <p>"She is a very normal, sensitive, proud girl, who has known little
 except unhappiness all her life, Rix&mdash;including two years of marital
-misery&mdash;two years of<span class="pagenum"><a id="Page_312"></a>[Pg 312]</span> horror.&mdash;And you forget that those two years were
+misery&mdash;two years of<span class="pagenum" id="Page_312">[Pg 312]</span> horror.&mdash;And you forget that those two years were
 the result of a demand purely and brutally emotional&mdash;to which, a
 novice, utterly ignorant, she yielded&mdash;pushed on by her mother....
 Please be fair to her; remember that her childhood was pinched with
@@ -6380,7 +6380,7 @@ half to himself. "She will go on in the predestined orbit&mdash;&mdash;"</p>
 
 <p>"Kindness. And also manhood, Ricky. Don't you?"</p>
 
-<p><span class="pagenum"><a id="Page_313"></a>[Pg 313]</span></p>
+<p><span class="pagenum" id="Page_313">[Pg 313]</span></p>
 
 <p>"Perhaps so&mdash;now&mdash;after a fashion.... But I am not the man who could
 ever attract her&mdash;&mdash;"</p>
@@ -6417,7 +6417,7 @@ pantomime unmistakable; but her pretty lips merely pressed each other
 tighter, and she sauntered out, crop under one arm, with a careless
 greeting to Langly.</p>
 
-<p>He came up offering his hand and she took it, then<span class="pagenum"><a id="Page_314"></a>[Pg 314]<br /><a id="Page_315"></a>[Pg 315]<br /><a id="Page_316"></a>[Pg 316]</span> stood a moment in
+<p>He came up offering his hand and she took it, then<span class="pagenum" id="Page_316">[Pg 316]</span> stood a moment in
 desultory conversation, facing the others so as to include Quarren.</p>
 
 <p>[Illustration: "Strelsa in the library, pulling on her gloves, was
@@ -6460,7 +6460,7 @@ briefly.</p>
 
 <p>Langly's restless eyes protruded; he glanced from Molly to Strelsa, then
 his indifferent gaze wandered over the landscape. It was plain that the
-rebuke had not made the slightest impression. Molly looked angrily at<span class="pagenum"><a id="Page_317"></a>[Pg 317]</span>
+rebuke had not made the slightest impression. Molly looked angrily at<span class="pagenum" id="Page_317">[Pg 317]</span>
 Strelsa, but the latter, eyes averted, was gazing at her horse. And when
 Quarren came back with a handful of sugar she took it and, descending
 the steps, fed it, lump by lump to the two horses.</p>
@@ -6498,7 +6498,7 @@ morning.... Will you motor with Jim and me, Ricky dear?"</p>
 
 <p>"If you like."</p>
 
-<p>She did like. So presently a racing car was brought<span class="pagenum"><a id="Page_318"></a>[Pg 318]</span> around, Jim came
+<p>She did like. So presently a racing car was brought<span class="pagenum" id="Page_318">[Pg 318]</span> around, Jim came
 reluctantly from the hangar, and away they tore into the dull weather
 now faintly illuminated by the prophecy of the sun.</p>
 
@@ -6528,7 +6528,7 @@ blossoms and in the delicately brilliant wings hovering over them.</p>
 
 <p>Far away he could see the river and the launch, too, where Sir Charles
 and Chrysos Lacy were circling hither and thither at full speed. Once,
-across a distant hill,<span class="pagenum"><a id="Page_319"></a>[Pg 319]</span> two horses and their riders passed outlined
+across a distant hill,<span class="pagenum" id="Page_319">[Pg 319]</span> two horses and their riders passed outlined
 against the sky; but even the eyes of a lover and a hater could not
 identify anybody at such a distance.</p>
 
@@ -6566,7 +6566,7 @@ gentle&mdash;even with such a man.</p>
 of anybody," said Ledwith, turning the pages of his book without looking
 at them. Then, furtively, his sunken eyes rested a moment on Quarren:</p>
 
-<p><span class="pagenum"><a id="Page_320"></a>[Pg 320]</span></p>
+<p><span class="pagenum" id="Page_320">[Pg 320]</span></p>
 
 <p>"You are stopping with&mdash;&mdash;"</p>
 
@@ -6607,7 +6607,7 @@ imperceptibly shifted his gaze craftily askance:</p>
 
 <p>"There's no use pretending to <i>you</i>, Quarren; is there?"</p>
 
-<p><span class="pagenum"><a id="Page_321"></a>[Pg 321]</span></p>
+<p><span class="pagenum" id="Page_321">[Pg 321]</span></p>
 
 <p>Quarren said nothing.</p>
 
@@ -6652,7 +6652,7 @@ they still knew me&mdash;you were very kind to me, Quarren."</p>
 <p>Ledwith was now picking at his fingers, and Quarren saw that they were
 dreadfully scarred and maltreated.</p>
 
-<p>"You've always been kind to me," repeated Led<span class="pagenum"><a id="Page_322"></a>[Pg 322]</span>with, his extinct eyes
+<p>"You've always been kind to me," repeated Led<span class="pagenum" id="Page_322">[Pg 322]</span>with, his extinct eyes
 fixed on space. "Other people would have halted at sight of me and gone
 the other way&mdash;or passed by cutting me dead.... <i>You</i> sat down beside
 me."</p>
@@ -6696,7 +6696,7 @@ back his cuff, bent over. After a few moments he turned around, calmly:</p>
 
 <p>"Otherwise, also."</p>
 
-<p>"Quite likely. I've known a pretty woman&mdash;" He<span class="pagenum"><a id="Page_323"></a>[Pg 323]</span> ended with a weary
+<p>"Quite likely. I've known a pretty woman&mdash;" He<span class="pagenum" id="Page_323">[Pg 323]</span> ended with a weary
 gesture and dropped his head between his hands.</p>
 
 <p>"Quarren," he said, "there's only one hurt left in it all. I have two
@@ -6741,7 +6741,7 @@ made absolute."</p>
 
 <p>Quarren looked up.</p>
 
-<p><span class="pagenum"><a id="Page_324"></a>[Pg 324]</span></p>
+<p><span class="pagenum" id="Page_324">[Pg 324]</span></p>
 
 <p>"She's coming back here soon, now. I've had the place put in shape for
 her."</p>
@@ -6782,7 +6782,7 @@ for Roger O'Hara."</p>
 <p>"I don't suppose her parents would object to Sir Charles," said Quarren,
 smiling.</p>
 
-<p><span class="pagenum"><a id="Page_325"></a>[Pg 325]</span></p>
+<p><span class="pagenum" id="Page_325">[Pg 325]</span></p>
 
 <p>"That's why I hesitate to write. Sir Charles is in love with Strelsa;
 anybody can see that and everybody knows it. And it isn't likely that a
@@ -6821,7 +6821,7 @@ sweetly and unobtrusively that the Baronet was totally unaware of it.
 Molly, frankly out of temper, made no effort of any sort; her husband in
 his usual rude health and spirits talked about the Stinger to everybody.
 Strelsa, who had arrived late, and whose toilet made her later still,
-seemed inclined<span class="pagenum"><a id="Page_326"></a>[Pg 326]</span> to be rather cheerful and animated, but received little
+seemed inclined<span class="pagenum" id="Page_326">[Pg 326]</span> to be rather cheerful and animated, but received little
 encouragement from Molly.</p>
 
 <p>However, she chatted gaily with Sir Charles and with Quarren, and after
@@ -6854,7 +6854,7 @@ return; but that fat sybarite had his chin on Quarren's knees; and,
 presently, Strelsa moved forward, slowly, already certain who it was
 ahead of her.</p>
 
-<p><span class="pagenum"><a id="Page_327"></a>[Pg 327]</span></p>
+<p><span class="pagenum" id="Page_327">[Pg 327]</span></p>
 
 <p>Quarren rose as she came around the curve in the path:</p>
 
@@ -6901,7 +6901,7 @@ close quietly."</p>
 
 <p>"Very well&mdash;if you care to humiliate me&mdash;him&mdash;&mdash;"</p>
 
-<p>"Dear Mrs. Leeds, he isn't going to be humiliated,<span class="pagenum"><a id="Page_328"></a>[Pg 328]</span> because he doesn't
+<p>"Dear Mrs. Leeds, he isn't going to be humiliated,<span class="pagenum" id="Page_328">[Pg 328]</span> because he doesn't
 care. And you know I wouldn't humiliate you for all the world&mdash;&mdash;"</p>
 
 <p>"You will unless you let Langly express his formal regrets to you&mdash;&mdash;"</p>
@@ -6945,7 +6945,7 @@ of it."</p>
 
 <p>"I thought I spoiled that for both of us," he said.</p>
 
-<p>"I didn't say so. I told you that I didn't know<span class="pagenum"><a id="Page_329"></a>[Pg 329]</span> what you had done. I've
+<p>"I didn't say so. I told you that I didn't know<span class="pagenum" id="Page_329">[Pg 329]</span> what you had done. I've
 had time to reflect. It&mdash;our friendship isn't spoiled&mdash;if you still
 value it."</p>
 
@@ -6989,7 +6989,7 @@ fingers.</p>
 
 <p>"Then I am sorry I forgave you."</p>
 
-<p><span class="pagenum"><a id="Page_330"></a>[Pg 330]</span></p>
+<p><span class="pagenum" id="Page_330">[Pg 330]</span></p>
 
 <p>"<i>Are</i> you?"</p>
 
@@ -7033,7 +7033,7 @@ degrading&mdash;contemptible&mdash;&mdash;"</p>
 
 <p>"What are you saying?"</p>
 
-<p><span class="pagenum"><a id="Page_331"></a>[Pg 331]</span></p>
+<p><span class="pagenum" id="Page_331">[Pg 331]</span></p>
 
 <p>"I am telling you the truth," she retorted, pale, and breathing faster.
 "I'm telling you what I know&mdash;what I have learned in a bitter
@@ -7068,7 +7068,7 @@ please&mdash;about Tom, Dick, and Harry and about me, too."</p>
 
 <p>"There," he whispered&mdash;"there, there&mdash;you little, little girl. That's
 all I want of you after all&mdash;only what you want of me. I don't wish to
-marry you if you don't wish it; I won't&mdash;I perhaps couldn't really love<span class="pagenum"><a id="Page_332"></a>[Pg 332]</span>
+marry you if you don't wish it; I won't&mdash;I perhaps couldn't really love<span class="pagenum" id="Page_332">[Pg 332]</span>
 you very deeply if you didn't respond. I shall not bother you any
 more&mdash;or worry or nag or insist. What you do is right as far as I am
 concerned; what you offer I take; and whenever you find yourself unable
@@ -7107,7 +7107,7 @@ then&mdash;I was unhappy about you."</p>
 <p>"Do you really?"</p>
 
 <p>"Yes. It's been a case of men following, crowding after you, urging,
-importuning you to consider their<span class="pagenum"><a id="Page_333"></a>[Pg 333]</span> desires&mdash;to care for them in their
+importuning you to consider their<span class="pagenum" id="Page_333">[Pg 333]</span> desires&mdash;to care for them in their
 own way&mdash;all sorts I suppose, sad and sentimental, eager and exacting,
 head-long and boisterous&mdash;all at you constantly to give them what is
 not in you to give&mdash;what has never been awakened&mdash;what lies stunned,
@@ -7147,7 +7147,7 @@ was no longer there.</p>
 <p>"The first time I have ever spoken of it to anybody.... As long as my
 mother lived I did not once speak of it to her."</p>
 
-<p><span class="pagenum"><a id="Page_334"></a>[Pg 334]</span></p>
+<p><span class="pagenum" id="Page_334">[Pg 334]</span></p>
 
 <p>She rested in silence for a while, then:</p>
 
@@ -7186,7 +7186,7 @@ coloured my ideas long after I was grown up."</p>
 his answering smile she turned her cheek to his shoulder, hastily, and
 lay silent for a while. Presently she continued in a low voice:</p>
 
-<p><span class="pagenum"><a id="Page_335"></a>[Pg 335]</span></p>
+<p><span class="pagenum" id="Page_335">[Pg 335]</span></p>
 
 <p>"It was when we were returning for the April vacation&mdash;and the platform
 was crowded and some of the girls' brothers were there. There were two
@@ -7219,7 +7219,7 @@ lawyers; did you know it?"</p>
 
 <p>"Yes," she said wearily, "it was a bad dream&mdash;my mother, others&mdash;<i>his</i>
 family&mdash;many people strange and familiar passed through it. Then we
-travelled; I saw<span class="pagenum"><a id="Page_336"></a>[Pg 336]</span> nothing, feeling half dead.... We were married in the
+travelled; I saw<span class="pagenum" id="Page_336">[Pg 336]</span> nothing, feeling half dead.... We were married in the
 Hawaiian Islands."</p>
 
 <p>"I know."</p>
@@ -7268,7 +7268,7 @@ make the best of it."</p>
 
 <p>"That was all I could see to do about it."</p>
 
-<p><span class="pagenum"><a id="Page_337"></a>[Pg 337]</span></p>
+<p><span class="pagenum" id="Page_337">[Pg 337]</span></p>
 
 <p>"Don't you believe in divorce?"</p>
 
@@ -7314,7 +7314,7 @@ far as your fortune is concerned, you can offer me little more.... But
 it's sweet of you. You <i>are</i> generous, having so little and wishing to
 share it with me&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_338"></a>[Pg 338]</span></p>
+<p><span class="pagenum" id="Page_338">[Pg 338]</span></p>
 
 <p>"Could you wait for me, Strelsa?"</p>
 
@@ -7362,7 +7362,7 @@ leave?"</p>
 
 <p>"<i>Have</i> I kept you too long?"</p>
 
-<p><span class="pagenum"><a id="Page_339"></a>[Pg 339]</span></p>
+<p><span class="pagenum" id="Page_339">[Pg 339]</span></p>
 
 <p>"No; I can make it. We'll have to walk rather fast&mdash;&mdash;"</p>
 
@@ -7395,7 +7395,7 @@ contact; then he kissed her clasped hands and was gone.</p>
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_340"></a>[Pg 340]</span></p>
+<p><span class="pagenum" id="Page_340">[Pg 340]</span></p>
 
 <h2 class="nobreak" id="CHAPTER_XI">CHAPTER XI</h2>
 </div>
@@ -7423,7 +7423,7 @@ show-windows.</p>
 
 <p>Firemen lounged outside the Eighth Battalion quarters; here and there a
 grocer's or wine-seller's windows remained illuminated where those who
-were neither well-<span class="pagenum"><a id="Page_341"></a>[Pg 341]</span>to-do nor very poor passed to and fro with little
+were neither well-<span class="pagenum" id="Page_341">[Pg 341]</span>to-do nor very poor passed to and fro with little
 packages which seemed a burden under the sultry skies.</p>
 
 <p>At last, ahead, the pseudo-oriental towers of a synagogue varied the
@@ -7455,7 +7455,7 @@ Quarren&mdash;they're not a very fragrant lot."</p>
 
 <p>"What audience? Who are they?"</p>
 
-<p>"You Americans would call them a 'tough-looking<span class="pagenum"><a id="Page_342"></a>[Pg 342]<br /><a id="Page_343"></a>[Pg 343]<br /><a id="Page_344"></a>[Pg 344]<br /><a id="Page_345"></a>[Pg 345]<br /><a id="Page_346"></a>[Pg 346]</span> bunch&mdash;except
+<p>"You Americans would call them a 'tough-looking<span class="pagenum" id="Page_346">[Pg 346]</span> bunch&mdash;except
 Westguard and Bleecker De Groot and Mrs. Caldera&mdash;&mdash;"</p>
 
 <p>[Illustration: "A high and soulful tenor was singing 'Perfumes of
@@ -7491,7 +7491,7 @@ derelicts of the rear row.</p>
 <p>A thin, hirsute young man had just finished scattering the perfumes of
 Araby; other perfumes nearly finished Quarren; but he held his ground
 and gazed grimly at an improvised platform where sat in a half-circle
-and in full evening dress, Karl Westguard, Cyrille Caldera<span class="pagenum"><a id="Page_347"></a>[Pg 347]</span> and Bleecker
+and in full evening dress, Karl Westguard, Cyrille Caldera<span class="pagenum" id="Page_347">[Pg 347]</span> and Bleecker
 De Groot. Also there was a table supporting a Calla lily.</p>
 
 <p>Westguard was saying very earnestly: "The world calls me a novelist. I
@@ -7525,7 +7525,7 @@ mute answer which I have given you?"</p>
 <p>"De merry mitt," said a voice, promptly. Mr. De Groot smiled with
 sweetness and indulgence.</p>
 
-<p>"I apprehend your quaint and trenchant vernacu<span class="pagenum"><a id="Page_348"></a>[Pg 348]</span>lar," he said. "It <i>is</i>
+<p>"I apprehend your quaint and trenchant vernacu<span class="pagenum" id="Page_348">[Pg 348]</span>lar," he said. "It <i>is</i>
 the 'merry mitt'&mdash;the 'glad glove,' the 'happy hand'! Fifth Avenue
 clasps palms with Doyers Street&mdash;&mdash;"</p>
 
@@ -7556,7 +7556,7 @@ something or other.</p>
 
 <p>Then Westguard arose once more and told them all about the higher type
 of novel he was writing for humanity's sake, and became so interested
-and absorbed in<span class="pagenum"><a id="Page_349"></a>[Pg 349]</span> his own business that the impatient shuffling of shabby
+and absorbed in<span class="pagenum" id="Page_349">[Pg 349]</span> his own business that the impatient shuffling of shabby
 feet on the floor alone interrupted him.</p>
 
 <p>"Has anybody," inquired De Groot, sweetly, "any vital question to
@@ -7592,7 +7592,7 @@ the front stoop. Neither made any comment on the proceedings.</p>
 <p>Later the derelicts, moodily replete, shuffled forth into the night,
 herded lovingly by De Groot, still shaking hands.</p>
 
-<p>From the corner of the street opposite, Quarren and<span class="pagenum"><a id="Page_350"></a>[Pg 350]</span> Dankmere observed
+<p>From the corner of the street opposite, Quarren and<span class="pagenum" id="Page_350">[Pg 350]</span> Dankmere observed
 their departure, and, later, they beheld De Groot and Mrs. Caldera slip
 around the block and discreetly disappear into a 1912 touring-car with
 silver mountings and two men in livery on the box.</p>
@@ -7633,7 +7633,7 @@ either De Groot or the clergy, if we used our leisure in
 self-examination."</p>
 
 <p>His lordship went on piling up chairs. When he finished he started
-wandering around, hands in his pock<span class="pagenum"><a id="Page_351"></a>[Pg 351]</span>ets. Then he turned out all the
+wandering around, hands in his pock<span class="pagenum" id="Page_351">[Pg 351]</span>ets. Then he turned out all the
 electric lamps, drew the bay-window curtains wide so that the silvery
 radiance from the arc-light opposite made the darkness dimly lustrous.</p>
 
@@ -7671,7 +7671,7 @@ first I also thought it was merely stupidity."</p>
 
 <p>Dankmere crossed his short legs and lighted his pipe:</p>
 
-<p>"The majority of your better people have managed<span class="pagenum"><a id="Page_352"></a>[Pg 352]</span> not to know me. I've
+<p>"The majority of your better people have managed<span class="pagenum" id="Page_352">[Pg 352]</span> not to know me. I've
 met a lot of men of sorts, but they draw the line across their home
 thresholds&mdash;most of them. Is it the taint of vaudeville that their wives
 sniff at, or my rather celebrated indigence?"</p>
@@ -7715,7 +7715,7 @@ don't happen to coincide&mdash;that's all, Quarren."</p>
 <p>"I see. You and I are to alternate as salesmen?"</p>
 
 <p>"For a while. When things start I want to rent the basement and open a
-department for repairing, relining<span class="pagenum"><a id="Page_353"></a>[Pg 353]</span> and cleaning; and I'd like to be
+department for repairing, relining<span class="pagenum" id="Page_353">[Pg 353]</span> and cleaning; and I'd like to be
 able to do some of the work myself."</p>
 
 <p>"<i>You?</i>"</p>
@@ -7750,7 +7750,7 @@ gleaning in the gutters, and the sparrows.</p>
 <p>Clothing was a burden. He had some pongee garments which he put on,
 installed himself in the gallery with a Sunday paper, an iced lime
 julep, and a cigarette, and awaited the event of the young lady who
-had<span class="pagenum"><a id="Page_354"></a>[Pg 354]<br /><a id="Page_355"></a>[Pg 355]<br /><a id="Page_356"></a>[Pg 356]<br /><a id="Page_357"></a>[Pg 357]<br /><a id="Page_358"></a>[Pg 358]</span> advertised that she knew all about book-keeping, stenography,
+had<span class="pagenum" id="Page_358">[Pg 358]</span> advertised that she knew all about book-keeping, stenography,
 and typewriting, and could prove it.</p>
 
 <p>[Illustration: "She came about noon&mdash;a pale young girl, very slim in her
@@ -7797,7 +7797,7 @@ it to her.</p>
 
 <p>"Six months."</p>
 
-<p><span class="pagenum"><a id="Page_359"></a>[Pg 359]</span></p>
+<p><span class="pagenum" id="Page_359">[Pg 359]</span></p>
 
 <p>"And before that where were you?"</p>
 
@@ -7845,7 +7845,7 @@ taken my choice of them."</p>
 
 <p>"No."</p>
 
-<p><span class="pagenum"><a id="Page_360"></a>[Pg 360]</span></p>
+<p><span class="pagenum" id="Page_360">[Pg 360]</span></p>
 
 <p>"Oh. Then I've taken my choice, too."</p>
 
@@ -7884,7 +7884,7 @@ impromptu patter-song&mdash;</p>
     <div class="verse indent0">Even Mænads on the go,</div>
     <div class="verse indent0">Fat Bacchantes in a row&mdash;</div>
     <div class="verse indent0">Even ladies in a show</div>
-    <div class="verse indent2">Wear <i>some</i> threads of naperies!</div><span class="pagenum"><a id="Page_361"></a>[Pg 361]</span>
+    <div class="verse indent2">Wear <i>some</i> threads of naperies!</div><span class="pagenum" id="Page_361">[Pg 361]</span>
     <div class="verse indent0">Through the heavens planet-strewn</div>
     <div class="verse indent2">Where a shred of vapour is</div>
     <div class="verse indent0">Quickly clothes herself the Moon!</div>
@@ -7929,7 +7929,7 @@ desk:</p>
 
 <p>"Are you going to tell people that?"</p>
 
-<p><span class="pagenum"><a id="Page_362"></a>[Pg 362]</span></p>
+<p><span class="pagenum" id="Page_362">[Pg 362]</span></p>
 
 <p>"If they ask me," said Quarren, smiling.</p>
 
@@ -7975,7 +7975,7 @@ ever see such colour?"</p>
 
 <p>"It's&mdash;er&mdash;pretty," said his lordship.</p>
 
-<p><span class="pagenum"><a id="Page_363"></a>[Pg 363]</span></p>
+<p><span class="pagenum" id="Page_363">[Pg 363]</span></p>
 
 <p>And so during the entire afternoon they compiled the price-list and
 catalogue, marking copies for what they were, noting such pictures as
@@ -8010,7 +8010,7 @@ side.</p>
 
 <p>"It sure is."</p>
 
-<p><span class="pagenum"><a id="Page_364"></a>[Pg 364]</span></p>
+<p><span class="pagenum" id="Page_364">[Pg 364]</span></p>
 
 <p>"God bless my soul! she acts as though she had just bought in the whole
 place."</p>
@@ -8047,7 +8047,7 @@ inclination of gravely preoccupied faces.</p>
 <p>When the last leisurely lingerer had taken his leave Quarren said to
 Jessie Vining:</p>
 
-<p>"Those are representatives of various first-class<span class="pagenum"><a id="Page_365"></a>[Pg 365]</span> dealers&mdash;confidential
+<p>"Those are representatives of various first-class<span class="pagenum" id="Page_365">[Pg 365]</span> dealers&mdash;confidential
 buyers, sons&mdash;even dealers themselves&mdash;like that handsome gray-haired
 young-looking man who is Max Von Ebers, head of that great house."</p>
 
@@ -8077,7 +8077,7 @@ bought pictures now and then because it was fashionable to do so. Also,
 these same women-brokers represented a number of those unhappy old
 families who, incognito, were being forced by straitened circumstances
 to part secretly with heirlooms&mdash;family plate, portraits, miniatures,
-furniture&mdash;even with the antique mirrors on the walls<span class="pagenum"><a id="Page_366"></a>[Pg 366]</span> and the very
+furniture&mdash;even with the antique mirrors on the walls<span class="pagenum" id="Page_366">[Pg 366]</span> and the very
 fire-dogs on the hearth amid the ashes of a burnt-out race almost
 extinct.</p>
 
@@ -8112,7 +8112,7 @@ at her elbow.</p>
 <p>The last days of June and the first of July were repetitions in a
 measure of the opening day at the Dankmere Galleries; people came and
 were received and entertained by Quarren; Dankmere sat about in various
-chairs or retired furtively to the backyard to<span class="pagenum"><a id="Page_367"></a>[Pg 367]</span> smoke at intervals;
+chairs or retired furtively to the backyard to<span class="pagenum" id="Page_367">[Pg 367]</span> smoke at intervals;
 Jessie Vining with more colour in her pale, oval face, ruled her corner
 of the room in a sort of sweet and silent dignity.</p>
 
@@ -8145,11 +8145,11 @@ society.</p>
 resembled his dead Countess that his lordship began to understand why he
 had committed a felony before he actually knew what he was doing.</p>
 
-<p><span class="pagenum"><a id="Page_368"></a>[Pg 368]</span></p>
+<p><span class="pagenum" id="Page_368">[Pg 368]</span></p>
 
 <p>[Illustration: Jessie Vining.]</p>
 
-<p><span class="pagenum"><a id="Page_369"></a>[Pg 369]<br /><a id="Page_370"></a>[Pg 370]</span></p>
+<p><span class="pagenum" id="Page_370">[Pg 370]</span></p>
 
 <p>And one day when Quarren was still out for lunch and Jessie had returned
 to her correspondence, the terrified Earl suddenly appeared before her
@@ -8187,7 +8187,7 @@ instinctive distrust and aversion which, in the beginning, she had
 entertained for his lordship, suddenly disappeared so entirely that it
 surprised her when she had leisure to think it over afterward.</p>
 
-<p>So she gave him the post-card, and next day she<span class="pagenum"><a id="Page_371"></a>[Pg 371]</span> found a rose in a glass
+<p>So she gave him the post-card, and next day she<span class="pagenum" id="Page_371">[Pg 371]</span> found a rose in a glass
 of water on her desk; and that ended the incident for them both except
 that Dankmere was shyer of her than ever and she was beginning to
 realise that his aloof and expressionless deportment was due to
@@ -8217,7 +8217,7 @@ his trade&mdash;the guarded secrets of mediums and solvents, the composition
 of ancient and modern canvases, how old and modern colours were ground
 and prepared, how mixed, how applied.</p>
 
-<p><span class="pagenum"><a id="Page_372"></a>[Pg 372]</span></p>
+<p><span class="pagenum" id="Page_372">[Pg 372]</span></p>
 
 <p>He learned how the old masters of the various schools of painting
 prepared a canvas or panel&mdash;how the snowy "veil" was spread and dried,
@@ -8248,7 +8248,7 @@ and cunning falsehoods.</p>
 relined; canvases showing portions of original colour; old canvases and
 panels repainted and artificially darkened and cleverly covered with
 both paint and varnish cracks; canvases that almost defied detection by
-needle-point or glass or thumb fric<span class="pagenum"><a id="Page_373"></a>[Pg 373]</span>tion or solvent, so ingenious was
+needle-point or glass or thumb fric<span class="pagenum" id="Page_373">[Pg 373]</span>tion or solvent, so ingenious was
 the forgery simulating age.</p>
 
 <p>Every known adjunct was provided to carry out deception&mdash;genuinely old
@@ -8277,7 +8277,7 @@ the second lest disaster tarnish forever the exquisite bloom of the
 shrouded glazing; to cautiously explore for suspected signatures, to
 brood and ponder over ancient records and alleged pedigrees; to compare
 prints and mezzotints, photographs and engravings in search for
-identities; to study threads of canvas, flakes of varnish,<span class="pagenum"><a id="Page_374"></a>[Pg 374]</span> flinty
+identities; to study threads of canvas, flakes of varnish,<span class="pagenum" id="Page_374">[Pg 374]</span> flinty
 globules of paint under the microscope; to learn, little by little, the
 technical manners and capricious mannerisms significant of the progress
 periods of each dead master; to pore over endless volumes, monographs,
@@ -8303,7 +8303,7 @@ either nostril.</p>
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_375"></a>[Pg 375]</span></p>
+<p><span class="pagenum" id="Page_375">[Pg 375]</span></p>
 
 <h2 class="nobreak" id="CHAPTER_XII">CHAPTER XII</h2>
 </div>
@@ -8336,7 +8336,7 @@ I'm burnt out&mdash;deadly tired, wanting nothing more than I shall have
 by marrying as I must marry. For I shall have you, too, as I have
 always had you. You said so, didn't you?</p>
 
-<p><span class="pagenum"><a id="Page_376"></a>[Pg 376]</span></p>
+<p><span class="pagenum" id="Page_376">[Pg 376]</span></p>
 
 <p>"What difference, then, does it make to you or me whether or not I
 am married?</p>
@@ -8372,7 +8372,7 @@ fished him out&mdash;swearing, they say.</p>
 
 <p>"Vincent Wier made a fine flight in his Delatour Dragon, sailing
 'round and 'round like a big hawk for a quarter of an hour, but the
-wind came up and he<span class="pagenum"><a id="Page_377"></a>[Pg 377]</span> couldn't land, and he finally came down thirty
+wind came up and he<span class="pagenum" id="Page_377">[Pg 377]</span> couldn't land, and he finally came down thirty
 miles north of us in a swamp.</p>
 
 <p>"Langly took me for a short flight in his Owlet No. 3&mdash;only two
@@ -8413,7 +8413,7 @@ days to come.</p>
 
 <p>"What you have written leaves me with nothing to answer except
 this. To all it is given to endure according to their strength;
-beyond it no one can<span class="pagenum"><a id="Page_378"></a>[Pg 378]</span> strive; but short of its limits it's a shame
+beyond it no one can<span class="pagenum" id="Page_378">[Pg 378]</span> strive; but short of its limits it's a shame
 to show faint-heartedness.</p>
 
 <p>"About the man you are determined to marry I have no further word
@@ -8447,7 +8447,7 @@ drowned it in my ass's ears.</p>
 there is only one thing that counts in the world&mdash;one thing worth
 having, worth giving&mdash;love!</p>
 
-<p><span class="pagenum"><a id="Page_379"></a>[Pg 379]</span></p>
+<p><span class="pagenum" id="Page_379">[Pg 379]</span></p>
 
 <p>"But in my heart I know it is not so; and the romancers are
 mistaken; and so is the heart denied.</p>
@@ -8483,7 +8483,7 @@ the world&mdash;after the approval of your own mind. I wish you cared
 for me not only as you do but with all that has never been aroused
 in you. For without that I am helpless to fight for you.</p>
 
-<p><span class="pagenum"><a id="Page_380"></a>[Pg 380]</span></p>
+<p><span class="pagenum" id="Page_380">[Pg 380]</span></p>
 
 <p>"So, in your own way, you will live life through, knowing that in
 me you will always have an unchanged friend&mdash;even though the lover
@@ -8516,7 +8516,7 @@ the work of silversmiths, goldsmiths, of sculptors in ivory or in
 wood long dead; or in the untinted marbles of the immortal masters.</p>
 
 <p>"Never before did I understand how indissolubly all arts are
-linked, how closely and eternally knit to<span class="pagenum"><a id="Page_381"></a>[Pg 381]</span>gether in the vast fabric
+linked, how closely and eternally knit to<span class="pagenum" id="Page_381">[Pg 381]</span>gether in the vast fabric
 fashioned by man from the beginning of time, and in the cryptograms
 of which lie buried all that man has ever thought and hoped.</p>
 
@@ -8549,7 +8549,7 @@ Dankmere and myself at some near restaurant; and after dinner Karl
 Westguard comes in and reads the most recent chapter of his
 novel&mdash;or perhaps Dankmere plays and sings old-time songs for
 us&mdash;or, if the heat makes us feel particularly futile, I perform
-some of those highly intellectual tricks which once made<span class="pagenum"><a id="Page_382"></a>[Pg 382]<br /><a id="Page_383"></a>[Pg 383]<br /><a id="Page_384"></a>[Pg 384]<br /><a id="Page_385"></a>[Pg 385]<br /><a id="Page_386"></a>[Pg 386]</span> me
+some of those highly intellectual tricks which once made<span class="pagenum" id="Page_386">[Pg 386]</span> me
 acceptable among people I now seldom or never see.</p>
 
 <p>[Illustration: "'In the evenings sometimes Miss Vining remains and
@@ -8586,7 +8586,7 @@ Water' for you; Miss Vining will talk pretty platitudes to you,
 Daisy will purr for you, and the painted eyes of Dankmere's
 ancestors will look down approvingly at you from the wall; and all
 our little world will know that the loveliest and best of all the
-greater world is break<span class="pagenum"><a id="Page_387"></a>[Pg 387]</span>ing bread with us under our roof, and that
+greater world is break<span class="pagenum" id="Page_387">[Pg 387]</span>ing bread with us under our roof, and that
 one for once, unlike man's dealings with your celestial sisters,
 our entertainment of you will not be wholly unawares.</p>
 </div>
@@ -8621,7 +8621,7 @@ keepers of the house shall tremble"? Perhaps he was unconsciously
 obeying nature's first law.</p>
 
 <p>And yet, slowly within him grew a certainty that these reasons were not
-the real ones&mdash;not the vital im<span class="pagenum"><a id="Page_388"></a>[Pg 388]</span>pulse that moved his hand steadily
+the real ones&mdash;not the vital im<span class="pagenum" id="Page_388">[Pg 388]</span>pulse that moved his hand steadily
 through critical and delicate moments as he bent, breathless, over the
 faded splendours of ancient canvases. No; somehow or other he had
 already begun to work for the sake of the work itself&mdash;whatever that
@@ -8652,7 +8652,7 @@ house not swarming with typhoid germs, get me a glass of it."</p>
 fanned and panted, her little green eyes roaming around her.</p>
 
 <p>Presently she dismissed the footman, and turned her heavily flushed face
-on Quarren. The rolls of fat<span class="pagenum"><a id="Page_389"></a>[Pg 389]</span> crowded the lace on her neck, perspiration
+on Quarren. The rolls of fat<span class="pagenum" id="Page_389">[Pg 389]</span> crowded the lace on her neck, perspiration
 glistened under her sparklike eyes.</p>
 
 <p>"How are you?" she inquired.</p>
@@ -8699,7 +8699,7 @@ I never fancied that little bounder&mdash;&mdash;"</p>
 <p>The old lady's eyes blazed. "I'm damned if I do!" she retorted&mdash;"I'll
 say what&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_390"></a>[Pg 390]</span></p>
+<p><span class="pagenum" id="Page_390">[Pg 390]</span></p>
 
 <p>"Not here! You mustn't be uncivil here. You know well enough how to
 behave when necessary; and if you don't do it I'll call your carriage."</p>
@@ -8740,7 +8740,7 @@ learn anything from Strelsa Leeds; and as for Langly he won't even
 answer my letters.</p>
 
 <p>"Now I want to know what is going on there? I've been as short with
-Strelsa as I dare be&mdash;she's got to be<span class="pagenum"><a id="Page_391"></a>[Pg 391]</span> led with sugar. I've almost
+Strelsa as I dare be&mdash;she's got to be<span class="pagenum" id="Page_391">[Pg 391]</span> led with sugar. I've almost
 ordered her to come to me at Newport&mdash;but she doesn't come."</p>
 
 <p>"She's resting," said Quarren coolly.</p>
@@ -8778,7 +8778,7 @@ remind you that you cannot expect me to answer them."</p>
 
 <p>"Because what concerns him does not concern me."</p>
 
-<p><span class="pagenum"><a id="Page_392"></a>[Pg 392]</span></p>
+<p><span class="pagenum" id="Page_392">[Pg 392]</span></p>
 
 <p>"I thought you were in love with Strelsa," she said bluntly.</p>
 
@@ -8816,7 +8816,7 @@ marrying Sir Charles. You know it is. Could anything on earth be more
 suitable?&mdash;happier for her as well as for him? Isn't he a man where
 Langly is a&mdash;a toad, a cold-blooded worm!&mdash;a&mdash;a thing!</p>
 
-<p>"I tell you my heart's set on it; there is nothing else<span class="pagenum"><a id="Page_393"></a>[Pg 393]</span> interests me; I
+<p>"I tell you my heart's set on it; there is nothing else<span class="pagenum" id="Page_393">[Pg 393]</span> interests me; I
 think of nothing else, care for nothing else&mdash;&mdash;"</p>
 
 <p>"Why?"</p>
@@ -8862,7 +8862,7 @@ pain had cut mirth short.</p>
 
 <p>"Nothing.... <i>You</i> are the matter.... I've always been fool enough to
 take you for a fool. You were the only one among us clever enough to
-read us<span class="pagenum"><a id="Page_394"></a>[Pg 394]</span> and remain unread. God! If only some of us could see what we
+read us<span class="pagenum" id="Page_394">[Pg 394]</span> and remain unread. God! If only some of us could see what we
 look like in the archives of your brain!... Let it go at that; I don't
 care what I look like as long as it's a friendly hand that draws my
 features.... I'm an old woman, remember.... And it <i>is</i> a friendly
@@ -8901,7 +8901,7 @@ these things, Rix?"</p>
 
 <p>"Then you know them now."</p>
 
-<p><span class="pagenum"><a id="Page_395"></a>[Pg 395]</span></p>
+<p><span class="pagenum" id="Page_395">[Pg 395]</span></p>
 
 <p>"Yes, I&mdash;" he hesitated, looking straight at her in silence. And after a
 while a slight colour not due to the heat deepened the florid hue of her
@@ -8934,7 +8934,7 @@ Quarren, all the cunning and hardness gone from her heavy features.</p>
 <p>"I've only been trying to do for a dead man's son what might have
 pleased that man were he alive," she said. "Sir Charles was a little lad
 when he died. But he left a letter for him to read when he was grown up.
-I never saw the letter, but Sir Charles has told me that,<span class="pagenum"><a id="Page_396"></a>[Pg 396]</span> in it, his
+I never saw the letter, but Sir Charles has told me that,<span class="pagenum" id="Page_396">[Pg 396]</span> in it, his
 father spoke&mdash;amiably&mdash;of me and said that in me his son would always
 find a friend.... That is all, Rix. Do you believe me?"</p>
 
@@ -8971,7 +8971,7 @@ Charles."</p>
 
 <p>Quarren looked at her oddly:</p>
 
-<p>"But Sir Charles is her friend, you see. And so<span class="pagenum"><a id="Page_397"></a>[Pg 397]</span> am I.... Friends do not
+<p>"But Sir Charles is her friend, you see. And so<span class="pagenum" id="Page_397">[Pg 397]</span> am I.... Friends do not
 make a convenience of one another."</p>
 
 <p>"She could learn to love him. He is a lovable fellow."</p>
@@ -9006,7 +9006,7 @@ Dankmere. Really, Rix, I must be going&mdash;if you'll call my man&mdash;&mdash;
 <p>So Mrs. Sprowl rolled away in her motor, and Quarren came back, wearied
 with the perplexities and strain of life, to face once more the lesser
 problems of the immediate present: one of them was an ancient panel in
-the<span class="pagenum"><a id="Page_398"></a>[Pg 398]</span> basement, and he went downstairs to solve it, leaving Dankmere
+the<span class="pagenum" id="Page_398">[Pg 398]</span> basement, and he went downstairs to solve it, leaving Dankmere
 sorting out old prints and Jessie Vining, who had just returned, writing
 business letters on her machine.</p>
 
@@ -9036,7 +9036,7 @@ prints over there, be a peer of the British realm? Was this young man,
 whom she had seen turning handsprings on the grass in the backyard, a
 belted Earl?</p>
 
-<p>In spite of herself her short upper lip curled slightly<span class="pagenum"><a id="Page_399"></a>[Pg 399]</span> as she turned
+<p>In spite of herself her short upper lip curled slightly<span class="pagenum" id="Page_399">[Pg 399]</span> as she turned
 from her book to glance at him. He looked up at the same moment, and
 smiled on meeting her eye&mdash;such a kindly yet diffident smile that she
 blushed a trifle.</p>
@@ -9084,7 +9084,7 @@ my mind is occupied in wondering what your age might be?"</p>
 
 <p>"Isn't it?"</p>
 
-<p><span class="pagenum"><a id="Page_400"></a>[Pg 400]</span></p>
+<p><span class="pagenum" id="Page_400">[Pg 400]</span></p>
 
 <p>"Of course not."</p>
 
@@ -9139,7 +9139,7 @@ are far worse off."</p>
 
 <p>"It's not so bad. That show business let me in for a lot."</p>
 
-<p><span class="pagenum"><a id="Page_401"></a>[Pg 401]</span></p>
+<p><span class="pagenum" id="Page_401">[Pg 401]</span></p>
 
 <p>"Why did you ever do it?"</p>
 
@@ -9182,7 +9182,7 @@ I'll be out of debt fast enough."</p>
 
 <p>"And leave Mr. Quarren?"</p>
 
-<p><span class="pagenum"><a id="Page_402"></a>[Pg 402]</span></p>
+<p><span class="pagenum" id="Page_402">[Pg 402]</span></p>
 
 <p>"What use am I? We'd share alike; he'd manage the business and I'd
 manage a musical comedy I'm writing after hours&mdash;&mdash;"</p>
@@ -9222,7 +9222,7 @@ softly, then drifted into the old-time melody, "Shannon Water."</p>
 
 <p>His voice was a pleasantly modulated barytone when he chose; he sang the
 quaint and lovely old song in perfect taste. Then, very lightly, he sang
-"The Harp,"<span class="pagenum"><a id="Page_403"></a>[Pg 403]</span> and afterward an old Breton song made centuries ago.</p>
+"The Harp,"<span class="pagenum" id="Page_403">[Pg 403]</span> and afterward an old Breton song made centuries ago.</p>
 
 <p>When he turned Miss Vining was resting her head on both hands, eyes
 lowered.</p>
@@ -9261,14 +9261,14 @@ with a nod of good-night, when he said:</p>
 <p>"Yes&mdash;if&mdash;&mdash;"</p>
 
 <p>Lord Dankmere waited, but she did not complete whatever it was she had
-meant to say. Then, very<span class="pagenum"><a id="Page_404"></a>[Pg 404]</span> slowly she turned northward, and he went, too,
+meant to say. Then, very<span class="pagenum" id="Page_404">[Pg 404]</span> slowly she turned northward, and he went, too,
 grasping his walking-stick with unnecessary firmness and carrying
 himself with the determination and dignity of a man who is walking
 beside a pretty girl slightly taller than himself.</p>
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_405"></a>[Pg 405]</span></p>
+<p><span class="pagenum" id="Page_405">[Pg 405]</span></p>
 
 <h2 class="nobreak" id="CHAPTER_XIII">CHAPTER XIII</h2>
 </div>
@@ -9300,7 +9300,7 @@ except what she had with her at Witch-Hollow, and her very beautiful
 collection of old lace, were placed in the hands of certain discreet
 people to dispose of privately.</p>
 
-<p><span class="pagenum"><a id="Page_406"></a>[Pg 406]</span></p>
+<p><span class="pagenum" id="Page_406">[Pg 406]</span></p>
 
 <p>Every servant in her employment except her maid was paid and dismissed;
 her resignation from the Province Club was forwarded, all social
@@ -9335,7 +9335,7 @@ me&mdash;you don't know, Rix&mdash;but while there remains any chance of
 meeting my obligations dollar for dollar I have refused to go
 through bankruptcy.</p>
 
-<p><span class="pagenum"><a id="Page_407"></a>[Pg 407]</span></p>
+<p><span class="pagenum" id="Page_407">[Pg 407]</span></p>
 
 <p>"I need not, now, I think. But the selling of everything will not
 leave me very much; and in the end my cowardice will do what you
@@ -9371,7 +9371,7 @@ bother to come up here&mdash;&mdash;"</p>
 
 <p>"Who?" said Strelsa, sitting up. "Mrs. Sprowl?"</p>
 
-<p><span class="pagenum"><a id="Page_408"></a>[Pg 408]</span></p>
+<p><span class="pagenum" id="Page_408">[Pg 408]</span></p>
 
 <p>"Certainly, horse, foot, and dragoons! She's coming, I tell you, and
 there's only one motive for her advent!"</p>
@@ -9412,7 +9412,7 @@ back.</p>
 <p>"If she means it that way, it is slanderous," she said. "The entire
 story is a base slander! Did <i>you</i> believe it, Molly?"</p>
 
-<p><span class="pagenum"><a id="Page_409"></a>[Pg 409]</span></p>
+<p><span class="pagenum" id="Page_409">[Pg 409]</span></p>
 
 <p>"Believe it? Of course I believe it&mdash;&mdash;"</p>
 
@@ -9460,7 +9460,7 @@ marry anybody!&mdash;Why&mdash;&mdash;"</p>
 I&mdash;I'm not very well&mdash;&mdash;"</p>
 
 <p>"I can't help it," said Molly, grimly. "I'm sorry, darling, but the
-moment your engagement to Langly is<span class="pagenum"><a id="Page_410"></a>[Pg 410]</span> announced there'll be a horrid
+moment your engagement to Langly is<span class="pagenum" id="Page_410">[Pg 410]</span> announced there'll be a horrid
 smash and some people are going to be spattered&mdash;&mdash;"</p>
 
 <p>"It <i>isn't</i> announced!" said the girl hotly. "Only you and Rix know
@@ -9501,7 +9501,7 @@ Of what, then?"</p>
 
 <p>"We're a hardened lot&mdash;some of us. But our most deadly fear is that the
 papers may <i>not</i> notice us. No matter what they say if they'll only say
-something!&mdash;that's our necessity and our unadmitted prayer. Be<span class="pagenum"><a id="Page_411"></a>[Pg 411]</span>cause
+something!&mdash;that's our necessity and our unadmitted prayer. Be<span class="pagenum" id="Page_411">[Pg 411]</span>cause
 we've neither brains nor culture nor any distinguishing virtue or
 ability&mdash;and we're nothing&mdash;absolutely nothing unless the papers create
 us! Don't tell me that any one among us is afraid of publicity!&mdash;not in
@@ -9540,11 +9540,11 @@ ask," she said almost drowsily.</p>
 <p>Molly sprang up, came around and kissed her, lightly: "Of course. That
 was what I was going to ask of you."</p>
 
-<p><span class="pagenum"><a id="Page_412"></a>[Pg 412]<br /><a id="Page_413"></a>[Pg 413]</span></p>
+<p><span class="pagenum" id="Page_413">[Pg 413]</span></p>
 
 <p>[Illustration: "'If you'll let me, I'll stand by you, darling.'"]</p>
 
-<p><span class="pagenum"><a id="Page_414"></a>[Pg 414]<br /><a id="Page_415"></a>[Pg 415]<br /><a id="Page_416"></a>[Pg 416]</span></p>
+<p><span class="pagenum" id="Page_416">[Pg 416]</span></p>
 
 <p>Strelsa closed her eyes. "I'll stay," she murmured.</p>
 
@@ -9579,7 +9579,7 @@ desperate self-control&mdash;two years of courage&mdash;high moral courage,
 determination, self-suppression&mdash;and of the startling and dreadful
 climax.</p>
 
-<p><span class="pagenum"><a id="Page_417"></a>[Pg 417]</span></p>
+<p><span class="pagenum" id="Page_417">[Pg 417]</span></p>
 
 <p>"That is the blow you are now feeling&mdash;and the reaction even after two
 years more of half-stunned solitude. You are waking, darling; that is
@@ -9626,7 +9626,7 @@ once&mdash;&mdash;"</p>
 <p>"Molly," she said, "I don't believe that Sir Charles is going to mind
 very much."</p>
 
-<p>Molly met her eyes for an instant, very near, and a<span class="pagenum"><a id="Page_418"></a>[Pg 418]</span> pale flash of
+<p>Molly met her eyes for an instant, very near, and a<span class="pagenum" id="Page_418">[Pg 418]</span> pale flash of
 telepathy passed between them. Then Strelsa smiled.</p>
 
 <p>"You mean Chrysos," said Molly.</p>
@@ -9667,7 +9667,7 @@ lot of the other kind all my life."</p>
 
 <p>They laughed.</p>
 
-<p><span class="pagenum"><a id="Page_419"></a>[Pg 419]</span></p>
+<p><span class="pagenum" id="Page_419">[Pg 419]</span></p>
 
 <p>Strelsa went on: "Perhaps when I sell everything I'll have enough left
 over to buy a little house up here near you, Molly, and have pigs and
@@ -9703,7 +9703,7 @@ money left to let me rest somewhere&mdash;&mdash;"</p>
 
 <p>"There will be," said Molly, watching her.</p>
 
-<p><span class="pagenum"><a id="Page_420"></a>[Pg 420]</span></p>
+<p><span class="pagenum" id="Page_420">[Pg 420]</span></p>
 
 <p>"Do you think so? And&mdash;then there would be no necessity for&mdash;for&mdash;&mdash;"</p>
 
@@ -9741,7 +9741,7 @@ they mean is Truth.</p>
 studied it and found comfort; all saints in all ages have found in
 it strength.</p>
 
-<p><span class="pagenum"><a id="Page_421"></a>[Pg 421]</span></p>
+<p><span class="pagenum" id="Page_421">[Pg 421]</span></p>
 
 <p>"I find its traces in every ancient picture that I touch. But there
 are books still older that have lived because of it. And one man
@@ -9781,7 +9781,7 @@ have altered her views of life.</p>
 Langly and the horses had already gathered: he put her up, and they
 cantered away down the wooded road that led to South Linden.</p>
 
-<p><span class="pagenum"><a id="Page_422"></a>[Pg 422]</span></p>
+<p><span class="pagenum" id="Page_422">[Pg 422]</span></p>
 
 <p>After their first gallop they slowed to a walk on the farther hill
 slope, chatting of inconsequential things; and it seemed to her that he
@@ -9822,7 +9822,7 @@ Ledwith returns to South Linden?"</p>
 <p>"Be civil if I see her."</p>
 
 <p>"Of course," she said, reddening. "I was wondering whether gossip might
-be nipped in the bud if you<span class="pagenum"><a id="Page_423"></a>[Pg 423]</span> left before she arrives and remained away
+be nipped in the bud if you<span class="pagenum" id="Page_423">[Pg 423]</span> left before she arrives and remained away
 until she leaves."</p>
 
 <p>His prominent eyes were searching her features all the while she was
@@ -9859,7 +9859,7 @@ later, when a man has got to consider himself."</p>
 
 <p>"Has it occurred to you to consider, me, Langly?"</p>
 
-<p><span class="pagenum"><a id="Page_424"></a>[Pg 424]</span></p>
+<p><span class="pagenum" id="Page_424">[Pg 424]</span></p>
 
 <p>"What? Certainly. Haven't I been doing that ever since we've been
 engaged&mdash;&mdash;"</p>
@@ -9901,7 +9901,7 @@ is visiting Mrs. Ledwith solely to embarrass me!"</p>
 
 <p>"How could it embarrass you?"</p>
 
-<p>"By giving colour to the lies told about me and the<span class="pagenum"><a id="Page_425"></a>[Pg 425]</span> Ledwiths," he said
+<p>"By giving colour to the lies told about me and the<span class="pagenum" id="Page_425">[Pg 425]</span> Ledwiths," he said
 in a hard voice&mdash;"by hinting that Mary Ledwith, free to marry, is
 accepted by my aunt; and the rest is up to me! That's what that female
 relative of mine has just done&mdash;" His big, white teeth closed with a
@@ -9944,7 +9944,7 @@ take it that you are not suggesting that, are you?"</p>
 
 <p>"I am suggesting nothing," she replied in a low voice.</p>
 
-<p><span class="pagenum"><a id="Page_426"></a>[Pg 426]</span></p>
+<p><span class="pagenum" id="Page_426">[Pg 426]</span></p>
 
 <p>"Well, <i>I</i> am. I'm suggesting that you and Molly and I go aboard the
 <i>Yulan</i> and clear out to-night!"</p>
@@ -9984,7 +9984,7 @@ hocks and drew bridle beside her.</p>
 
 <p>"How?"</p>
 
-<p>"How do I know? Ledwith and I were connected<span class="pagenum"><a id="Page_427"></a>[Pg 427]</span> in business matters; I saw
+<p>"How do I know? Ledwith and I were connected<span class="pagenum" id="Page_427">[Pg 427]</span> in business matters; I saw
 more or less of them both&mdash;and he was too busy to be with his wife every
 time I happened to be with her. So&mdash;you know what they said."</p>
 
@@ -10021,7 +10021,7 @@ her. Quickly the hint of tears dried out in her gray eyes&mdash;from whatever
 cause they sprang glimmering there to dim her eyesight. She bent her
 head, absently arranging, rearranging and shifting her bridle.</p>
 
-<p>"The thing to do," he said, curling his long mous<span class="pagenum"><a id="Page_428"></a>[Pg 428]</span>tache with powerful
+<p>"The thing to do," he said, curling his long mous<span class="pagenum" id="Page_428">[Pg 428]</span>tache with powerful
 fingers&mdash;"is for the Wycherlys to stand by us now&mdash;and the others
 there&mdash;that little Lacy girl&mdash;and Sir Charles if he chooses. We'll have
 to take the whole lot of them aboard I suppose."</p>
@@ -10062,7 +10062,7 @@ realised his mistake.</p>
 <p>"We can't get a licence if we leave to-night," he said, breathing
 heavily. "But we can touch at any port and manage that."</p>
 
-<p><span class="pagenum"><a id="Page_429"></a>[Pg 429]</span></p>
+<p><span class="pagenum" id="Page_429">[Pg 429]</span></p>
 
 <p>"You&mdash;you <i>would</i> take me&mdash;permit me to go&mdash;in such a manner?" she
 breathed, still staring at him.</p>
@@ -10099,7 +10099,7 @@ a moment&mdash;when you said&mdash;something in your smile made me think&mdash;&
 
 <p>"You need not think any further," she said.</p>
 
-<p><span class="pagenum"><a id="Page_430"></a>[Pg 430]</span></p>
+<p><span class="pagenum" id="Page_430">[Pg 430]</span></p>
 
 <p>"What do you mean?"</p>
 
@@ -10141,7 +10141,7 @@ her friends."</p>
 Strelsa, and then let us be reconciled."</p>
 
 <p>"No, it is too late. It was too late even before we started out
-together. Why&mdash;I didn't realise it then&mdash;<span class="pagenum"><a id="Page_431"></a>[Pg 431]</span>but it was too late long
+together. Why&mdash;I didn't realise it then&mdash;<span class="pagenum" id="Page_431">[Pg 431]</span>but it was too late long
 ago&mdash;from the day you spoke as you did in my presence to Mr. Quarren.
 That finished you, Langly&mdash;if, indeed, you ever really began to mean
 anything at all to me."</p>
@@ -10180,7 +10180,7 @@ the proposed arrangement."</p>
 <p>His visage altered alarmingly:</p>
 
 <p>"Who have you got on the string now!" he broke out&mdash;"you little
-adventuress! What damned fool is<span class="pagenum"><a id="Page_432"></a>[Pg 432]</span> damned fool enough to marry you when
+adventuress! What damned fool is<span class="pagenum" id="Page_432">[Pg 432]</span> damned fool enough to marry you when
 anybody could get you for less if they care to spend the time on
 you&mdash;&mdash;"</p>
 
@@ -10220,7 +10220,7 @@ closed.</p>
 
 <p>"No."</p>
 
-<p>His eyes seemed starting from his head and the<span class="pagenum"><a id="Page_433"></a>[Pg 433]</span> deep blood rushed to his
+<p>His eyes seemed starting from his head and the<span class="pagenum" id="Page_433">[Pg 433]</span> deep blood rushed to his
 face and neck, and he flung her bridle into her face with an
 inarticulate sound.</p>
 
@@ -10270,12 +10270,12 @@ to <i>you</i>?"</p>
 immensely relieved&mdash;and that cat of an aunt of his here to make
 mischief!&mdash;and poor Mary Ledwith&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_434"></a>[Pg 434]<br /><a id="Page_435"></a>[Pg 435]</span></p>
+<p><span class="pagenum" id="Page_435">[Pg 435]</span></p>
 
 <p>[Illustration: "'Is it to be Sir Charles after all, darling?' she asked
 caressingly."]</p>
 
-<p><span class="pagenum"><a id="Page_436"></a>[Pg 436]<br /><a id="Page_437"></a>[Pg 437]<br /><a id="Page_438"></a>[Pg 438]</span></p>
+<p><span class="pagenum" id="Page_438">[Pg 438]</span></p>
 
 <p>"Molly, I&mdash;I simply can't talk about it&mdash;any of it&mdash;&mdash;"</p>
 
@@ -10309,7 +10309,7 @@ all&mdash;the whole thing, Molly. What do you suppose is the matter with me?"</p
 <p>"No, I'm not," said the girl with a quiet conviction that disconcerted
 the elder woman.</p>
 
-<p><span class="pagenum"><a id="Page_439"></a>[Pg 439]</span></p>
+<p><span class="pagenum" id="Page_439">[Pg 439]</span></p>
 
 <p>"Then I don't see why you should be very happy," said Molly honestly.</p>
 
@@ -10347,7 +10347,7 @@ did&mdash;&mdash;"</p>
 
 <p>Strelsa coloured: "Everything worthy is founded on Truth," she said.</p>
 
-<p>"That sounds like Tupper or a copy-book," said<span class="pagenum"><a id="Page_440"></a>[Pg 440]</span> Molly, laughing. "For
+<p>"That sounds like Tupper or a copy-book," said<span class="pagenum" id="Page_440">[Pg 440]</span> Molly, laughing. "For
 surely those profound reflections never emanated originally from you or
 Rix&mdash;did they?"</p>
 
@@ -10393,7 +10393,7 @@ hurry to go there."</p>
 there is&mdash;I'm in no hurry, but it has always interested me.... I've had
 a theory that perhaps to everybody worthy is given, hereafter, exactly
 the kind of heaven they expect&mdash;to Buddhist, Brahman, Mohammedan,
-Christian&mdash;to the Shinto priest<span class="pagenum"><a id="Page_441"></a>[Pg 441]</span> as well as to the Sagamore.... There's
+Christian&mdash;to the Shinto priest<span class="pagenum" id="Page_441">[Pg 441]</span> as well as to the Sagamore.... There's
 plenty of time&mdash;I'm in no hurry, nor would it be too soon to-morrow for
 me to find out how near I am to the truth."</p>
 
@@ -10411,7 +10411,7 @@ winged thing came to her ears on the summer wind.</p>
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_442"></a>[Pg 442]</span></p>
+<p><span class="pagenum" id="Page_442">[Pg 442]</span></p>
 
 <h2 class="nobreak" id="CHAPTER_XIV">CHAPTER XIV</h2>
 </div>
@@ -10448,7 +10448,7 @@ wait. I thought you ought to know. He acts queerly."</p>
 
 <p>"If there was I'd tell you, wouldn't I?"</p>
 
-<p>Kyte's lowered gaze stole upward toward his em<span class="pagenum"><a id="Page_443"></a>[Pg 443]</span>ployer, sustained his
+<p>Kyte's lowered gaze stole upward toward his em<span class="pagenum" id="Page_443">[Pg 443]</span>ployer, sustained his
 expressionless glare for a second, then shifted.</p>
 
 <p>"Very well," he said unlocking the library door; "I thought he might be
@@ -10490,7 +10490,7 @@ there, his sunken eyes fixed on the westering sun.</p>
 
 <p>The man's clothing hung loosely on his frame, showing bony angles at
 elbow and knee. Burrs and black swamp-mud stuck to his knickerbockers
-and golf-stock<span class="pagenum"><a id="Page_444"></a>[Pg 444]</span>ings; he sat very still save for a constant twitching of
+and golf-stock<span class="pagenum" id="Page_444">[Pg 444]</span>ings; he sat very still save for a constant twitching of
 the muscles.</p>
 
 <p>The necessity for nervous and physical fatigue drove Sprowl back into
@@ -10529,7 +10529,7 @@ across the lawn, and Ledwith went with him. Neither spoke. Shadows of
 tall trees lay like velvet on the grass; the crests of the woods beyond
 grew golden, their depths dusky and bluish. Everywhere robins were
 noisily at supper, tilting for earthworms on the lawns; golden-winged
-woodpeckers imitated them;<span class="pagenum"><a id="Page_445"></a>[Pg 445]</span> in the late sunlight the grackles' necks
+woodpeckers imitated them;<span class="pagenum" id="Page_445">[Pg 445]</span> in the late sunlight the grackles' necks
 were rainbow tinted.</p>
 
 <p>On distant hillcrests Sprowl could see his brood-mares feeding,
@@ -10573,7 +10573,7 @@ it?"</p>
 
 <p>"Then&mdash;my wife has returned."</p>
 
-<p><span class="pagenum"><a id="Page_446"></a>[Pg 446]</span></p>
+<p><span class="pagenum" id="Page_446">[Pg 446]</span></p>
 
 <p>"Your ex-wife," corrected Sprowl without a shade of expression in voice
 or features.</p>
@@ -10618,7 +10618,7 @@ unclosing:</p>
 
 <p>"Is that all, Ledwith?"</p>
 
-<p>"That's all&mdash;when you have confirmed what I have<span class="pagenum"><a id="Page_447"></a>[Pg 447]</span> said concerning the
+<p>"That's all&mdash;when you have confirmed what I have<span class="pagenum" id="Page_447">[Pg 447]</span> said concerning the
 necessity for your marriage with the woman you debauched."</p>
 
 <p>"You lie," said Langly.</p>
@@ -10655,7 +10655,7 @@ you say so."</p>
 
 <p>"I'll marry whom I choose! Do you understand that?"</p>
 
-<p><span class="pagenum"><a id="Page_448"></a>[Pg 448]</span></p>
+<p><span class="pagenum" id="Page_448">[Pg 448]</span></p>
 
 <p>"Of course. But you will choose to marry her."</p>
 
@@ -10693,7 +10693,7 @@ his aunt was within driving distance of his own quarters.</p>
 <p>A dull hot anguish, partly rage, possessed him, tormenting brain and
 heart incessantly and giving him no rest. His own clumsy madness in
 destroying what he believed had been a certainty&mdash;his stupidity, his
-loss of<span class="pagenum"><a id="Page_449"></a>[Pg 449]</span> self-control, not only in betraying passion prematurely but in
+loss of<span class="pagenum" id="Page_449">[Pg 449]</span> self-control, not only in betraying passion prematurely but in
 his subsequent violence and brutality, almost drove him insane.</p>
 
 <p>Never before in any affair with women had he forgotten caution in any
@@ -10726,7 +10726,7 @@ drawing-room, pronouncing his name with unmistakable decision. And,
 before the servants, he swallowed the greeting he had hoped to give her,
 and led her into the library.</p>
 
-<p>"Mercy on us, Langly!" she exclaimed, eyeing his<span class="pagenum"><a id="Page_450"></a>[Pg 450]</span> reeking boots and
+<p>"Mercy on us, Langly!" she exclaimed, eyeing his<span class="pagenum" id="Page_450">[Pg 450]</span> reeking boots and
 riding-breeches; "do you live like a pig up here?"</p>
 
 <p>"I've been out," he said briefly. "What do you want?"</p>
@@ -10765,7 +10765,7 @@ is finished. If you've an ounce of brains remaining you know that you're
 done for this time. So go and dress and come over to dinner.... And
 don't worry; I'll keep away from you after you're married."</p>
 
-<p><span class="pagenum"><a id="Page_451"></a>[Pg 451]</span></p>
+<p><span class="pagenum" id="Page_451">[Pg 451]</span></p>
 
 <p>"You'll keep your distance before that," he said slowly.</p>
 
@@ -10808,7 +10808,7 @@ last? Do you understand clearly?&mdash;you fat-headed, meddlesome old fool!"</p>
 <p>He sprang to his feet in an access of fury and began loping up and down
 the room, gesticulating, almost mouthing out his hatred and
 abuse&mdash;rendered more furious still by the knowledge of his own weakness
-and dis<span class="pagenum"><a id="Page_452"></a>[Pg 452]</span>integration&mdash;his downfall from that silent citadel of
+and dis<span class="pagenum" id="Page_452">[Pg 452]</span>integration&mdash;his downfall from that silent citadel of
 self-control which had served him so many years as a stronghold for
 defiance or refuge.</p>
 
@@ -10840,7 +10840,7 @@ footman.</p>
 
 <p>"I'm sorry I cannot drive with you this evening," he said quietly, as
 the footman supported Mrs. Sprowl to her feet, "but I've promised the
-Wycherlys. Pray<span class="pagenum"><a id="Page_453"></a>[Pg 453]</span> offer my compliments and friendly wishes to Mrs.
+Wycherlys. Pray<span class="pagenum" id="Page_453">[Pg 453]</span> offer my compliments and friendly wishes to Mrs.
 Ledwith."</p>
 
 <p>When she had gone he walked back into the library, picked up the
@@ -10880,7 +10880,7 @@ sneaking way of doing it!"</p>
 
 <p>Strelsa looked out of the dark window in silence.</p>
 
-<p>Molly said: "I wish he'd go away, I never can<span class="pagenum"><a id="Page_454"></a>[Pg 454]</span> look at him without
+<p>Molly said: "I wish he'd go away, I never can<span class="pagenum" id="Page_454">[Pg 454]</span> look at him without
 thinking of Chester Ledwith&mdash;and all that wretched affair.... Not that I
 am sniffy about Mary&mdash;the poor little fool.... Anyway," she added
 naïvely, "old lady Sprowl has fixed her status and now we all know how
@@ -10917,7 +10917,7 @@ with the main chance."</p>
 <p>"I don't know, dear.... How clean the woods and fields seem after a day
 indoors with many people."</p>
 
-<p><span class="pagenum"><a id="Page_455"></a>[Pg 455]</span></p>
+<p><span class="pagenum" id="Page_455">[Pg 455]</span></p>
 
 <p>"You mean we all need moral baths?"</p>
 
@@ -10966,7 +10966,7 @@ I'd never had one.... You can't know whether you want a baby or not
 until you have one.... I know now. I'm crazy about it.... I think it
 would&mdash;would kill me if Jim is annoyed&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_456"></a>[Pg 456]</span></p>
+<p><span class="pagenum" id="Page_456">[Pg 456]</span></p>
 
 <p>"He won't be, darling!" whispered Strelsa. "Don't mind what he says
 anyway. He's only a man. He never even knew as much about it as you did.
@@ -11002,7 +11002,7 @@ hands. "Are you coming in to try a cocktail with us?"</p>
 <p>"Ask her, Jim.... And, if you care one atom for her&mdash;be happy at what
 she tells you&mdash;and tell her that you are. Will you?"</p>
 
-<p>He stared at her, then lost countenance. Then he<span class="pagenum"><a id="Page_457"></a>[Pg 457]</span> looked at her in a
+<p>He stared at her, then lost countenance. Then he<span class="pagenum" id="Page_457">[Pg 457]</span> looked at her in a
 panicky way and started to go, but she held on to him with
 determination:</p>
 
@@ -11049,7 +11049,7 @@ in his arms, the grin breaking out from utter blankness.</p>
 
 <p>"You're a corker, ducky!" he whispered. "You for me all the time!"</p>
 
-<p><span class="pagenum"><a id="Page_458"></a>[Pg 458]</span></p>
+<p><span class="pagenum" id="Page_458">[Pg 458]</span></p>
 
 <p>"Jim!... Really?"</p>
 
@@ -11092,7 +11092,7 @@ hangar until&mdash;&mdash;"</p>
 scowl. He had behaved pretty well&mdash;about like the majority of husbands
 outside of popular romances.</p>
 
-<p><span class="pagenum"><a id="Page_459"></a>[Pg 459]</span></p>
+<p><span class="pagenum" id="Page_459">[Pg 459]</span></p>
 
 <p>The amateur aeronauts left in the morning before anybody was stirring
 except the servants&mdash;Vincent Wier, Lester Caldera, the Van Dynes and the
@@ -11124,7 +11124,7 @@ lapel, tall, clear-skinned, nice to look upon.</p>
 
 <p>What he really thought of what he had seen in America, of the sort of
 people who had entertained him, of the grotesque imitation of exotic
-society&mdash;or of a certain sort of it&mdash;nobody really knew. Doubtless his<span class="pagenum"><a id="Page_460"></a>[Pg 460]</span>
+society&mdash;or of a certain sort of it&mdash;nobody really knew. Doubtless his<span class="pagenum" id="Page_460">[Pg 460]</span>
 estimate was inclined to be a kindly one, for he was essentially that&mdash;a
 philosophical, chivalrous, and modest man; and if his lines had fallen
 in places where vulgarity, extravagance, and ostentation
@@ -11156,7 +11156,7 @@ words of which Strelsa herself was totally unconscious.</p>
 furiously with reeking spurs, after his morning's gallop with Strelsa;
 and he had caught a glimpse of the man's face; and that was enough.</p>
 
-<p><span class="pagenum"><a id="Page_461"></a>[Pg 461]</span></p>
+<p><span class="pagenum" id="Page_461">[Pg 461]</span></p>
 
 <p>So there was really nothing to keep him in America any longer. He wanted
 to get back to his own kind&mdash;into real life again, among people of real
@@ -11189,7 +11189,7 @@ present himself at so early an hour.</p>
 <p>A man took his card, returned presently saying that Mrs. Ledwith had not
 yet risen, but that Mrs. Sprowl would receive him.</p>
 
-<p><span class="pagenum"><a id="Page_462"></a>[Pg 462]</span></p>
+<p><span class="pagenum" id="Page_462">[Pg 462]</span></p>
 
 <p>Conducted to the old lady's apartments he was ushered into a
 dressing-room done in pastel tints, and which hideously set forth the
@@ -11237,7 +11237,7 @@ of mine?" she demanded.</p>
 
 <p>"I'm glad of it!" she said angrily. "If it was not to be you I'm glad
 that it may be Rix. It&mdash;it would have killed me to see her fall into
-Langly's hands....<span class="pagenum"><a id="Page_463"></a>[Pg 463]</span> I'm ill on account of him&mdash;his shocking treatment of
+Langly's hands....<span class="pagenum" id="Page_463">[Pg 463]</span> I'm ill on account of him&mdash;his shocking treatment of
 me last evening. It was a brutal scene&mdash;one of those terrible family
 scenes!&mdash;and he threatened me&mdash;cursed me&mdash;&mdash;"</p>
 
@@ -11273,7 +11273,7 @@ stood before her.</p>
 
 <p>She knew that her words were vain, her boast empty; she knew there was
 nothing more for her to do&mdash;nothing even that Sir Charles might do
-toward winning Strelsa without also doing the only thing in the world<span class="pagenum"><a id="Page_464"></a>[Pg 464]</span>
+toward winning Strelsa without also doing the only thing in the world<span class="pagenum" id="Page_464">[Pg 464]</span>
 which could really terrify herself. Even at the mere thought of it she
 trembled again, and fear forced her to speech born of fear:</p>
 
@@ -11306,7 +11306,7 @@ closed eyelids tears trembled.</p>
 lungs with the fragrant morning air. Hedges still glistened with
 spiders' tapestry; the birds which sulked all day in their early
 moulting-fever still sang a little in the cool of the morning, and he
-listened to them as he walked while his quiet, impartial<span class="pagenum"><a id="Page_465"></a>[Pg 465]</span> eye ranged
+listened to them as he walked while his quiet, impartial<span class="pagenum" id="Page_465">[Pg 465]</span> eye ranged
 over the lovely rolling country, dew-washed and exquisite under a
 cloudless sky.</p>
 
@@ -11338,7 +11338,7 @@ tint in her cheeks. She considered the bull, absently, patted a tendril
 of hair into symmetry; but the breeze loosened it again, and she let it
 blow across her cheek.</p>
 
-<p>"We should have been in South Africa together,"<span class="pagenum"><a id="Page_466"></a>[Pg 466]<br /><a id="Page_467"></a>[Pg 467]<br /><a id="Page_468"></a>[Pg 468]<br /><a id="Page_469"></a>[Pg 469]<br /><a id="Page_470"></a>[Pg 470]</span> said Sir Charles.
+<p>"We should have been in South Africa together,"<span class="pagenum" id="Page_470">[Pg 470]</span> said Sir Charles.
 "We manœuvre beautifully as a unit."</p>
 
 <p>[Illustration: "'And it is to be your last breakfast.'"]</p>
@@ -11382,7 +11382,7 @@ the features he could not notice it.</p>
 
 <p>"And I you, Sir Charles."</p>
 
-<p><span class="pagenum"><a id="Page_471"></a>[Pg 471]</span></p>
+<p><span class="pagenum" id="Page_471">[Pg 471]</span></p>
 
 <p>"You'll be over, I suppose."</p>
 
@@ -11425,7 +11425,7 @@ exquisite avowal, childlike in its silent directness, charming in its
 surprise. A wave of tenderness and awe mounted within him, touching his
 bronzed cheeks with a deeper colour.</p>
 
-<p><span class="pagenum"><a id="Page_472"></a>[Pg 472]</span></p>
+<p><span class="pagenum" id="Page_472">[Pg 472]</span></p>
 
 <p>"If you will, Chrysos," he said in a still voice.</p>
 
@@ -11451,7 +11451,7 @@ shoulder; she laid her cheek against it.</p>
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_473"></a>[Pg 473]</span></p>
+<p><span class="pagenum" id="Page_473">[Pg 473]</span></p>
 
 <h2 class="nobreak" id="CHAPTER_XV">CHAPTER XV</h2>
 </div>
@@ -11484,7 +11484,7 @@ whichever I am, I am a happy one.</p>
 
 <p>"I wish to tell you something. Last winter when they fished me out
 of my morbid seclusion, I thought that the life I then entered upon
-was the only panacea<span class="pagenum"><a id="Page_474"></a>[Pg 474]</span> for the past, the only oblivion, the only
+was the only panacea<span class="pagenum" id="Page_474">[Pg 474]</span> for the past, the only oblivion, the only
 guarantee for the future.</p>
 
 <p>"Now I suppose I have gone to the other extreme, because, let me
@@ -11516,7 +11516,7 @@ brain is humming with schemes, millions of them. Isn't it heavenly?</p>
 <p>"Besides, from my second-story windows I shall be able to see
 Molly's chimneys above the elms. And Molly is going to remain here
 all winter, because, Rix&mdash;and this is a close secret&mdash;a little heir
-or heiress is<span class="pagenum"><a id="Page_475"></a>[Pg 475]</span> coming to make <i>this</i> House of Wycherly 'an
+or heiress is<span class="pagenum" id="Page_475">[Pg 475]</span> coming to make <i>this</i> House of Wycherly 'an
 habitation enforced'&mdash;and a happier habitation than it has been
 since they bought it.</p>
 
@@ -11547,11 +11547,11 @@ man. There is not one atom of anything small or unworthy in his
 character. And I tell you very frankly that, thinking about him at
 times, I am amazed at myself for not falling in love with him.</p>
 
-<p><span class="pagenum"><a id="Page_476"></a>[Pg 476]</span></p>
+<p><span class="pagenum" id="Page_476">[Pg 476]</span></p>
 
 <p>[Illustration: Strelsa Leeds.]</p>
 
-<p><span class="pagenum"><a id="Page_477"></a>[Pg 477]<br /><a id="Page_478"></a>[Pg 478]</span></p>
+<p><span class="pagenum" id="Page_478">[Pg 478]</span></p>
 
 <p>"Which is proof sufficient that if I couldn't care for him I cannot
 ever care for any man. Don't you think so?</p>
@@ -11586,7 +11586,7 @@ ever since under its ignoble integument of foolish paint.</p>
 <p>"No, I promise not to say one word about it until I have your
 permission. I understand quite well why you desire to keep the
 matter from the newspapers for the present. But&mdash;won't it make you
-and Lord Dank<span class="pagenum"><a id="Page_479"></a>[Pg 479]</span>mere rich? Tell me&mdash;please tell me. I don't want
+and Lord Dank<span class="pagenum" id="Page_479">[Pg 479]</span>mere rich? Tell me&mdash;please tell me. I don't want
 money for myself any more, but I do want it for you. You need it;
 you can do so much with it, use it so intelligently, so gloriously,
 make the world better with it,&mdash;make it more beautiful, and people
@@ -11616,7 +11616,7 @@ Streets'&mdash;'and all the daughters of music shall be brought low.'</p>
 <p>"My poor comrade! Must you remain a prisoner in the Streets of
 Ascalon? Yet, through your soul I know as free and fresh a breeze
 is blowing as stirs the curtains at my open window!&mdash;You wonderful
-man to evoke in imagery&mdash;to visualise and conceive all that<span class="pagenum"><a id="Page_480"></a>[Pg 480]</span> had to
+man to evoke in imagery&mdash;to visualise and conceive all that<span class="pagenum" id="Page_480">[Pg 480]</span> had to
 be concrete to cure me soul and body of my hurts!</p>
 
 <hr class="tb" />
@@ -11655,7 +11655,7 @@ chintzed and made livable and lovable.</p>
 <span class="smcap">Strelsa</span>."</p>
 </div>
 
-<p><span class="pagenum"><a id="Page_481"></a>[Pg 481]</span></p>
+<p><span class="pagenum" id="Page_481">[Pg 481]</span></p>
 
 <p>Quarren telegraphed:</p>
 
@@ -11694,7 +11694,7 @@ me, Ledwith."</p>
 
 <p>The man's hollow eyes avoided his and roamed restlessly about the
 gallery, looking at picture after picture and scarcely seeing them.
-Inside his loose summer<span class="pagenum"><a id="Page_482"></a>[Pg 482]</span> clothing his thin, nervous frame was shifting
+Inside his loose summer<span class="pagenum" id="Page_482">[Pg 482]</span> clothing his thin, nervous frame was shifting
 continually even while he stood gazing almost vacantly at the walls of
 the gallery.</p>
 
@@ -11733,7 +11733,7 @@ bones&mdash;or that's the belief, anyway. It's gilder's glue.</p>
 of the picture three layers of tissue-paper, one on top of the
 other&mdash;so!</p>
 
-<p><span class="pagenum"><a id="Page_483"></a>[Pg 483]</span></p>
+<p><span class="pagenum" id="Page_483">[Pg 483]</span></p>
 
 <p>"Now here is a new chassis or stretcher over which I have stretched a
 new linen canvas. Yesterday I sponged it as a tailor sponges cloth; and
@@ -11768,7 +11768,7 @@ air get in to blister the surface."</p>
 already relined it and it's fixed on its new canvas and stretcher and is
 thoroughly dry and ready for cleaning. And this is how I begin."</p>
 
-<p>He took a fine sponge, soaked it in a weak solution<span class="pagenum"><a id="Page_484"></a>[Pg 484]</span> of alcohol, and
+<p>He took a fine sponge, soaked it in a weak solution<span class="pagenum" id="Page_484">[Pg 484]</span> of alcohol, and
 very gingerly washed the blackened and dirty canvas. Then he dried it.
 Then he gave it a coat of varnish.</p>
 
@@ -11797,7 +11797,7 @@ part of my fascinating profession.</p>
 <p>"Sometimes I lift the entire skin of paint from a canvas&mdash;picking out
 the ancient threads from the rotten texture&mdash;and transfer it to a new
 canvas or panel. Sometimes I cross-saw a panel, then chisel to the
-plaster that lies beneath the painting, and so transfer it to a<span class="pagenum"><a id="Page_485"></a>[Pg 485]</span> new and
+plaster that lies beneath the painting, and so transfer it to a<span class="pagenum" id="Page_485">[Pg 485]</span> new and
 sound support. Sometimes&mdash;" he laughed&mdash;"but there are a hundred
 delicate and interesting surgical operations which I attempt&mdash;a thousand
 exciting problems to solve&mdash;experiments without end that tempt me,
@@ -11844,7 +11844,7 @@ me."</p>
 
 <p>"We make our own hells."</p>
 
-<p><span class="pagenum"><a id="Page_486"></a>[Pg 486]</span></p>
+<p><span class="pagenum" id="Page_486">[Pg 486]</span></p>
 
 <p>"I didn't make mine. They dug the pit and I fell into it&mdash;Hell's own
 pit, Quarren&mdash;&mdash;"</p>
@@ -11891,7 +11891,7 @@ Can't you reason? A bullet-stung animal sometimes turns and bites
 itself. Is that why you are doing it?&mdash;to arouse the amusement and
 contempt of your hunter?"</p>
 
-<p><span class="pagenum"><a id="Page_487"></a>[Pg 487]</span></p>
+<p><span class="pagenum" id="Page_487">[Pg 487]</span></p>
 
 <p>"Quarren! By God you shall not say that to me&mdash;&mdash;"</p>
 
@@ -11924,7 +11924,7 @@ nerve and muscle and common sense."</p>
 <p>"Then? Oh, anything that you fancy. It's according to a man's personal
 taste. You can take him by the neck and beat him up in public if you
 like&mdash;or knock him down in the club as often as he gets up. It all
-depends, Ledwith. Some of us maintain self-respect<span class="pagenum"><a id="Page_488"></a>[Pg 488]</span> without violence;
+depends, Ledwith. Some of us maintain self-respect<span class="pagenum" id="Page_488">[Pg 488]</span> without violence;
 some of us seem to require it. It's up to you."</p>
 
 <p>"Yes."</p>
@@ -11963,7 +11963,7 @@ her?"</p>
 
 <p>"You are generous enough to care, Ledwith."</p>
 
-<p><span class="pagenum"><a id="Page_489"></a>[Pg 489]</span></p>
+<p><span class="pagenum" id="Page_489">[Pg 489]</span></p>
 
 <p>"I am not!" he said, hoarsely. "I don't care a damn!"</p>
 
@@ -11999,7 +11999,7 @@ Ledwith?"</p>
 
 <p>While they were waiting Ledwith laid a shaking hand on Quarren's sleeve
 and clung to it. He was trembling like a leaf when they entered the cab,
-whimpering when they left it in front of a wide brown-stone<span class="pagenum"><a id="Page_490"></a>[Pg 490]</span> building
+whimpering when they left it in front of a wide brown-stone<span class="pagenum" id="Page_490">[Pg 490]</span> building
 composed of several old-time private residences thrown together.</p>
 
 <p>"Stand by me, Quarren," he whispered brokenly&mdash;"you won't go away, will
@@ -12038,7 +12038,7 @@ carefully around him to be certain that Jessie Vining was still in the
 basement where she had gone to straighten up one or two things for
 Quarren, then, with a perfectly serious face, he began to dance, softly.</p>
 
-<p>The Earl of Dankmere was light-footed and graceful<span class="pagenum"><a id="Page_491"></a>[Pg 491]</span> when paying tribute
+<p>The Earl of Dankmere was light-footed and graceful<span class="pagenum" id="Page_491">[Pg 491]</span> when paying tribute
 to Terpsichore; walking-stick balanced in both hands, straw hat on the
 back of his head, he performed in absolute silence to the rhythm of the
 tune running through his head, backward, forward, sideways, airy as a
@@ -12076,7 +12076,7 @@ see those people at Witch-Hollow."</p>
 <p>"Perhaps," she said, making a few erasures in her type-written folio and
 rewriting the blank spaces. Then she glanced over the top of the machine
 at his lordship, who, as it happened, was gazing at her with such
-pecu<span class="pagenum"><a id="Page_492"></a>[Pg 492]</span>liar intensity that it took him an appreciable moment to rouse
+pecu<span class="pagenum" id="Page_492">[Pg 492]</span>liar intensity that it took him an appreciable moment to rouse
 himself and take his eyes elsewhere.</p>
 
 <p>"When do you take your vacation?" he asked, carelessly.</p>
@@ -12114,7 +12114,7 @@ don't believe it."</p>
 <p>"Yes, I do. I stand in awe of you. When you come into the room I seem to
 hear trumpets sounding in the far distance&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_493"></a>[Pg 493]</span></p>
+<p><span class="pagenum" id="Page_493">[Pg 493]</span></p>
 
 <p>"My boots squeak&mdash;&mdash;"</p>
 
@@ -12152,7 +12152,7 @@ who smiles at me every morning in such friendly fashion?' And, would you
 believe it!&mdash;she turns out to be Jessie Vining every time!"</p>
 
 <p>She was in a gay mood; she rattled away at her machine, glancing over it
-mischievously at him from time<span class="pagenum"><a id="Page_494"></a>[Pg 494]</span> to time. He, having nothing to do except
+mischievously at him from time<span class="pagenum" id="Page_494">[Pg 494]</span> to time. He, having nothing to do except
 to look at her, did so as often as he dared.</p>
 
 <p>And so they kept the light conversational shuttle-cock flying through
@@ -12190,7 +12190,7 @@ not unbecomingly suffused.</p>
 <p>Then, incredulous, and a little nervous, she rose to prepare the tea;
 and he sprang up to bring the folding table.</p>
 
-<p>The ceremony passed almost in silence; neither he<span class="pagenum"><a id="Page_495"></a>[Pg 495]</span> nor she made the
+<p>The ceremony passed almost in silence; neither he<span class="pagenum" id="Page_495">[Pg 495]</span> nor she made the
 effort to return to the lighter, gayer vein. When they spoke at all it
 was on some matter connected with business; and her voice seemed to him
 listless, almost tired.</p>
@@ -12233,7 +12233,7 @@ interfering in your affairs without consulting you."</p>
 
 <p>"It happened yesterday about this hour," he said.</p>
 
-<p><span class="pagenum"><a id="Page_496"></a>[Pg 496]</span></p>
+<p><span class="pagenum" id="Page_496">[Pg 496]</span></p>
 
 <p>"What happened?"</p>
 
@@ -12274,7 +12274,7 @@ He's looking rather badly these days.... We talked a few minutes&mdash;&mdash;"<
 <p>Pale, angry, every sense of modesty and reserve outraged, the girl faced
 him, small head erect:</p>
 
-<p><span class="pagenum"><a id="Page_497"></a>[Pg 497]</span></p>
+<p><span class="pagenum" id="Page_497">[Pg 497]</span></p>
 
 <p>"You went there to&mdash;to discuss <i>me</i> with <i>that</i> man!"</p>
 
@@ -12308,7 +12308,7 @@ holding them, looking into her eyes.</p>
 
 <p>"You know what I am," he said. "I have nothing to say about myself. But
 I love you very dearly.... I loved before, once, and married. And she
-died.... After that I didn't behave very well&mdash;until I knew you.... It<span class="pagenum"><a id="Page_498"></a>[Pg 498]</span>
+died.... After that I didn't behave very well&mdash;until I knew you.... It<span class="pagenum" id="Page_498">[Pg 498]</span>
 is really in me to be a decent husband&mdash;if you can care for me.... And I
 don't think we're likely to starve&mdash;&mdash;"</p>
 
@@ -12346,7 +12346,7 @@ streets of Ascalon.</p>
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_499"></a>[Pg 499]</span></p>
+<p><span class="pagenum" id="Page_499">[Pg 499]</span></p>
 
 <h2 class="nobreak" id="CHAPTER_XVI">CHAPTER XVI</h2>
 </div>
@@ -12376,7 +12376,7 @@ escape.</p>
 Vining one evening leaving the Dankmere Galleries. And Langly Sprowl
 never denied himself anything that seemed incapable of self-defence.</p>
 
-<p>He stopped his car and got out and spoke to her,<span class="pagenum"><a id="Page_500"></a>[Pg 500]</span> very civilly, and with
+<p>He stopped his car and got out and spoke to her,<span class="pagenum" id="Page_500">[Pg 500]</span> very civilly, and with
 a sort of kindly frankness which he sometimes used with convincing
 effect. She refused the proffered car to take her to her destination,
 but could not very well avoid his escort; and their encounter ended by
@@ -12405,7 +12405,7 @@ everybody's but seeing nobody unless directly saluted.</p>
 <p>Now, his right eye rivalling a thunder-cloud in tints, he drove one of
 his racing cars as fast as he dared, swinging through Westchester or
 scurrying about Long Island. Occasionally he went aboard the <i>Yulan</i>,
-but a burning restlessness kept him moving; and at last he<span class="pagenum"><a id="Page_501"></a>[Pg 501]</span> returned to
+but a burning restlessness kept him moving; and at last he<span class="pagenum" id="Page_501">[Pg 501]</span> returned to
 South Linden in a cold but deadly rage, determined to win back the
 chances which he supposed he had thrown away in the very moment of
 victory.</p>
@@ -12439,7 +12439,7 @@ still astonished him.</p>
 <p>The Bermuda lilies were in bloom and Strelsa stood near them, listening
 to him, touching the tall stalks absently at intervals. And while she
 listened she became more conscious still of the great change in
-herself&mdash;of<span class="pagenum"><a id="Page_502"></a>[Pg 502]</span> her altered attitude toward so much in life that once had
+herself&mdash;of<span class="pagenum" id="Page_502">[Pg 502]</span> her altered attitude toward so much in life that once had
 seemed to her important. After he had ceased she still stood pensively
 among the lilies, gray eyes brooding. At length, looking up, she said
 very quietly:</p>
@@ -12475,7 +12475,7 @@ low voice.</p>
 
 <p>"Why?"</p>
 
-<p><span class="pagenum"><a id="Page_503"></a>[Pg 503]</span></p>
+<p><span class="pagenum" id="Page_503">[Pg 503]</span></p>
 
 <p>"Because I am wretchedly unhappy. And I care for you&mdash;more than you
 realise."</p>
@@ -12511,7 +12511,7 @@ with the storm of passion rising so swiftly within him, almost choking
 him&mdash;so that his voice and limbs already trembled in its furious
 surge&mdash;&mdash;</p>
 
-<p>"Strelsa&mdash;I love you! For God's sake show me some<span class="pagenum"><a id="Page_504"></a>[Pg 504]</span> mercy!" he stammered.
+<p>"Strelsa&mdash;I love you! For God's sake show me some<span class="pagenum" id="Page_504">[Pg 504]</span> mercy!" he stammered.
 "I come to you half crazed by the solitude to which your anger has
 consigned me. I cannot endure it&mdash;I need you&mdash;I want you&mdash;I ask for your
 compassion&mdash;&mdash;"</p>
@@ -12552,7 +12552,7 @@ forward.</p>
 
 <p>Ghostlike as it was he knew it instantly, stood rooted in his tracks
 while Strelsa stole away from him through the star-lit gloom, farther,
-farther, slipping forever<span class="pagenum"><a id="Page_505"></a>[Pg 505]</span> from him now&mdash;he knew that as he stood there
+farther, slipping forever<span class="pagenum" id="Page_505">[Pg 505]</span> from him now&mdash;he knew that as he stood there
 staring like a damned man upon that other dim shape in the darkness
 beyond.</p>
 
@@ -12583,7 +12583,7 @@ effort and saved her from giving him the slip and sowing a wind in Reno
 which already had become enough of a breeze to bother him.</p>
 
 <p>With her, for a while, he might be able to distract his mind from this
-recent obsession tormenting him. To<span class="pagenum"><a id="Page_506"></a>[Pg 506]</span> overcome her would interest him;
+recent obsession tormenting him. To<span class="pagenum" id="Page_506">[Pg 506]</span> overcome her would interest him;
 and he had no doubt it could be done&mdash;for she was a little fool&mdash;silly
 enough to slap the world in the face and brave public opinion at Reno.
 No&mdash;it was not necessary to marry such a woman. She might think so, but
@@ -12615,7 +12615,7 @@ at once; now it's going to be difficult."</p>
 
 <p>Yet he sullenly welcomed the difficulty&mdash;hoped that she'd hold out. That
 was what he wanted, the excitement of it to take his mind from
-Strelsa&mdash;keep him interested and employed until the moment arrived once<span class="pagenum"><a id="Page_507"></a>[Pg 507]</span>
+Strelsa&mdash;keep him interested and employed until the moment arrived once<span class="pagenum" id="Page_507">[Pg 507]</span>
 more when he might venture to see her again. He was, by habit, a patient
 man. Only in the case of Strelsa Leeds had passion ever prematurely
 betrayed him; and, pacing his porch there in the darkness, he set his
@@ -12647,7 +12647,7 @@ thundering his baffled fury as long as Sprowl remained in sight.</p>
 <p>It was not all bad disposition. Sprowl, who cared nothing for animals,
 hated the bull, and, when nothing more attractive offered, was
 accustomed to come to the fence, irritate the animal, lure him within
-range, and<span class="pagenum"><a id="Page_508"></a>[Pg 508]</span> strike him. He had done it many times; and, some day, he
+range, and<span class="pagenum" id="Page_508">[Pg 508]</span> strike him. He had done it many times; and, some day, he
 meant to go into the pasture with a rifle, stand the animal's charge,
 and shoot him.</p>
 
@@ -12677,7 +12677,7 @@ almost unseen against the sky. Somewhere some gardener had been burning
 leaves and refuse, and the odour made the dusk more autumn-like.</p>
 
 <p>As he crossed the line separating his land from the Ledwith estate he
-nodded to the daughter of one of his<span class="pagenum"><a id="Page_509"></a>[Pg 509]</span> own gardeners who was passing with
+nodded to the daughter of one of his<span class="pagenum" id="Page_509">[Pg 509]</span> own gardeners who was passing with
 a collie; and then he turned to look again at the child whose slender
 grace and freshness interested him.</p>
 
@@ -12724,7 +12724,7 @@ her into the drawing-room.</p>
 <p>"Please, sir&mdash;&mdash;"</p>
 
 <p>"Do as I tell you, my good girl. Here&mdash;where's that button?&mdash;there!&mdash;"
-as the pretty room sprang<span class="pagenum"><a id="Page_510"></a>[Pg 510]</span> into light&mdash;"Now never mind your instructions
+as the pretty room sprang<span class="pagenum" id="Page_510">[Pg 510]</span> into light&mdash;"Now never mind your instructions
 but go and say to Mrs. Ledwith that I <i>must</i> see her."</p>
 
 <p>He calmly unfolded a flat packet of fresh bank-notes, selected one,
@@ -12754,7 +12754,7 @@ often accompanies it, coolness, obstinacy, and effrontery.</p>
 
 <p>He had decided to wait until his cigar had been leisurely finished.
 Then, other measures&mdash;perhaps walking upstairs, unannounced, perhaps an
-unresentful with<span class="pagenum"><a id="Page_511"></a>[Pg 511]</span>drawal, a note by messenger, and another attempt to see
+unresentful with<span class="pagenum" id="Page_511">[Pg 511]</span>drawal, a note by messenger, and another attempt to see
 her to-morrow&mdash;he did not yet know&mdash;had arrived at no conclusion&mdash;but
 would make up his mind when he finished his cigar and then do whatever
 caution dictated.</p>
@@ -12788,7 +12788,7 @@ this!&mdash;go out of the house!"</p>
 
 <p>"I can't, Quarren! I&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_512"></a>[Pg 512]</span></p>
+<p><span class="pagenum" id="Page_512">[Pg 512]</span></p>
 
 <p>"You promised not to come in until that man had left&mdash;&mdash;"</p>
 
@@ -12828,7 +12828,7 @@ gets away from me."</p>
 
 <p>"I've a notion to kick you both out," he drawled.</p>
 
-<p><span class="pagenum"><a id="Page_513"></a>[Pg 513]</span></p>
+<p><span class="pagenum" id="Page_513">[Pg 513]</span></p>
 
 <p>"It would be a mistake," panted Quarren. "Can't you go while there's
 time, Sprowl! I tell you he'll kill you in this room if you don't."</p>
@@ -12862,7 +12862,7 @@ to you.... Will you go upstairs?"</p>
 
 <p>Ledwith turned and went out into the familiar hall. Then, as though
 dazed, resting one thin hand on the rail, he mounted the stairway, head
-hanging, feeling his<span class="pagenum"><a id="Page_514"></a>[Pg 514]<br /><a id="Page_515"></a>[Pg 515]<br /><a id="Page_516"></a>[Pg 516]</span> way blindly back toward all that life had ever
+hanging, feeling his<span class="pagenum" id="Page_516">[Pg 516]</span> way blindly back toward all that life had ever
 held for him, but which he had been too weak to keep or even to defend.</p>
 
 <p>[Illustration: "'Let him loose, Quarren,' said Sprowl."]</p>
@@ -12903,7 +12903,7 @@ returned he lifted his bruised face and stared murderously about him.
 Quarren was walking toward Witch-Hollow&mdash;half way there already and out
 of earshot as well as sight.</p>
 
-<p><span class="pagenum"><a id="Page_517"></a>[Pg 517]</span></p>
+<p><span class="pagenum" id="Page_517">[Pg 517]</span></p>
 
 <p>Against the stars something moved on a near hill-top, and Sprowl reeled
 forward in pursuit, breaking into a heavy and steady run as the thing
@@ -12935,7 +12935,7 @@ orchid from the greenhouse.</p>
 
 <p>Every newspaper in America gave up the right-hand columns to huge
 headlines and an account of the tragedy at South Linden. Every paper in
-the world<span class="pagenum"><a id="Page_518"></a>[Pg 518]</span> chronicled it. There were few richer men in the world than
+the world<span class="pagenum" id="Page_518">[Pg 518]</span> chronicled it. There were few richer men in the world than
 Langly Sprowl. The tragedy moved everybody in various ways; stocks,
 however, did not move either way to the surprise of everybody. On second
 thoughts, however, the world realised that his wealth had been too
@@ -12981,7 +12981,7 @@ he?"</p>
 
 <p>"But where is he? You&mdash;you don't mean to say&mdash;&mdash;"</p>
 
-<p>"Yes, I do. He went upstairs and didn't re<span class="pagenum"><a id="Page_519"></a>[Pg 519]</span>turn.... So I waited for a
+<p>"Yes, I do. He went upstairs and didn't re<span class="pagenum" id="Page_519">[Pg 519]</span>turn.... So I waited for a
 while and then&mdash;came back."</p>
 
 <p>They sat silent for a while, then Molly lifted her eyes to his and they
@@ -13023,7 +13023,7 @@ anything to conceal."</p>
 
 <p>"I believe he was lying, too.... It was just like that romantic little
 fool to run off to Reno after nothing worse than the imprudence of
-infatuation. I've<span class="pagenum"><a id="Page_520"></a>[Pg 520]</span> known her a long while, Rix. She's too shallow for
+infatuation. I've<span class="pagenum" id="Page_520">[Pg 520]</span> known her a long while, Rix. She's too shallow for
 real passion, too selfish to indulge it anyway. His name and fortune did
 the business for her&mdash;little idiot. Really she annoys me."</p>
 
@@ -13058,7 +13058,7 @@ missed you.... But don't be in a hurry with her, will you, Rix?"</p>
 <p>"If Chester Ledwith doesn't return by twelve I'm going to have the house
 locked," she said, stifling a yawn.</p>
 
-<p><span class="pagenum"><a id="Page_521"></a>[Pg 521]</span></p>
+<p><span class="pagenum" id="Page_521">[Pg 521]</span></p>
 
 <p>At twelve o'clock the house was accordingly locked for the night.</p>
 
@@ -13067,7 +13067,7 @@ fools they are."</p>
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_522"></a>[Pg 522]</span></p>
+<p><span class="pagenum" id="Page_522">[Pg 522]</span></p>
 
 <h2 class="nobreak" id="CHAPTER_XVII">CHAPTER XVII</h2>
 </div>
@@ -13097,7 +13097,7 @@ laughing in her excitement and surprise. They met midway, and she
 whipped off her glove and gave him her hand in a firm, cool clasp.</p>
 
 <p>"Why the dickens didn't you wire!" she said. "You're a fraud, Rix! I
-might easily have been away!&mdash;You might have missed me&mdash;we might have<span class="pagenum"><a id="Page_523"></a>[Pg 523]</span>
+might easily have been away!&mdash;You might have missed me&mdash;we might have<span class="pagenum" id="Page_523">[Pg 523]</span>
 missed each other.... Is <i>that</i> all you care about seeing me?&mdash;after all
 these weeks!"</p>
 
@@ -13137,7 +13137,7 @@ Finally she relented.</p>
 
 <p>"You <i>are</i> satisfactory," she said as they returned to the front veranda
 and seated themselves. "And really, Rix, I'm so terribly glad to see you
-that I for<span class="pagenum"><a id="Page_524"></a>[Pg 524]<br /><a id="Page_525"></a>[Pg 525]<br /><a id="Page_526"></a>[Pg 526]<br /><a id="Page_527"></a>[Pg 527]<br /><a id="Page_528"></a>[Pg 528]</span>give your neglect.... Are you well? You don't look very
+that I for<span class="pagenum" id="Page_528">[Pg 528]</span>give your neglect.... Are you well? You don't look very
 well," she added earnestly. "Why are you so white?"</p>
 
 <p>[Illustration: "'I wanted to surprise you,' he explained feebly."]</p>
@@ -13176,7 +13176,7 @@ unpinning and untying it, her gray eyes never leaving him in their
 unabashed delight in him.</p>
 
 <p>Then she disappeared for a few minutes only to reappear wearing a pair
-of stout little shoes and carry<span class="pagenum"><a id="Page_529"></a>[Pg 529]</span>ing a walking-stick which she said she
+of stout little shoes and carry<span class="pagenum" id="Page_529">[Pg 529]</span>ing a walking-stick which she said she
 used in rough country.</p>
 
 <p>And first they visited her garden where all the old-fashioned autumn
@@ -13212,7 +13212,7 @@ Quarren said, slowly:</p>
 
 <p>"Then, it has to do with Ledwith. He's not very well but he's better
 than he was. You see he wanted to take a course of treatment to regain
-his health, and<span class="pagenum"><a id="Page_530"></a>[Pg 530]</span> there seemed to be nobody else, so&mdash;I offered to see
+his health, and<span class="pagenum" id="Page_530">[Pg 530]</span> there seemed to be nobody else, so&mdash;I offered to see
 him through."</p>
 
 <p>"That's like you, Rix," she said, looking at him.</p>
@@ -13253,7 +13253,7 @@ only stayed long enough to change to boating flannels.... You should see
 him; he's twenty years younger.... I fancy they'll get along together in
 future."</p>
 
-<p><span class="pagenum"><a id="Page_531"></a>[Pg 531]</span></p>
+<p><span class="pagenum" id="Page_531">[Pg 531]</span></p>
 
 <p>"Oh, Rix!" she said, "that was darling of you! You <i>are</i> wonderful even
 if you don't seem to know it!... And to think&mdash;to <i>think</i> that Mary
@@ -13285,7 +13285,7 @@ so."</p>
 <p>"I don't doubt it," he said. "But one way or the other you might as well
 reproach a humming-bird for its morals. There are such people."</p>
 
-<p><span class="pagenum"><a id="Page_532"></a>[Pg 532]</span></p>
+<p><span class="pagenum" id="Page_532">[Pg 532]</span></p>
 
 <p>After a short silence she said:</p>
 
@@ -13334,7 +13334,7 @@ me."</p>
 <p>They looked at each other and laughed over the reminiscence. Then he
 said:</p>
 
-<p><span class="pagenum"><a id="Page_533"></a>[Pg 533]</span></p>
+<p><span class="pagenum" id="Page_533">[Pg 533]</span></p>
 
 <p>"I <i>did</i> disappoint you when you found out what sort of a man I was."</p>
 
@@ -13375,7 +13375,7 @@ unhappy months could have been spared me&mdash;&mdash;"</p>
 
 <p>"Well, I was&mdash;thinking of what I had done to you.... And all those men
 bothering me, every moment, and everybody at me to marry everybody
-else&mdash;and all I<span class="pagenum"><a id="Page_534"></a>[Pg 534]</span> wanted was to be friends with <i>you</i>!... I wasn't sure
+else&mdash;and all I<span class="pagenum" id="Page_534">[Pg 534]</span> wanted was to be friends with <i>you</i>!... I wasn't sure
 of what I wanted from the very beginning, of course, but I knew it as
 soon as I saw you at the Bazaar again.... I was <i>so</i> lonely, Rix&mdash;&mdash;"</p>
 
@@ -13409,7 +13409,7 @@ comprehend you."</p>
 <p>"What was I before you awoke me?"</p>
 
 <p>"A man neglecting his nobler self.... But it could not have lasted; your
-real self could not have long<span class="pagenum"><a id="Page_535"></a>[Pg 535]</span> endured that harlequinade we once thought
+real self could not have long<span class="pagenum" id="Page_535">[Pg 535]</span> endured that harlequinade we once thought
 was real life.... I'm glad if you think that I&mdash;something about
 me&mdash;aroused you.... But if I had not, somebody or some circumstance
 would have very soon served the same purpose."</p>
@@ -13447,7 +13447,7 @@ she's as crazy about Dankmere as he is about her.... Really, Strelsa,
 she's a charming young girl, and she'll make as pretty a countess as any
 of the Dankmeres have married in many a generation."</p>
 
-<p>Strelsa's lip curled: "I don't doubt that. They<span class="pagenum"><a id="Page_536"></a>[Pg 536]</span> were always a horrid
+<p>Strelsa's lip curled: "I don't doubt that. They<span class="pagenum" id="Page_536">[Pg 536]</span> were always a horrid
 cock-fighting, prize-fighting, dissolute lot, weren't they?"</p>
 
 <p>"Something like that. But the present Dankmere is a good sort&mdash;really he
@@ -13485,7 +13485,7 @@ million on him.... I tell you, Strelsa, the rich convert has less honour
 among the poor than the dingiest little 'dip' among the gorgeous
 corsairs of Wall Street.</p>
 
-<p><span class="pagenum"><a id="Page_537"></a>[Pg 537]</span></p>
+<p><span class="pagenum" id="Page_537">[Pg 537]</span></p>
 
 <p>"I don't know how it happens, but Christ was never yet successfully
 preached from Fifth Avenue, and the millionaire whose heart bleeds for
@@ -13521,7 +13521,7 @@ themselves."</p>
 life," she said seriously, "and yet I can foresee lots and lots of most
 delicious leisure awaiting me."</p>
 
-<p><span class="pagenum"><a id="Page_538"></a>[Pg 538]</span></p>
+<p><span class="pagenum" id="Page_538">[Pg 538]</span></p>
 
 <p>"Do you foresee anything else, pretty prophetess?"</p>
 
@@ -13568,7 +13568,7 @@ steadily.</p>
 
 <p>"I desire them to be what they are&mdash;<i>always</i>."</p>
 
-<p><span class="pagenum"><a id="Page_539"></a>[Pg 539]</span></p>
+<p><span class="pagenum" id="Page_539">[Pg 539]</span></p>
 
 <p>"Then that is my wish also," he said with a smile so genuine and gay
 that, a little confused by his acquiescence, her own response was slow.
@@ -13604,7 +13604,7 @@ slowly away toward Witch-Hollow.</p>
 
 <p>From the hill-top they noticed one of Sprowl's farm-waggons slowly
 entering the drive, followed on foot by several men and a little girl.
-Her blond hair and apron<span class="pagenum"><a id="Page_540"></a>[Pg 540]</span> fluttered in the breeze. She was too far away
+Her blond hair and apron<span class="pagenum" id="Page_540">[Pg 540]</span> fluttered in the breeze. She was too far away
 for them to see that she was weeping.</p>
 
 <p>"I wonder what they've got in that waggon?" said Quarren, curiously.</p>
@@ -13639,7 +13639,7 @@ my heart."</p>
 <p>Molly glanced after Quarren who had wandered indoors to find a cigarette
 in the smoking-room.</p>
 
-<p><span class="pagenum"><a id="Page_541"></a>[Pg 541]</span></p>
+<p><span class="pagenum" id="Page_541">[Pg 541]</span></p>
 
 <p>"If you don't marry that delectable young man," she said, "I'll take a
 stick and beat you, Strelsa."</p>
@@ -13680,7 +13680,7 @@ heard.</p>
 <p>"But she exists; don't worry. And any man worth his title is certain to
 encounter her sooner or later."</p>
 
-<p><span class="pagenum"><a id="Page_542"></a>[Pg 542]</span></p>
+<p><span class="pagenum" id="Page_542">[Pg 542]</span></p>
 
 <p>The girl, flushed, dumb, watched her out of wide gray eyes in which the
 unshed tears had dried. The pretty matron slowly shook her head:</p>
@@ -13718,7 +13718,7 @@ moment, her hands covering her eyes.</p>
 
 <p>"Must it be&mdash;that way?"</p>
 
-<p><span class="pagenum"><a id="Page_543"></a>[Pg 543]</span></p>
+<p><span class="pagenum" id="Page_543">[Pg 543]</span></p>
 
 <p>"It will be that way, Strelsa."</p>
 
@@ -13759,7 +13759,7 @@ me for one when we were at&mdash;our house?"</p>
 
 <p>Her gray eyes met his with a frightened sort of courage.</p>
 
-<p>"<i>Our house</i>&mdash;if you wish&mdash;" But her lips had be<span class="pagenum"><a id="Page_544"></a>[Pg 544]</span>gun to tremble and she
+<p>"<i>Our house</i>&mdash;if you wish&mdash;" But her lips had be<span class="pagenum" id="Page_544">[Pg 544]</span>gun to tremble and she
 could not control them or force from them another word for all her
 courage.</p>
 

--- a/src/tests/testhtml5baseline.html
+++ b/src/tests/testhtml5baseline.html
@@ -1,5 +1,5 @@
 <body>
-<p><span class="pagenum"><a id="Page_1"></a>[Pg 1]</span></p>
+<p><span class="pagenum" id="Page_1">[Pg 1]</span></p>
 
 <p>
 
@@ -55,7 +55,7 @@ sent <i>free</i> by mail, on receipt of price, by
 
 G. W. CARLETON &amp; CO., Publishers,
 New York.
-<span class="pagenum"><a id="Page_2"></a>[Pg 2]</span></pre>
+<span class="pagenum" id="Page_2">[Pg 2]</span></pre>
 
 
 
@@ -89,7 +89,7 @@ LONDON: S. LOW, SON &amp; CO.
 MDCCCLXXXVII.
 </p>
 
-<p><span class="pagenum"><a id="Page_3"></a>[Pg 3]</span></p>
+<p><span class="pagenum" id="Page_3">[Pg 3]</span></p>
 
 
 
@@ -108,7 +108,7 @@ Printing and Book Binding Co.</span>
 N. Y.
 </p>
 
-<p><span class="pagenum"><a id="Page_4"></a>[Pg 4]</span></p>
+<p><span class="pagenum" id="Page_4">[Pg 4]</span></p>
 
 
 
@@ -244,7 +244,7 @@ the mystery of his Life.                                                        
 also arrive at Gloster.&mdash;Mr. Pinkerton, as a Laborer, anxious for a Job,
 inspects the Morita Mansion.                                                     143</p>
 
-<p><span class="pagenum"><a id="Page_5"></a>[Pg 5]</span></p>
+<p><span class="pagenum" id="Page_5">[Pg 5]</span></p>
 </div>
 
 <p class="center">CHAPTER III.
@@ -387,7 +387,7 @@ to the Illinois Penitentiary for five years.&mdash;Mr. Pinkerton's
 Theory of the Manner in which Trafton was murdered                               356</p>
 </div>
 
-<p><span class="pagenum"><a id="Page_6"></a>[Pg 6]</span></p>
+<p><span class="pagenum" id="Page_6">[Pg 6]</span></p>
 
 
 
@@ -417,7 +417,7 @@ worse punishment, more so than any suffering which
 could have been entailed on them from leading a poor
 but honest life.</p>
 
-<p><span class="pagenum"><a id="Page_7"></a>[Pg 7]</span></p>
+<p><span class="pagenum" id="Page_7">[Pg 7]</span></p>
 
 <p>The story of the "<span class="smcap">Mississippi Outlaws and the
 Detectives</span>" is written to illustrate incidents which
@@ -447,7 +447,7 @@ plainly and truthfully told as they occurred.</p>
 <hr class="chap" />
 
 <div class="chapter">
-<p><span class="pagenum"><a id="Page_8"></a>[Pg 8]</span></p>
+<p><span class="pagenum" id="Page_8">[Pg 8]</span></p>
 
 <h2 class="nobreak" id="F">F/
 THE MISSISSIPPI OUTLAWS</h2>
@@ -488,7 +488,7 @@ objects of attack by thieves of every grade,
 from the embezzling cashier to the petty sneak-thief,
 and some of the operations connected with
 the detection of this class of criminals are among
-the most difficult and dangerous that have ever<span class="pagenum"><a id="Page_9"></a>[Pg 9]</span>
+the most difficult and dangerous that have ever<span class="pagenum" id="Page_9">[Pg 9]</span>
 been intrusted to me. Probably a no more reckless
 and desperate body of men were ever banded
 together in a civilized community than those who
@@ -521,7 +521,7 @@ other criminals. In spite, however, of the efforts
 of two of my men, who were immediately sent to
 the scene of the robbery, the guilty parties escaped
 into the almost impenetrable swamps along
-the Mississippi River, and the chase was reluct<span class="pagenum"><a id="Page_10"></a>[Pg 10]</span>antly
+the Mississippi River, and the chase was reluct<span class="pagenum" id="Page_10">[Pg 10]</span>antly
 abandoned, as it was impossible to tell where
 they would come out or cross the river. The
 amount stolen was not sufficiently large to warrant
@@ -554,7 +554,7 @@ arrival of the train bound south. As soon as the
 side track was reached the conductor, engineer,
 fireman, brakeman, and express messenger went
 to supper, leaving the train deserted except by
-the express guard, named George Thompson, and<span class="pagenum"><a id="Page_11"></a>[Pg 11]</span>
+the express guard, named George Thompson, and<span class="pagenum" id="Page_11">[Pg 11]</span>
 a few passengers. The local express agent came
 up at this moment, gave his packages to Thompson,
 receiving his receipt therefor, and returned
@@ -587,7 +587,7 @@ desk, he heard a noise at the door, and turning,
 he was confronted by two men, one of whom held
 a revolver at his head, while the other seized his
 throat. Thompson was a young man, and, not
-being accustomed to meet such hard characters,<span class="pagenum"><a id="Page_12"></a>[Pg 12]</span>
+being accustomed to meet such hard characters,<span class="pagenum" id="Page_12">[Pg 12]</span>
 he was badly frightened. He immediately gave
 up the safe key and helped one of the men to unlock
 the safe. Having taken all the money out
@@ -620,7 +620,7 @@ no action seems to have been taken until
 the following Wednesday&mdash;four days later&mdash;when
 Mr. O'Brien sent me a brief telegram announcing
 the robbery, and requesting me to come to Union
-City in person, if possible, and if not, to send my<span class="pagenum"><a id="Page_13"></a>[Pg 13]</span>
+City in person, if possible, and if not, to send my<span class="pagenum" id="Page_13">[Pg 13]</span>
 eldest son, William A. Pinkerton. The telegraph
 was used freely for the next two days, and while
 my son was gathering clues and making his preparations,
@@ -653,7 +653,7 @@ descriptions he received, he obtained a pretty fair
 idea of the party.</p>
 
 <p>The first thing which struck him was the similarity
-of this robbery to the one which had occurred<span class="pagenum"><a id="Page_14"></a>[Pg 14]</span>
+of this robbery to the one which had occurred<span class="pagenum" id="Page_14">[Pg 14]</span>
 exactly three months before at Moscow, Kentucky.
 The appearance of the men and their actions had
 been precisely like those of the Moscow party, and
@@ -686,7 +686,7 @@ civilized people. There seems to have been some
 convulsion of the earth at this point, which is
 sunk so far below the general level of the whole
 country as to make it a perpetual swamp. The
-annual overflow of the Ohio and Mississippi lays<span class="pagenum"><a id="Page_15"></a>[Pg 15]</span>
+annual overflow of the Ohio and Mississippi lays<span class="pagenum" id="Page_15">[Pg 15]</span>
 the country under water for a distance of many
 miles, while even in the dryest season, the morasses,
 sunken lakes, and dense cane-brakes, render
@@ -722,7 +722,7 @@ man be thoroughly acquainted with the country,
 he can never tell where any given path will lead
 him.</p>
 
-<p><span class="pagenum"><a id="Page_16"></a>[Pg 16]</span></p>
+<p><span class="pagenum" id="Page_16">[Pg 16]</span></p>
 
 <p>The people around the towns, such as Hickman,
 Union City, Dyersburg, and Moscow, are a highly
@@ -755,7 +755,7 @@ and it is frequently said of their most expert
 hunters that they seem to have been born
 shot-gun or rifle in hand. Accomplishments they
 have none, except the rare instances where a few
-tunes upon the banjo have been learned from the<span class="pagenum"><a id="Page_17"></a>[Pg 17]</span>
+tunes upon the banjo have been learned from the<span class="pagenum" id="Page_17">[Pg 17]</span>
 negroes. Their tastes are few and simple,&mdash;whisky,
 snuff, hog, and hominy being the necessities and
 luxuries of life; that is, whisky and snuff are the
@@ -788,7 +788,7 @@ lifeless always; after that period, they become
 gaunt, emaciated, and yellow. Whisky hath
 charms for them, also, but their favorite dissipation
 is snuff-dipping. They marry very early and
-bear children nearly every year, so that the size<span class="pagenum"><a id="Page_18"></a>[Pg 18]</span>
+bear children nearly every year, so that the size<span class="pagenum" id="Page_18">[Pg 18]</span>
 of many of these West Tennessee families is often
 enormous. The father exercises patriarchal control
 over his whole household until the daughters
@@ -823,7 +823,7 @@ largely indebted for assistance and information.</p>
 <p>There was one redeeming feature also to the
 character of the "cane-fed" population; in the
 main they were honest, and they would do all in
-their power to break up a thieving gang, even if<span class="pagenum"><a id="Page_19"></a>[Pg 19]</span>
+their power to break up a thieving gang, even if<span class="pagenum" id="Page_19">[Pg 19]</span>
 they had to hang a few of its members as a warning
 to the rest. I was thus able to trust them to
 a certain extent, though the fear which they had
@@ -852,7 +852,7 @@ was a naturally gifted detective, and many were
 the annoying delays which resulted from their
 interference.</p>
 
-<p><span class="pagenum"><a id="Page_20"></a>[Pg 20]</span></p>
+<p><span class="pagenum" id="Page_20">[Pg 20]</span></p>
 
 
 
@@ -893,7 +893,7 @@ delay. Such a state of affairs frequently occurred
 during this operation, and much time and money
 were spent upon matters too trifling even for consideration.</p>
 
-<p><span class="pagenum"><a id="Page_21"></a>[Pg 21]</span></p>
+<p><span class="pagenum" id="Page_21">[Pg 21]</span></p>
 
 <p>The principal of a detective agency, from his
 long experience with criminals, learns the earmarks
@@ -927,7 +927,7 @@ expenditure of much thought, time, and money,
 proved after all to be of no value whatever in
 developing any evidence in the case. In this
 operation, such instances were of frequent occurrence,
-and I propose to mention a few of them to<span class="pagenum"><a id="Page_22"></a>[Pg 22]</span>
+and I propose to mention a few of them to<span class="pagenum" id="Page_22">[Pg 22]</span>
 show how wide is the range of the detective's
 inquiries, and also the annoying delays to which
 he is often subjected by the inconsiderate zeal
@@ -962,7 +962,7 @@ and, where such are the circumstances, the detection
 of the criminal is apt to be one of the most
 difficult of all operations. Having once solved
 these two difficulties satisfactorily, however, and
-having observed the relative bearings of time,<span class="pagenum"><a id="Page_23"></a>[Pg 23]</span>
+having observed the relative bearings of time,<span class="pagenum" id="Page_23">[Pg 23]</span>
 place, and means to the crime itself, the question
 of individuals is the important one to be determined.
 It often happens that there is no concealment
@@ -996,7 +996,7 @@ we were forced to follow during this operation.</p>
 Union City, he was informed by the superintendent
 of the express company having charge
 of the operation, that there was a young man in
-Moscow who could give important information<span class="pagenum"><a id="Page_24"></a>[Pg 24]</span>
+Moscow who could give important information<span class="pagenum" id="Page_24">[Pg 24]</span>
 relative to the first robbery at that place. This
 young man, Thomas Carr by name, was a lawyer
 who had once had fine prospects, but he had become
@@ -1031,7 +1031,7 @@ to the South; then Carr was to take the same
 train and give a signal to the rest of the party on
 arriving at the designated spot.</p>
 
-<p><span class="pagenum"><a id="Page_25"></a>[Pg 25]</span></p>
+<p><span class="pagenum" id="Page_25">[Pg 25]</span></p>
 
 <p>On hearing Carr's story, William sent him back
 to Moscow with instructions to renew his intimacy
@@ -1065,7 +1065,7 @@ Trunnion had then said he was only fooling, and
 that he did not mean anything by it. William
 learned that Trunnion was then engaged in selling
 trees for a nursery at Clinton, Kentucky, and that
-he was regarded as a half-cracked, boasting fool,<span class="pagenum"><a id="Page_26"></a>[Pg 26]</span>
+he was regarded as a half-cracked, boasting fool,<span class="pagenum" id="Page_26">[Pg 26]</span>
 who might be anything bad, if he were influenced
 by bold, unscrupulous men. William therefore
 paid a visit to Mr. Trunnion, whom he found to
@@ -1098,7 +1098,7 @@ party in that place, just a week before. Santon
 represented that he knew the man well, having
 been acquainted with him for years in Cairo, and
 that he could not be mistaken, as he had spoken
-with him on the day mentioned. William found<span class="pagenum"><a id="Page_27"></a>[Pg 27]</span>
+with him on the day mentioned. William found<span class="pagenum" id="Page_27">[Pg 27]</span>
 that the man Santon was a natural liar, who could
 not tell the truth even when it was for his interest
 to do so. The descriptions of the various robbers
@@ -1131,7 +1131,7 @@ the robbery, and he intended to tell the company's
 officers that this nephew had been engaged in the
 robbery; then if the company captured the
 nephew, Swing hoped to get back his horse. A
-truly brilliant scheme it was, but, unfortunately<span class="pagenum"><a id="Page_28"></a>[Pg 28]</span>
+truly brilliant scheme it was, but, unfortunately<span class="pagenum" id="Page_28">[Pg 28]</span>
 for his expectations, William could not be misled
 by his plausible story; and, if he ever recovered
 his horse, he did so without the assistance of the
@@ -1163,7 +1163,7 @@ they could not make the desired exchange. One
 of the women was a blonde and the other was a
 brunette. They were about of the same height,
 and they dressed in such marked contrast as to
-set each other off to the best advantage; indeed,<span class="pagenum"><a id="Page_29"></a>[Pg 29]</span>
+set each other off to the best advantage; indeed,<span class="pagenum" id="Page_29">[Pg 29]</span>
 their dresses seemed to have attracted so much
 attention that I could gain very little acquaintance
 with their personal appearance. I could not connect
@@ -1197,7 +1197,7 @@ large expense with no possibility of a return.</p>
 
 <p>Very shortly after the Union City robbery, a
 letter was received from a man in Kansas City,
-calling himself Charles Lavalle. The writer<span class="pagenum"><a id="Page_30"></a>[Pg 30]</span>
+calling himself Charles Lavalle. The writer<span class="pagenum" id="Page_30">[Pg 30]</span>
 claimed that he had been with the gang who had
 robbed the train, but that they had refused to
 divide with him, and so, out of revenge, he was
@@ -1232,7 +1232,7 @@ that no more money would be advanced until
 some of his party were actually discovered and
 trapped through his agency, he soon ceased writing.</p>
 
-<p><span class="pagenum"><a id="Page_31"></a>[Pg 31]</span></p>
+<p><span class="pagenum" id="Page_31">[Pg 31]</span></p>
 
 <p>The foregoing are only a few of the instances
 in which our attention was diverted from the
@@ -1272,7 +1272,7 @@ happy inebriety, ready to "hail fellow, well met,"
 with any person he might encounter.</p>
 
 <p>On his way home, about three-quarters of a mile
-west of Union City, he saw a camp-fire burning a<span class="pagenum"><a id="Page_32"></a>[Pg 32]</span>
+west of Union City, he saw a camp-fire burning a<span class="pagenum" id="Page_32">[Pg 32]</span>
 short distance from the track, and around it were
 gathered five men. They hailed him, and asked
 him to take a drink; and as this was an invitation
@@ -1307,7 +1307,7 @@ deer-hunt in which he had participated, in Fayette
 county, Illinois, on the Kaskaskia river, and
 when he mentioned the place, the others scowled
 and winked at him, as if to stop him. Hicks said
-that they seemed to be familiar with Cincinnati,<span class="pagenum"><a id="Page_33"></a>[Pg 33]</span>
+that they seemed to be familiar with Cincinnati,<span class="pagenum" id="Page_33">[Pg 33]</span>
 Louisville, Evansville, and other northern cities,
 and that they talked somewhat like Yankees.
 He remained with them until about midnight,
@@ -1341,7 +1341,7 @@ I could gain no news whatever, except from St.
 Louis, whence an answer was returned to the
 effect that Nelson was said to be stopping somewhere
 in the country back of Hickman, Kentucky.
-Ogle's wife was in St. Louis, and she had<span class="pagenum"><a id="Page_34"></a>[Pg 34]</span>
+Ogle's wife was in St. Louis, and she had<span class="pagenum" id="Page_34">[Pg 34]</span>
 been seen by a detective walking and talking earnestly
 with a strange man a short time previous.
 The information about Nelson was important,
@@ -1375,7 +1375,7 @@ passed for river gamblers.</p>
 <p>On William's return to Union City from Hickman,
 he decided to make a visit to this grocery-store
 to learn something about the men who frequented
-it. Having none of his own men with<span class="pagenum"><a id="Page_35"></a>[Pg 35]</span>
+it. Having none of his own men with<span class="pagenum" id="Page_35">[Pg 35]</span>
 him, he chose one of the express company's detectives,
 named Patrick Connell, to accompany
 him, and, on the last day of October, they started
@@ -1408,7 +1408,7 @@ were careful never to give any hint of their previous
 place of residence in the hearing of strangers.
 Mr. Merrick had, however, heard Russell
 say that he had once run a stationary engine in
-Missouri, and from occasional expressions by<span class="pagenum"><a id="Page_36"></a>[Pg 36]</span>
+Missouri, and from occasional expressions by<span class="pagenum" id="Page_36">[Pg 36]</span>
 Barton it would appear that the latter had once
 worked on a railroad in some capacity. They
 dressed quite well, and treated strangers politely,
@@ -1442,7 +1442,7 @@ a distance of about thirty yards from the house.
 The wood-yard and landing at the water's level
 were some ten or fifteen feet below the rising
 ground upon which the house stood. The store
-was a shanty of rough pine boards with one door<span class="pagenum"><a id="Page_37"></a>[Pg 37]</span>
+was a shanty of rough pine boards with one door<span class="pagenum" id="Page_37">[Pg 37]</span>
 and one window, and it stood at the head of the
 diagonal path leading from the landing to the high
 ground. A short distance back was a rail fence
@@ -1475,7 +1475,7 @@ about the clearing did not prevent William from
 exercising his usual caution in approaching the
 house; but he did consider it unnecessary to take
 any stronger force into an apparently unoccupied
-log-cabin, where at most he had only vague sus<span class="pagenum"><a id="Page_38"></a>[Pg 38]</span>picions
+log-cabin, where at most he had only vague sus<span class="pagenum" id="Page_38">[Pg 38]</span>picions
 of finding the objects of his search;
 hence, he left Gordon and Bledsoe behind. Knowing
 the general construction of this class of
@@ -1509,7 +1509,7 @@ corner stood several shot-guns, and in another,
 four or five heavy axes. Grouped about near
 the fire, in different attitudes of surprise, defiance,
 and alarm, were the occupants of the cabin,
-while to the left, in the half-open door stood<span class="pagenum"><a id="Page_39"></a>[Pg 39]</span>
+while to the left, in the half-open door stood<span class="pagenum" id="Page_39">[Pg 39]</span>
 Connell. The flickering flame of the rotten wood
 gave a most unsatisfactory light, in which they
 all seemed nearly as dark as negroes, so that
@@ -1544,7 +1544,7 @@ a large cottonwood tree and fired back at Connell
 and William, who were in full view on the porch.
 The second shot struck Connell in the pit of the
 stomach, and he fell backward. At this moment,
-<span class="pagenum"><a id="Page_40"></a>[Pg 40]<br /><a id="Page_41"></a>[Pg 41]<br /><a id="Page_42"></a>[Pg 42]</span>the powerful ruffian, Burtine, seized William
+<span class="pagenum" id="Page_42">[Pg 42]</span>the powerful ruffian, Burtine, seized William
 from behind and tried to drag him down, at the
 same time calling for a shot-gun "to finish the
 Yankee&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;." Turning suddenly upon
@@ -1578,7 +1578,7 @@ nearly to the small of his back, where it had
 gone out. The shock of the blow had stunned
 him somewhat, the button having been forced
 edgewise some distance into the flesh, but his
-wound was very trifling, and he was able to go<span class="pagenum"><a id="Page_43"></a>[Pg 43]</span>
+wound was very trifling, and he was able to go<span class="pagenum" id="Page_43">[Pg 43]</span>
 on with the search with very little inconvenience.
 Having captured three out of the five inmates of
 the cabin, William felt as though he had done as
@@ -1614,7 +1614,7 @@ they were clearly not the train robbers, while it
 was equally evident that the two who had escaped
 were the guilty parties.</p>
 
-<p><span class="pagenum"><a id="Page_44"></a>[Pg 44]</span></p>
+<p><span class="pagenum" id="Page_44">[Pg 44]</span></p>
 
 <p>William learned that the young man who had
 first slipped out was Barton, and the man who
@@ -1651,7 +1651,7 @@ intentions of the man Russell, while Burtine had
 evidently intended that they should never leave
 the house alive.</p>
 
-<p><span class="pagenum"><a id="Page_45"></a>[Pg 45]</span></p>
+<p><span class="pagenum" id="Page_45">[Pg 45]</span></p>
 
 <p>It may be supposed that the shooting on both
 sides was none of the best, but it must be remembered
@@ -1689,7 +1689,7 @@ they would, since no man could find his way
 there in broad daylight, much less at night. They
 further admitted that they dare not attempt it, as
 Russell would kill them if they learned of their
-action. It was now pitch dark, and after a vain<span class="pagenum"><a id="Page_46"></a>[Pg 46]</span>
+action. It was now pitch dark, and after a vain<span class="pagenum" id="Page_46">[Pg 46]</span>
 attempt to beat through the cane in search of the
 fugitives, William decided to return to Mr. Merrick's
 until next day.</p>
@@ -1723,7 +1723,7 @@ of Russell, Clark, and Barton, except that they
 had come to his place in July, built the store
 there, and had been around the landing more or
 less ever since. He said that he knew nothing
-against them, except that they were gamblers,<span class="pagenum"><a id="Page_47"></a>[Pg 47]</span>
+against them, except that they were gamblers,<span class="pagenum" id="Page_47">[Pg 47]</span>
 and that they often went off on gambling excursions,
 during one of which, according to their
 own statements, they had killed a man in a quarrel.</p>
@@ -1757,7 +1757,7 @@ said to have gone there three days before.</p>
 superintendent telegraphed to me the result of
 William's visit to Lester's Landing, and authorized
 me to send an operative to Farmington,
-Illinois, to hunt up Mrs. Kate Graham, and learn<span class="pagenum"><a id="Page_48"></a>[Pg 48]</span>
+Illinois, to hunt up Mrs. Kate Graham, and learn<span class="pagenum" id="Page_48">[Pg 48]</span>
 what she could tell about Russell, Clark, and
 Barton. A man was sent there the next day, and
 he had no difficulty in finding Mrs. Graham, who
@@ -1790,7 +1790,7 @@ of Clark's companion, Mrs. Slaughter, and there
 he found them both. Clark was surprised by the
 officers, but he made a bold fight, and was overpowered
 with difficulty. When finally handcuffed
-and searched, a navy revolver and fifty<span class="pagenum"><a id="Page_49"></a>[Pg 49]</span>
+and searched, a navy revolver and fifty<span class="pagenum" id="Page_49">[Pg 49]</span>
 dollars in money were taken from him; he was
 then taken nine miles on horseback to Cape Girardeau,
 where Connell obtained a light wagon to
@@ -1823,7 +1823,7 @@ The chase was kept up as long as the pursuers
 were able to distinguish the direction of his flight,
 but, in the darkness of the gloomy woods, it was
 impossible to follow an athletic fellow like Clark
-with any hope of success. Connell returned to<span class="pagenum"><a id="Page_50"></a>[Pg 50]</span>
+with any hope of success. Connell returned to<span class="pagenum" id="Page_50">[Pg 50]</span>
 Union City very much crestfallen, and reported
 his misfortune. My first feeling, on learning the
 news, was one of deep regret and anxiety at the
@@ -1856,7 +1856,7 @@ Adams Express Company gave me a fair opportunity
 to work to good advantage, and victory
 was the result.</p>
 
-<p><span class="pagenum"><a id="Page_51"></a>[Pg 51]</span></p>
+<p><span class="pagenum" id="Page_51">[Pg 51]</span></p>
 
 
 
@@ -1896,7 +1896,7 @@ the middle of October, the three storekeepers
 went away, and were gone until October 24, three
 days after the robbery, on which day Lester met
 Clark and Barton walking toward his house, on
-the way from Hickman. They seemed quite ex<span class="pagenum"><a id="Page_52"></a>[Pg 52]</span>cited,
+the way from Hickman. They seemed quite ex<span class="pagenum" id="Page_52">[Pg 52]</span>cited,
 and said that they had been engaged in a
 difficulty, but they did not state what it was.
 They asked him whether he had seen Russell recently,
@@ -1928,7 +1928,7 @@ landing the next day to capture the men if they
 returned, but they were afraid to attempt it, although
 they had a good opportunity that night.
 Russell came into the house alone, showing no
-signs of having been wounded, and said that he<span class="pagenum"><a id="Page_53"></a>[Pg 53]</span>
+signs of having been wounded, and said that he<span class="pagenum" id="Page_53">[Pg 53]</span>
 and Barton had joined four friends, who were
 outside waiting for him; that they were all well
 mounted and armed, and that they intended to
@@ -1962,7 +1962,7 @@ Russell, Clark, and Barton, from whatever source
 information could be obtained. Barton was well
 known in Nashville, New Madrid, and Union
 City. He was quite young, but he had been involved
-in a stabbing affray in Nashville, and was<span class="pagenum"><a id="Page_54"></a>[Pg 54]</span>
+in a stabbing affray in Nashville, and was<span class="pagenum" id="Page_54">[Pg 54]</span>
 regarded as a desperate character. He had been
 respectably brought up by Major Landis, General
 Agent of the Nashville and Northwestern Railroad,
@@ -1996,7 +1996,7 @@ and Barton were lurking around Lester's, and
 so, while William went to Nashville to see what
 could be learned about Barton and his companions,
 a number of men were hired to scour the
-country, hunt through the brake, and guard the<span class="pagenum"><a id="Page_55"></a>[Pg 55]</span>
+country, hunt through the brake, and guard the<span class="pagenum" id="Page_55">[Pg 55]</span>
 Mississippi ferries, while Connell and Crowley,
 the express messenger, were placed on the Missouri
 bank, to scout that side of the river. I may
@@ -2029,7 +2029,7 @@ being quite young. Hillary and Levi Farrington
 bore a very bad reputation, having been mixed
 up in all kinds of fights and quarrels for a number
 of years. They were suspected of horse-stealing
-and counterfeiting; but most people were<span class="pagenum"><a id="Page_56"></a>[Pg 56]</span>
+and counterfeiting; but most people were<span class="pagenum" id="Page_56">[Pg 56]</span>
 afraid of them, and they had never been arrested
 in that vicinity. William here learned, also, that
 Barton had been a frequent visitor at the Farringtons',
@@ -2062,7 +2062,7 @@ who have seen them together believe them to
 have been brothers. Hillary and Levi Farrington,
 I am told, also closely resemble each other,
 and they have not been seen about here for some
-months, they being, according to their mother's<span class="pagenum"><a id="Page_57"></a>[Pg 57]</span>
+months, they being, according to their mother's<span class="pagenum" id="Page_57">[Pg 57]</span>
 account, in Texas. The chain of evidence is very
 complete; what if Russell and Clark should prove
 to be the Farrington brothers!"</p>
@@ -2102,7 +2102,7 @@ latter had warned him of his danger, and he had
 then disappeared in the cane-brake. The men
 stationed at Lester's for the express purpose of
 arresting any of the robbers who might come
-there, had been either unaware of Clark's visit,<span class="pagenum"><a id="Page_58"></a>[Pg 58]</span>
+there, had been either unaware of Clark's visit,<span class="pagenum" id="Page_58">[Pg 58]</span>
 or else they had been afraid to attempt his capture,
 and he had escaped again when almost
 within our grasp. William had, therefore, been
@@ -2137,7 +2137,7 @@ the question of identity at once, for, on being
 told that she would be obliged to let him search
 her wagons for certain men, she replied:</p>
 
-<p><span class="pagenum"><a id="Page_59"></a>[Pg 59]</span></p>
+<p><span class="pagenum" id="Page_59">[Pg 59]</span></p>
 
 <p>"Oh! yes; I know what you want. You would
 like to find my two sons and Barton for the express
@@ -2172,7 +2172,7 @@ where to go.</p>
 at their mother's house Friday evening, November
 10, and that a man who had gone there
 to sell her a wagon had been met by Hillary Farrington
-with a shot-gun; on seeing that it was a<span class="pagenum"><a id="Page_60"></a>[Pg 60]</span>
+with a shot-gun; on seeing that it was a<span class="pagenum" id="Page_60">[Pg 60]</span>
 neighbor, however, Hillary had lowered his gun
 and allowed him to come in. It was also learned
 that the three desperadoes had been seen at the
@@ -2208,7 +2208,7 @@ not have hesitated a moment to lie in ambush
 and kill their pursuers, if they had found it possible
 to do so.</p>
 
-<p><span class="pagenum"><a id="Page_61"></a>[Pg 61]</span></p>
+<p><span class="pagenum" id="Page_61">[Pg 61]</span></p>
 
 <p>In order to intercept the fugitives before reaching
 the swampy country near the Mississippi, the
@@ -2241,7 +2241,7 @@ equally daring means of ridding themselves of
 pursuit. The manner in which Ball and Bledsoe
 exposed their intentions wherever they went
 showed the inexperience of both men in such
-work; for, along the whole route over which<span class="pagenum"><a id="Page_62"></a>[Pg 62]</span>
+work; for, along the whole route over which<span class="pagenum" id="Page_62">[Pg 62]</span>
 they passed, they were known as officers tracking
 a band of thieves; and we afterward learned
 that, while they were innocently and unsuspectingly
@@ -2274,7 +2274,7 @@ to manage the whole operation by my own plans
 and with my own men. While William, therefore,
 was at work with indefatigable energy and
 perseverance, scouting and following up all the
-reports brought in by the vast army of volunteer<span class="pagenum"><a id="Page_63"></a>[Pg 63]</span>
+reports brought in by the vast army of volunteer<span class="pagenum" id="Page_63">[Pg 63]</span>
 detectives in the company's employ, we were both
 satisfied that the method adopted was useless, and
 that even the ferry guards would discover nothing.
@@ -2307,7 +2307,7 @@ away flourishing his bloody knife and threatening
 to kill any one who should stand in his way.
 The sight of William's heavy revolver leveled at
 his head, backed by the certainty which he saw
-in William's face that death or surrender was his<span class="pagenum"><a id="Page_64"></a>[Pg 64]</span>
+in William's face that death or surrender was his<span class="pagenum" id="Page_64">[Pg 64]</span>
 only alternative, caused him to choose the latter,
 and he was lodged in jail to await his trial for
 murder. The people of the town were quite enthusiastic
@@ -2341,7 +2341,7 @@ Bird's Point, opposite Cairo, and the fact was reported
 to William and to me by telegraph. We
 had previously learned that Mrs. Farrington had
 relatives in Springfield, Missouri, and in Dade
-County, in the same State, and the probabilities<span class="pagenum"><a id="Page_65"></a>[Pg 65]</span>
+County, in the same State, and the probabilities<span class="pagenum" id="Page_65">[Pg 65]</span>
 were that, instead of going to Texas, she was
 going to visit in one of these places. Meanwhile,
 though my opinion was that her sons intended to
@@ -2374,7 +2374,7 @@ be questioned; and, third, while their intention
 might have been to meet there, subsequent events
 might have altered their plans. Still, thinking
 the subject over carefully, I decided that she
-would not take so difficult a course unless she<span class="pagenum"><a id="Page_66"></a>[Pg 66]</span>
+would not take so difficult a course unless she<span class="pagenum" id="Page_66">[Pg 66]</span>
 really intended to meet her sons there. My reasons
 for so thinking were based upon the nature
 of the place, and, to comprehend my solicitude
@@ -2407,7 +2407,7 @@ rankest of swamp-vegetation is seen, growing in
 wild profusion and covering the treacherous ooze
 with a close network of leaves and branches,
 until the surface looks firm enough to be taken
-for solid ground; but should any unfortunate<span class="pagenum"><a id="Page_67"></a>[Pg 67]</span>
+for solid ground; but should any unfortunate<span class="pagenum" id="Page_67">[Pg 67]</span>
 traveler venture to cross such a spot, his limbs
 would be clogged by these clinging water-plants,
 his feet would find no secure resting-place, and,
@@ -2441,7 +2441,7 @@ every person traveling through either way must
 pass this place. Knowing this fact, I felt sure
 that Mrs. Farrington would await the arrival of
 her sons at "The Gates," in case she entered the
-swamp, and I determined that, in such an event,<span class="pagenum"><a id="Page_68"></a>[Pg 68]</span>
+swamp, and I determined that, in such an event,<span class="pagenum" id="Page_68">[Pg 68]</span>
 I should try to capture them there. I was fully
 aware of the danger of such an attempt, but I
 knew that to take the bull by the horns is sometimes
@@ -2474,7 +2474,7 @@ went north to Fredericktown, there was no doubt
 that she had changed her plan of meeting her
 sons in Nigger-Wool Swamp.</p>
 
-<p><span class="pagenum"><a id="Page_69"></a>[Pg 69]</span></p>
+<p><span class="pagenum" id="Page_69">[Pg 69]</span></p>
 
 
 
@@ -2516,7 +2516,7 @@ but I hope it will stay so, as you say it is a soft
 thing&mdash;as soft as things gets to be. I would like
 to see something like that, you bet. You talk like
 it can't be beat. That is the thing to take in. I
-think, and I know you think it, for I saw your<span class="pagenum"><a id="Page_70"></a>[Pg 70]</span>
+think, and I know you think it, for I saw your<span class="pagenum" id="Page_70">[Pg 70]</span>
 name. I guess I did see you. You know Mr.
 Crapmel? He is a great fellow; you bet it is so.
 I have nothing more to write at present, as you
@@ -2554,7 +2554,7 @@ their operations.</p>
 <p>On reading this letter, William sent a copy to
 me immediately, and suggested that one or two
 good men be sent to Verona to get work near this
-man Durham, and to get into the confidence of<span class="pagenum"><a id="Page_71"></a>[Pg 71]</span>
+man Durham, and to get into the confidence of<span class="pagenum" id="Page_71">[Pg 71]</span>
 the family, so that, when Mrs. Farrington should
 arrive, she would not be likely to suspect any one
 who had come before her. I fully approved of
@@ -2587,7 +2587,7 @@ them had been based upon the supposition that
 they would find a number of robbers, horse-thieves,
 and counterfeiters around Verona, and
 that they would be easily able to get Durham's
-confidence by appearing as reckless and desperate<span class="pagenum"><a id="Page_72"></a>[Pg 72]</span>
+confidence by appearing as reckless and desperate<span class="pagenum" id="Page_72">[Pg 72]</span>
 as any one. They had each prepared a choice autobiography
 for use among the residents, and, according
 to their own intended accounts of themselves,
@@ -2620,7 +2620,7 @@ with Cottrell and Marriott on Tuesday, December
 railroad company wished to sell. During Sunday
 and Monday both of the detectives were trying to
 learn where Durham lived, but no one seemed to
-know; neither could any one tell them anything<span class="pagenum"><a id="Page_73"></a>[Pg 73]</span>
+know; neither could any one tell them anything<span class="pagenum" id="Page_73">[Pg 73]</span>
 about John Ellis, upon whose farm Durham had
 said he was living. The idea that Mrs. Farrington
 was rapidly pushing west, toward Durham's place,
@@ -2653,7 +2653,7 @@ story to Mr. Purdy, and showed him their credentials.
 He was quite astonished at their revelations,
 but he was very hearty and sincere in his
 expressions of good will toward them, and he
-promised to aid them in every possible way. He<span class="pagenum"><a id="Page_74"></a>[Pg 74]</span>
+promised to aid them in every possible way. He<span class="pagenum" id="Page_74">[Pg 74]</span>
 knew John Ellis quite well, having sold him the
 farm on which he was living, and he had heard of
 Durham, who hired a small portion of the Ellis
@@ -2687,7 +2687,7 @@ to come.</p>
 <p>Thus the first week of December passed, and
 the operation was not progressing very favorably
 anywhere. Ball and Bledsoe had reported Mrs.
-Farrington's route up to the thirtieth of November,<span class="pagenum"><a id="Page_75"></a>[Pg 75]</span>
+Farrington's route up to the thirtieth of November,<span class="pagenum" id="Page_75">[Pg 75]</span>
 and she had moved quite rapidly up to that date,
 but nothing had been learned since, and I expected
 to hear of her arrival at Verona every day. She
@@ -2720,7 +2720,7 @@ Barton, it occurred to him that these might have
 been the women who were said to have been in
 Kansas City with so much money. He started
 at once for Louisville, at the same time telegraphing
-to me his suspicions in the matter, and I<span class="pagenum"><a id="Page_76"></a>[Pg 76]</span>
+to me his suspicions in the matter, and I<span class="pagenum" id="Page_76">[Pg 76]</span>
 began inquiries again in Kansas City by telegraph.
 I could learn very little except from the teller of
 one bank, who described the women as well as he
@@ -2753,7 +2753,7 @@ Durham, and they rented a small house on a part
 of the Ellis farm. Nothing positive had ever been
 discovered against the character of either James
 or Tilman Durham, but the neighbors had a poor
-opinion of them, and kept a pretty close watch<span class="pagenum"><a id="Page_77"></a>[Pg 77]</span>
+opinion of them, and kept a pretty close watch<span class="pagenum" id="Page_77">[Pg 77]</span>
 upon their actions. During the previous fall a
 young man had visited them for some time, and
 his description was exactly that of Levi Farrington;
@@ -2786,7 +2786,7 @@ September had given his name as Levi Farrington,
 and had passed as the beau of the young Durham
 girl. In speaking of him, Jim Durham had told
 Mr. Stone that he did not wish his sister to marry
-Farrington, as the latter was a dangerous man,<span class="pagenum"><a id="Page_78"></a>[Pg 78]</span>
+Farrington, as the latter was a dangerous man,<span class="pagenum" id="Page_78">[Pg 78]</span>
 and had recently killed a man in a quarrel, while
 those who stood about were too much afraid of
 him to arrest him. Mr. Wisbey then returned
@@ -2822,7 +2822,7 @@ as follows:</p>
 
 <p>"Are you sure it is Levi Farrington? His
 brother and Barton will probably be at Verona
-soon. We must get the whole. I think they<span class="pagenum"><a id="Page_79"></a>[Pg 79]</span>
+soon. We must get the whole. I think they<span class="pagenum" id="Page_79">[Pg 79]</span>
 will come from Douglas County. Probably Connell
 and Galway will be with you by Monday or
 Tuesday night; they can identify the men. Mrs.
@@ -2856,7 +2856,7 @@ my reply to their telegram announcing this fact
 until late that day, and so they could do nothing
 toward satisfying themselves as to Levi Farrington's
 identity until next morning, when they
-visited Wisbey at his own house. Mr. Stone,<span class="pagenum"><a id="Page_80"></a>[Pg 80]</span>
+visited Wisbey at his own house. Mr. Stone,<span class="pagenum" id="Page_80">[Pg 80]</span>
 Wisbey's son-in-law, had met a man named
 Smothers, who worked for Jim Durham, and
 Smothers had told him all about the two men
@@ -2890,7 +2890,7 @@ Hillary.</p>
 the contents of the store at Lester's,
 knew that they were not worth over two hundred
 dollars, and he telegraphed me to that effect,
-suggesting that it was improbable that Hillary<span class="pagenum"><a id="Page_81"></a>[Pg 81]</span>
+suggesting that it was improbable that Hillary<span class="pagenum" id="Page_81">[Pg 81]</span>
 should run so much risk for so small a sum. On
 learning this fact, I coincided with him, and
 ordered him to go on to Verona, as I had originally
@@ -2929,7 +2929,7 @@ morning Mr. Stone came to Verona, and told
 them that he had learned that Farrington and
 cousins intended to leave Durham's for the Indian
 Territory the next day. The news was
-doubtless authentic, Stone having heard it from<span class="pagenum"><a id="Page_82"></a>[Pg 82]</span>
+doubtless authentic, Stone having heard it from<span class="pagenum" id="Page_82">[Pg 82]</span>
 Smothers, who had said that Farrington had told
 him so himself. It was clearly impossible to wait
 for William's arrival, as, by that time, the men
@@ -2962,7 +2962,7 @@ by telegraph, and so he was unable to accompany
 the detectives and citizens on their expedition to
 Durham's. The party of eight met the detectives
 outside the town, and they were joined on
-their way by three others, who lived on the road.<span class="pagenum"><a id="Page_83"></a>[Pg 83]</span>
+their way by three others, who lived on the road.<span class="pagenum" id="Page_83">[Pg 83]</span>
 They were all substantial business men or
 farmers, but they were accustomed to a life in
 the saddle, and they had all borne arms during
@@ -2996,7 +2996,7 @@ owned the house and land where the Durhams
 were living; he was a very highly respected citizen,
 and was not at all displeased at the idea of
 getting rid of his semi-disreputable tenants. The
-management of the affair was then unanimously<span class="pagenum"><a id="Page_84"></a>[Pg 84]</span>
+management of the affair was then unanimously<span class="pagenum" id="Page_84">[Pg 84]</span>
 voted to Cottrell, and the party rode rapidly
 toward the Durham house. It was situated at
 the edge of a clearing, with underbrush and
@@ -3029,7 +3029,7 @@ him to surrender. He then hastily tried to close
 the back door also, and pointed his revolver
 through the crack; but the discharge of several
 shots, which struck close to him, caused him to
-withdraw his pistol and tightly close the door. It<span class="pagenum"><a id="Page_85"></a>[Pg 85]</span>
+withdraw his pistol and tightly close the door. It<span class="pagenum" id="Page_85">[Pg 85]</span>
 was evident that the birds were caged at last, and
 it was now only a question of time when they
 would be taken; as it was only one o'clock in the
@@ -3063,7 +3063,7 @@ believed she could induce them to surrender.
 Accordingly, she went to the front window and
 implored them not to have the house burned
 down, as all her household goods would be destroyed.
-They replied that they might as well<span class="pagenum"><a id="Page_86"></a>[Pg 86]</span>
+They replied that they might as well<span class="pagenum" id="Page_86">[Pg 86]</span>
 die inside as to come out and be shot down. Cottrell
 sent back word that they should be treated
 like all other prisoners if they would pass out
@@ -3097,7 +3097,7 @@ appeal to the ruffians inside, but they would not
 listen to her entreaties. They asked her, however,
 what kind of a looking man Cottrell was,
 and what he wanted to arrest them for. Cottrell
-was standing near enough to hear the question,<span class="pagenum"><a id="Page_87"></a>[Pg 87]</span>
+was standing near enough to hear the question,<span class="pagenum" id="Page_87">[Pg 87]</span>
 and after Mrs. Durham had described his appearance,
 he told them that he wanted them for an
 express robbery; that he would treat them kindly
@@ -3132,7 +3132,7 @@ which a frightened man stood out in bold relief
 against the sky, tearing off the shingles and
 piling them upon a glowing flame at his feet.
 Everything was now hushed in deathly silence,
-<span class="pagenum"><a id="Page_88"></a>[Pg 88]<br /><a id="Page_89"></a>[Pg 89]<br /><a id="Page_90"></a>[Pg 90]</span>and it needed no explanation for any one to understand
+<span class="pagenum" id="Page_90">[Pg 90]</span>and it needed no explanation for any one to understand
 that a bloody tragedy was about to occur
 if that flame should be allowed to envelop the
 building. It was now the prison of its two occupants,
@@ -3166,7 +3166,7 @@ house, and leave them to their fate. She made
 one more appeal, and Barton handed her a navy
 revolver; then Farrington did the same, and she
 brought them to Cottrell, saying that they would
-surrender if they could be sure that their lives<span class="pagenum"><a id="Page_91"></a>[Pg 91]</span>
+surrender if they could be sure that their lives<span class="pagenum" id="Page_91">[Pg 91]</span>
 would be spared. Cottrell told her to go back
 and get the rest of their arms, and assure them
 that they should be taken to Tennessee for trial.
@@ -3199,7 +3199,7 @@ the house and saddling their animals, it was nearly
 dark by the time they started for Verona. Farrington
 and Barton were carefully tied upon the
 horse and mule respectively, and, after thanking
-the neighboring farmers for their assistance, Cot<span class="pagenum"><a id="Page_92"></a>[Pg 92]</span>trell
+the neighboring farmers for their assistance, Cot<span class="pagenum" id="Page_92">[Pg 92]</span>trell
 took the road back, accompanied by the
 eleven men who belonged in and about Verona.
 The greatest care was taken that the prisoners
@@ -3236,7 +3236,7 @@ watches, determined that no possible loophole for
 escape should again be afforded to such daring
 villains as these two.</p>
 
-<p><span class="pagenum"><a id="Page_93"></a>[Pg 93]</span></p>
+<p><span class="pagenum" id="Page_93">[Pg 93]</span></p>
 
 <p>The result of the expedition was, of course,
 transmitted to me in telegraphic cipher at once;
@@ -3270,7 +3270,7 @@ informed them that he considered them entitled
 to it, and that he should recommend its payment,
 but that the matter would be decided by the officers
 of the company. I may here anticipate
-events somewhat to state that the company paid<span class="pagenum"><a id="Page_94"></a>[Pg 94]</span>
+events somewhat to state that the company paid<span class="pagenum" id="Page_94">[Pg 94]</span>
 the citizens and farmers a liberal amount for their
 services in capturing the robbers, and a settlement
 was made which was satisfactory to all parties.</p>
@@ -3308,7 +3308,7 @@ When quite young, I left home and
 took to following the army. About five or six
 years ago I moved to Normandy, Tennessee, and
 lived with the family of Major Landis, and two
-or three years later, I went to work on the Nash<span class="pagenum"><a id="Page_95"></a>[Pg 95]</span>ville
+or three years later, I went to work on the Nash<span class="pagenum" id="Page_95">[Pg 95]</span>ville
 and Northwestern Railroad as a brakeman,
 remaining as such over two years. About three
 years since I formed the acquaintance of Hillary
@@ -3341,7 +3341,7 @@ either on that road or on the Mobile and Ohio
 Railroad. At Union City we changed cars, and
 arrived at Moscow just after dark. The plan was,
 that we all three should enter the car and overpower
-the messenger; but Levi and Hillary were<span class="pagenum"><a id="Page_96"></a>[Pg 96]</span>
+the messenger; but Levi and Hillary were<span class="pagenum" id="Page_96">[Pg 96]</span>
 the only ones who entered. I remained on the
 platform of the first passenger coach and kept
 watch. When the train was passing the water
@@ -3375,7 +3375,7 @@ to be known as Lester's Landing; our object
 in this move was, of course, to give an added
 color of respectability and <i>bona fide</i> business to
 our transactions. From this time until the middle
-of October, I remained at the store nearly all<span class="pagenum"><a id="Page_97"></a>[Pg 97]</span>
+of October, I remained at the store nearly all<span class="pagenum" id="Page_97">[Pg 97]</span>
 the time; Hillary was also there most of the time,
 but Levi very seldom. During one of the latter's
 western trips, he said he had been out to see his
@@ -3408,7 +3408,7 @@ woods that evening, about ten o'clock, an old
 man named Hicks came along with a bottle of
 whisky and stopped at our camp-fire quite a
 time. There were present Hillary, Levi, myself,
-and Bill Taylor. We remained in the woods all<span class="pagenum"><a id="Page_98"></a>[Pg 98]</span>
+and Bill Taylor. We remained in the woods all<span class="pagenum" id="Page_98">[Pg 98]</span>
 that night. The next day we moved further into
 the woods toward Hickman, and at night, just at
 dark, we came back to Union City.</p>
@@ -3444,7 +3444,7 @@ we had very little to eat.</p>
 but Levi, who carried it, showed up only twenty
 three hundred dollars.</p>
 
-<p><span class="pagenum"><a id="Page_99"></a>[Pg 99]</span></p>
+<p><span class="pagenum" id="Page_99">[Pg 99]</span></p>
 
 <p>"Sunday night we stole a skiff in Hickman
 and went down the river to James' Bayou, and
@@ -3479,7 +3479,7 @@ days.</p>
 was on the Tuesday night following, when
 Messrs. Pinkerton and Connell rode up to Lester's
 house. At the first glance, I thought they were
-officers, and Levi told me that he thought the<span class="pagenum"><a id="Page_100"></a>[Pg 100]</span>
+officers, and Levi told me that he thought the<span class="pagenum" id="Page_100">[Pg 100]</span>
 same. I saw him pull his pistol out of his
 pocket before getting out of his chair."</p>
 
@@ -3514,7 +3514,7 @@ conductor of the train was Conductor Roberts, on
 whose run I had formerly been brakeman; and,
 being afraid he might recognize me, I laid down
 in my seat and covered up my face, while Levi
-paid both fares. We arrived at Gillem Station<span class="pagenum"><a id="Page_101"></a>[Pg 101]</span>
+paid both fares. We arrived at Gillem Station<span class="pagenum" id="Page_101">[Pg 101]</span>
 about three o'clock in the morning, and reached
 Mrs. Farrington's house about daylight.</p>
 
@@ -3549,7 +3549,7 @@ for Missouri; I was riding a sorrel horse; Hillary,
 a chestnut-sorrel horse; and Levi, a large brown
 mule. We spent two days at the house of Mr.
 Douglas, near Mrs. Farrington's, and then crossed
-the Tennessee River at Cuba. We crossed the<span class="pagenum"><a id="Page_102"></a>[Pg 102]</span>
+the Tennessee River at Cuba. We crossed the<span class="pagenum" id="Page_102">[Pg 102]</span>
 Mississippi River by the last ferryboat on Friday
 evening, November 10, at Hall's Ferry, opposite
 Point Pleasant, Missouri. We saw no men on
@@ -3586,7 +3586,7 @@ few new points learned. The information that
 Mrs. Farrington had possession of nearly all the
 stolen money was valuable, and I sent instructions
 to Cottrell, at once, to attach all of her
-property in the name of the Southern Express<span class="pagenum"><a id="Page_103"></a>[Pg 103]</span>
+property in the name of the Southern Express<span class="pagenum" id="Page_103">[Pg 103]</span>
 Company, if it could be done. But the most important
 feature brought out was the hiding-place
 of Levi Farrington, which was given as
@@ -3619,7 +3619,7 @@ city marshal, who promised to give all the aid in
 his power to arrest Farrington.</p>
 
 <p>About two o'clock they saw the latter coming
-down the street, and, by previous arrangement,<span class="pagenum"><a id="Page_104"></a>[Pg 104]</span>
+down the street, and, by previous arrangement,<span class="pagenum" id="Page_104">[Pg 104]</span>
 Robert allowed Levi to pass him, both walking
 toward Brown and the marshal. Levi Farrington
 was a very powerful man, standing six feet
@@ -3651,7 +3651,7 @@ could before being killed himself; to release his
 arms, therefore, would enable him to draw a
 weapon, as he was undoubtedly well armed, hence
 Robert never relaxed his hold. Having a professional
-pride in securing his prisoner alive, more<span class="pagenum"><a id="Page_105"></a>[Pg 105]</span>over,
+pride in securing his prisoner alive, more<span class="pagenum" id="Page_105">[Pg 105]</span>over,
 he did not wish to resort to extreme measures
 except to save the lives of other persons, and, as
 a large crowd had gathered around the moment
@@ -3684,7 +3684,7 @@ very large sum of money.</p>
 <p>They arrived so late on Saturday that there
 was no train for Cairo before the following evening,
 and meantime the prisoner required the
-most careful watching, as none of our handcuffs<span class="pagenum"><a id="Page_106"></a>[Pg 106]</span>
+most careful watching, as none of our handcuffs<span class="pagenum" id="Page_106">[Pg 106]</span>
 were large enough to fit his wrists without cutting
 into the flesh. Robert and Brown were completely
 prostrated by the strain upon their muscles
@@ -3718,7 +3718,7 @@ seem anxious to get away by force. He tried,
 however, to induce Robert to let him go, telling
 him that it would be worth a very large amount
 of money to him to do so. Finding his offers disregarded,
-he appeared to take his arrest very<span class="pagenum"><a id="Page_107"></a>[Pg 107]</span>
+he appeared to take his arrest very<span class="pagenum" id="Page_107">[Pg 107]</span>
 coolly, saying that he guessed he had money
 enough to see him through.</p>
 
@@ -3757,7 +3757,7 @@ trying to obtain a confession and to learn what
 had been done with the money secured at the two
 robberies. From the questions that William
 asked, Hillary soon learned, or surmised, that
-Barton had confessed. He was terribly enraged<span class="pagenum"><a id="Page_108"></a>[Pg 108]</span>
+Barton had confessed. He was terribly enraged<span class="pagenum" id="Page_108">[Pg 108]</span>
 at this, and without doubt he would have killed
 Barton if he could have got at him; but being
 unable to do so, his fury was all turned upon his
@@ -3792,7 +3792,7 @@ just forward of the paddle-box.</p>
 <p>As they were about to enter the barber shop
 from the saloon, Hillary drew back, saying that
 he did not want to go that way, as there were
-some men in that room whom he knew. They<span class="pagenum"><a id="Page_109"></a>[Pg 109]</span>
+some men in that room whom he knew. They<span class="pagenum" id="Page_109">[Pg 109]</span>
 therefore went out upon the guards to walk along
 to the outer door of the bar-room. The space
 was narrow, and the rail quite low, so that it
@@ -3825,7 +3825,7 @@ death was going on.</p>
 
 <p>Hardly had William's hand touched the doorknob
 ere he felt the pistol drawn out of his coat
-pocket. He knew there was but one person who<span class="pagenum"><a id="Page_110"></a>[Pg 110]</span>
+pocket. He knew there was but one person who<span class="pagenum" id="Page_110">[Pg 110]</span>
 could have done it, and that person was a perfect
 devil thirsting for his blood. Turning like a
 flash, he seized Farrington by both wrists, just as
@@ -3857,7 +3857,7 @@ the pistol exploded close to his ear, the
 ball ploughing a little furrow in the scalp, while the
 powder scorched his neck and hair. Staggering
 back stunned and dizzy for a moment, he was
-caught by Connell, who asked whether he was<span class="pagenum"><a id="Page_111"></a>[Pg 111]</span>
+caught by Connell, who asked whether he was<span class="pagenum" id="Page_111">[Pg 111]</span>
 much hurt. He soon gathered his senses, and,
 finding his wound to be only trifling, he asked
 what had become of Farrington. Connell pointed
@@ -3891,7 +3891,7 @@ with the circumstances; yet there were not wanting
 people who insinuated that he had been
 allowed to escape by jumping overboard and
 swimming ashore. The absurdity of such a story
-is manifest, for, even supposing that his irons had<span class="pagenum"><a id="Page_112"></a>[Pg 112]</span>
+is manifest, for, even supposing that his irons had<span class="pagenum" id="Page_112">[Pg 112]</span>
 been removed, and that he had escaped injury
 from the paddle-wheels, he never could have
 swam ashore at the spot where the affair occurred.
@@ -3926,7 +3926,7 @@ there Friday morning.</p>
 
 <p>About this time, Mr. Ball, who had been sent
 to follow the wagon train of Mrs. Farrington, reported,
-after a silence of several days, that he had<span class="pagenum"><a id="Page_113"></a>[Pg 113]</span>
+after a silence of several days, that he had<span class="pagenum" id="Page_113">[Pg 113]</span>
 traced her into the Indian Territory. In point of
 fact, she was settled at Ash Grove, near Mount
 Vernon, in Greene County, Missouri, and had
@@ -3960,7 +3960,7 @@ bold step of arresting her for receiving stolen
 goods. She was taken to Mount Vernon, where
 she engaged a lawyer to defend her, and then, of
 course, Cottrell was also obliged to employ a legal
-adviser. At length, a compromise was effected,<span class="pagenum"><a id="Page_114"></a>[Pg 114]</span>
+adviser. At length, a compromise was effected,<span class="pagenum" id="Page_114">[Pg 114]</span>
 by which Mrs. Farrington was allowed to retain
 a small portion of the property; Cottrell then
 took possession of the remainder as agent of the
@@ -3995,7 +3995,7 @@ and Connell were sent to arrest him.</p>
 
 <p>At Mr. Merrick's they obtained a good guide,
 and four other citizens joined them, so that they
-had quite a formidable party. After visiting sev<span class="pagenum"><a id="Page_115"></a>[Pg 115]</span>eral
+had quite a formidable party. After visiting sev<span class="pagenum" id="Page_115">[Pg 115]</span>eral
 houses in the cane-brake, they learned where
 Taylor was staying, and, on going there, they
 saw him looking at them from a front window.
@@ -4028,7 +4028,7 @@ keeping prisoners.</p>
 <p>On learning that the whole party had been arrested,
 Taylor made a very full confession of all
 the circumstances connected with the robbery,
-and the movements of the robbers after it had<span class="pagenum"><a id="Page_116"></a>[Pg 116]</span>
+and the movements of the robbers after it had<span class="pagenum" id="Page_116">[Pg 116]</span>
 occurred. He confirmed Barton's account in every
 particular, but revealed nothing new of any importance.
 His share of the stolen money had
@@ -4060,7 +4060,7 @@ Hillary Farrington twice as belonging to different
 persons. Hicks's vision was somewhat uncertain
 that night, evidently.</p>
 
-<p><span class="pagenum"><a id="Page_117"></a>[Pg 117]</span></p>
+<p><span class="pagenum" id="Page_117">[Pg 117]</span></p>
 
 
 
@@ -4101,7 +4101,7 @@ he took his prisoner to the hotel for safe keeping,
 with the others. They were kept in separate
 rooms, and a detective remained with each of
 them constantly. William spent several hours
-with Levi Farrington, trying to induce him to<span class="pagenum"><a id="Page_118"></a>[Pg 118]</span>
+with Levi Farrington, trying to induce him to<span class="pagenum" id="Page_118">[Pg 118]</span>
 tell where he had hidden the stolen papers, and
 also what he had done with his share of the
 money, of which he had undoubtedly retained
@@ -4134,7 +4134,7 @@ party of robbers. About eleven o'clock
 that night, a policeman, named Benjamin Kline,
 discovered this man Towler with a drawn revolver,
 skulking behind a car standing on the side
-track near the dépôt. He immediately called for<span class="pagenum"><a id="Page_119"></a>[Pg 119]</span>
+track near the dépôt. He immediately called for<span class="pagenum" id="Page_119">[Pg 119]</span>
 the railroad company's night watchman, and the
 two approached the thief to arrest him. The
 man instantly shot Kline through the lungs, and
@@ -4166,7 +4166,7 @@ the time of Levi's arrest, only one of these revolvers
 was found, and he said that he had given
 away the other to a friend, retaining number
 1,279 himself. When Towler was captured,
-William happened to notice that his revolver was<span class="pagenum"><a id="Page_120"></a>[Pg 120]</span>
+William happened to notice that his revolver was<span class="pagenum" id="Page_120">[Pg 120]</span>
 similar to the one Levi had carried. This would
 have been nothing to be remarked under ordinary
 circumstances, since there were, undoubtedly,
@@ -4200,7 +4200,7 @@ deep indignation at any time; but just now there
 were additional reasons why the affair should excite
 a desire for summary vengeance upon his
 assassin. It had been shown that Towler must
-have formerly been on intimate terms with the<span class="pagenum"><a id="Page_121"></a>[Pg 121]</span>
+have formerly been on intimate terms with the<span class="pagenum" id="Page_121">[Pg 121]</span>
 Farringtons, and these latter were well known as
 desperadoes, whose hand was turned against every
 man; hence, the crimes of the whole party were
@@ -4235,7 +4235,7 @@ and property of the community was then discussed,
 and a conclusion was soon reached, without
 a dissenting voice.</p>
 
-<p><span class="pagenum"><a id="Page_122"></a>[Pg 122]</span></p>
+<p><span class="pagenum" id="Page_122">[Pg 122]</span></p>
 
 <p>Throughout the town all was hushed in the
 usual stillness of a winter's night; no lights were
@@ -4269,7 +4269,7 @@ heard them until the doors were forced open.
 Then the policy of silence was dropped, and a
 rush upon the guards was made. A battery of
 pistols suddenly confronted them, and, as resistance
-was clearly impossible, an unconditional<span class="pagenum"><a id="Page_123"></a>[Pg 123]</span>
+was clearly impossible, an unconditional<span class="pagenum" id="Page_123">[Pg 123]</span>
 surrender was at once made. The bursting in of
 the doors awakened William and Robert, who
 hastily sprang up, and, without stopping to put
@@ -4304,7 +4304,7 @@ or three minutes; when it ceased, Levi Farrington
 was no more, his body having been struck by
 more than thirty balls, almost any one of which
 would have been instantaneously fatal. His
-<span class="pagenum"><a id="Page_124"></a>[Pg 124]<br /><a id="Page_125"></a>[Pg 125]<br /><a id="Page_126"></a>[Pg 126]</span>body was left where it fell, and the room was
+<span class="pagenum" id="Page_126">[Pg 126]</span>body was left where it fell, and the room was
 soon deserted as the party hastened after the detachment
 which had Towler in charge. The
 whole affair was over in ten minutes, and when
@@ -4338,7 +4338,7 @@ not only as a punishment for their past crimes,
 but as a means of security in the future. Believing
 that a sentence to the penitentiary was
 wholly inadequate, and that their escape therefrom
-was not only possible, but probable, the cit<span class="pagenum"><a id="Page_127"></a>[Pg 127]</span>izens
+was not only possible, but probable, the cit<span class="pagenum" id="Page_127">[Pg 127]</span>izens
 preferred to take no risks of future robberies
 and murders by these desperadoes, and
 they therefore took the most effectual method of
@@ -4373,7 +4373,7 @@ Memphis, and then, having settled up all the
 business of which he had had charge, he also returned
 home.</p>
 
-<p>At the next term of court in Obion County,<span class="pagenum"><a id="Page_128"></a>[Pg 128]</span>
+<p>At the next term of court in Obion County,<span class="pagenum" id="Page_128">[Pg 128]</span>
 Tennessee, Barton and Taylor pleaded guilty of
 grand larceny, and were each sentenced to five
 years' confinement at hard labor in the penitentiary.
@@ -4392,8 +4392,8 @@ of the Southwest.</p>
 <p class="center">THE END.
 </p>
 
-<p><span class="pagenum"><a id="Page_129"></a>[Pg 129]</span></p>
-<p><span class="pagenum"><a id="Page_130"></a>[Pg 130]</span></p>
+<p><span class="pagenum" id="Page_129">[Pg 129]</span></p>
+<p><span class="pagenum" id="Page_130">[Pg 130]</span></p>
 
 
 
@@ -4434,7 +4434,7 @@ cupidity of the victim is so great that the sharper
 hardly offers the bait ere it is swallowed by some
 confiding simpleton. Hence, as a warning for
 the future, the lessons of past frauds possess no
-small degree of interest and value to the world;<span class="pagenum"><a id="Page_131"></a>[Pg 131]</span>
+small degree of interest and value to the world;<span class="pagenum" id="Page_131">[Pg 131]</span>
 and as there is no portion of society free from
 the depredations of these schemers, their various
 wiles and snares cannot be exposed too often.</p>
@@ -4468,7 +4468,7 @@ own mind that there was a fraudulent scheme in
 contemplation, and his positive conviction had
 great weight with me. The Senator's interest in
 the case had led him to make extensive inquiries
-into the antecedents of these parties, but he was<span class="pagenum"><a id="Page_132"></a>[Pg 132]</span>
+into the antecedents of these parties, but he was<span class="pagenum" id="Page_132">[Pg 132]</span>
 unable to trace them further back than their arrival
 in New York, several months before. There
 they had suddenly appeared in society with a
@@ -4501,7 +4501,7 @@ follows.</p>
 <p>José Gomez, a cadet of the ancient Brazilian
 family of that name, began life with a fine physique,
 ample mental endowments, and a high social
-position. He was the heir-expectant of a<span class="pagenum"><a id="Page_133"></a>[Pg 133]</span>
+position. He was the heir-expectant of a<span class="pagenum" id="Page_133">[Pg 133]</span>
 valuable estate, and no pains were spared upon
 his education. As he grew to manhood, however,
 his habits became such as to excite the
@@ -4534,7 +4534,7 @@ where he lived in regal splendor; indeed,
 his extravagance was so great as to make him
 conspicuous even among the reckless throng who
 filled the Golden City. After wasting a fortune
-with a prodigal hand, however, he suddenly van<span class="pagenum"><a id="Page_134"></a>[Pg 134]</span>ished,
+with a prodigal hand, however, he suddenly van<span class="pagenum" id="Page_134">[Pg 134]</span>ished,
 and, although little was known positively
 on the subject, it was commonly understood that
 he had swindled a number of bankers and capitalists
@@ -4568,7 +4568,7 @@ and became a great favorite in society. His wife
 was a beautiful Spaniard, and her exquisite taste,
 courtesy, and knowledge of the world were highly
 appreciated by the select circle of aristocracy into
-which she and her husband were soon admitted.<span class="pagenum"><a id="Page_135"></a>[Pg 135]</span>
+which she and her husband were soon admitted.<span class="pagenum" id="Page_135">[Pg 135]</span>
 Don José Arias was the name of this gentleman,
 and he was soon known in nearly every drawing-room
 in Belgravia. He was introduced by the
@@ -4601,7 +4601,7 @@ their arrival, but spent the latter part of the summer
 in the White Mountains in a very retired
 manner, although they lived in the best style
 that the place afforded. In August, they made
-a hasty trip to Washington and back to New<span class="pagenum"><a id="Page_136"></a>[Pg 136]</span>
+a hasty trip to Washington and back to New<span class="pagenum" id="Page_136">[Pg 136]</span>
 York again, where they began a more pretentious
 mode of life than they had chosen theretofore.
 Don Pedro kept a yacht elegantly fitted up, and
@@ -4633,7 +4633,7 @@ the parties, and to make a complete review of
 their past history so far as it might be possible to
 obtain it. No harm could result from such a
 course, whether they were honest or the reverse;
-and so, having decided upon a simple plan, I re<span class="pagenum"><a id="Page_137"></a>[Pg 137]</span>turned
+and so, having decided upon a simple plan, I re<span class="pagenum" id="Page_137">[Pg 137]</span>turned
 to Chicago to select the persons to represent
 me in Gloster.</p>
 
@@ -4667,7 +4667,7 @@ was recognized throughout the whole country.
 His reputation as a shrewd business man
 made him a species of authority among his fellow-townspeople,
 and few persons would have
-ventured to distrust the safety of any enterprise<span class="pagenum"><a id="Page_138"></a>[Pg 138]</span>
+ventured to distrust the safety of any enterprise<span class="pagenum" id="Page_138">[Pg 138]</span>
 in which he was actively interested. Indeed, so
 complete was the confidence of most men in him,
 that it was not considered necessary in buying
@@ -4703,7 +4703,7 @@ world, and he rarely denied himself any indulgence
 that passion craved and that money could
 procure.</p>
 
-<p><span class="pagenum"><a id="Page_139"></a>[Pg 139]</span></p>
+<p><span class="pagenum" id="Page_139">[Pg 139]</span></p>
 
 <p>It was while Mather and Perkins were on their
 annual visit to New York that they met Señor
@@ -4738,7 +4738,7 @@ was, that Gloster had never entertained
 two more thoroughly pleasing guests than
 the Don and Donna Morito.</p>
 
-<p>Don Pedro was about forty years of age, but<span class="pagenum"><a id="Page_140"></a>[Pg 140]</span>
+<p>Don Pedro was about forty years of age, but<span class="pagenum" id="Page_140">[Pg 140]</span>
 he had all the brilliancy and ease of a man of
 thirty. His figure was very fine, being slightly
 above the medium height, erect, compact, and
@@ -4771,7 +4771,7 @@ variety of characters, each one giving the
 precise shade of meaning most applicable to the
 time, place, person, and sentiment. In short, she
 was so near perfection that nearly all the men she
-met were in love with her, and nine-tenths of<span class="pagenum"><a id="Page_141"></a>[Pg 141]</span>
+met were in love with her, and nine-tenths of<span class="pagenum" id="Page_141">[Pg 141]</span>
 them more than half believed that she regretted
 her marriage for their sake. Nevertheless, she
 kept all admirers at a certain distance, which
@@ -4805,7 +4805,7 @@ had a habit of running his fingers through his
 long, thick hair, which he would also, at times,
 throw back with a peculiar jerk of his head.
 This habit was especially frequent when he became
-deeply interested in his subject, and the<span class="pagenum"><a id="Page_142"></a>[Pg 142]</span>
+deeply interested in his subject, and the<span class="pagenum" id="Page_142">[Pg 142]</span>
 spectators could always tell whether Dan was
 doing his best, even when they could not hear his
 words.</p>
@@ -4839,7 +4839,7 @@ of dollars belonging to the school fund to his own
 use; that he could easily contribute freely to his
 church, when he used the church property in his
 own interests and managed the society to suit
-himself; and that there was no great amount of<span class="pagenum"><a id="Page_143"></a>[Pg 143]</span>
+himself; and that there was no great amount of<span class="pagenum" id="Page_143">[Pg 143]</span>
 philanthropy in giving a few hundred dollars to
 miscellaneous charities, when he made ten times
 the amount in shaving notes at usurious interest
@@ -4873,7 +4873,7 @@ offers to purchase until his real estate was more
 extended and valuable than that of any other
 property-owner in the city. Personally he was
 very thin and angular, with such a sickly look
-that his death seemed possible any day, though<span class="pagenum"><a id="Page_144"></a>[Pg 144]</span>
+that his death seemed possible any day, though<span class="pagenum" id="Page_144">[Pg 144]</span>
 his constitution was of that character which
 might hold out much longer than that of a more
 robust type. His wife was a very charming
@@ -4907,7 +4907,7 @@ instance of the importance which self-complacent
 mediocrity can obtain in a newly-settled community,
 in spite of ponderous stupidity. His
 large head gave him his only excuse for professing
-to have brains, and his air of preoccupation<span class="pagenum"><a id="Page_145"></a>[Pg 145]</span>
+to have brains, and his air of preoccupation<span class="pagenum" id="Page_145">[Pg 145]</span>
 made him in appearance the personification
 of wisdom; indeed, a witty journalist, who had
 sounded the depths of Humphrey's ignorance,
@@ -4940,7 +4940,7 @@ Esq., formerly Member of Congress, and late
 Minister Plenipotentiary at an important European
 court. The suggestion having once been
 made to him by some waggish diplomat that he
-resembled the first Napoleon, he was ever after<span class="pagenum"><a id="Page_146"></a>[Pg 146]</span>ward
+resembled the first Napoleon, he was ever after<span class="pagenum" id="Page_146">[Pg 146]</span>ward
 desirous of drawing attention to this fancied
 resemblance. He was a vain, fussy, consequential
 politician, whose principal strength was
@@ -4974,7 +4974,7 @@ three per cent a month.</p>
 
 <p>It was among a society of which the foregoing
 were shining lights, that I was to operate at the
-request of Senator Muirhead. On returning to<span class="pagenum"><a id="Page_147"></a>[Pg 147]</span>
+request of Senator Muirhead. On returning to<span class="pagenum" id="Page_147">[Pg 147]</span>
 Chicago from Gloster, I gave a great deal of
 thought to the case, for there was so little to act
 upon that none of the ordinary plans could be
@@ -5006,7 +5006,7 @@ trusted companion and adviser. At the same
 time, it would be essential to learn as much as
 possible relative to the previous career of both
 the Don and Donna, for it might be desirable to
-use a little moral suasion with them by showing<span class="pagenum"><a id="Page_148"></a>[Pg 148]</span>
+use a little moral suasion with them by showing<span class="pagenum" id="Page_148">[Pg 148]</span>
 that their history was known. This plan would
 involve no injustice to them, for, if innocent of
 wrong-doing, they would never know that they
@@ -5045,7 +5045,7 @@ my employ. Mr. and Mrs. Rosel were natives of
 France, and as they had been constantly in my
 service almost from the time of their arrival in
 this country, I felt sure they would not be recognized
-as detectives by any one in the city of<span class="pagenum"><a id="Page_149"></a>[Pg 149]</span>
+as detectives by any one in the city of<span class="pagenum" id="Page_149">[Pg 149]</span>
 Gloster. They were people of more than average
 intelligence and education, with a natural refinement
 which would be especially desirable in the
@@ -5079,7 +5079,7 @@ Lucia.</p>
 <p>Mr. Rosel was to make a slight detour, arriving
 in Gloster from the east. He would be known
 as Monsieur Girard Lesparre, and his ostensible
-character was to be that of a man of moderate<span class="pagenum"><a id="Page_150"></a>[Pg 150]</span>
+character was to be that of a man of moderate<span class="pagenum" id="Page_150">[Pg 150]</span>
 capital from Bordeaux, looking for a favorable
 opportunity to invest some of his means in a
 profitable business.</p>
@@ -5113,7 +5113,7 @@ wife.</p>
 <p>On leaving my hotel to visit the house which
 Don Pedro was fitting up for his residence, I met
 Charlie Morton, the United States Commissioner
-of Gloster. Morton was a capable lawyer and a<span class="pagenum"><a id="Page_151"></a>[Pg 151]</span>
+of Gloster. Morton was a capable lawyer and a<span class="pagenum" id="Page_151">[Pg 151]</span>
 shrewd politician. He was equally attentive to
 ladies as to gentlemen, and it was well known
 that Charlie would never slight any one who
@@ -5149,7 +5149,7 @@ and abroad."</p>
 asked, "or do people run after them simply because
 they are rich foreigners?"</p>
 
-<p>"Of course their wealth and foreign birth<span class="pagenum"><a id="Page_152"></a>[Pg 152]</span>
+<p>"Of course their wealth and foreign birth<span class="pagenum" id="Page_152">[Pg 152]</span>
 would cause many people to pay them attention,"
 said Morton; "but their popularity is something
 exceptional, and is undoubtedly due to their perfect
@@ -5183,7 +5183,7 @@ with which it was decorated and furnished. It
 was certainly a model of good taste, while the
 paintings, statuary, frescoing, and articles of
 <i>bijouterie</i> were evidences of enormous expenditures.
-Having obtained a thorough knowledge<span class="pagenum"><a id="Page_153"></a>[Pg 153]</span>
+Having obtained a thorough knowledge<span class="pagenum" id="Page_153">[Pg 153]</span>
 of the plan of the house, I withdrew, receiving
 fifty cents for my labor.</p>
 
@@ -5216,7 +5216,7 @@ sum. Heavy drafts to pay his current expenses
 and to furnish his house had largely reduced his
 available cash, though he still had an ample sum
 on hand. Knowing how enormous his expenses
-were, I felt sure that he would reach the end of<span class="pagenum"><a id="Page_154"></a>[Pg 154]</span>
+were, I felt sure that he would reach the end of<span class="pagenum" id="Page_154">[Pg 154]</span>
 his bank account in a short time, unless he should
 have other funds, of whose existence I was unaware.
 If this sum of seventeen thousand dollars
@@ -5249,7 +5249,7 @@ Madame Sevier was to be her near neighbor in
 her new residence, became very intimate with
 her, especially as Donna Lucia was desirous of
 reviving her knowledge and practice of the French
-language. Consequently, when Don Pedro's ar<span class="pagenum"><a id="Page_155"></a>[Pg 155]</span>rangements
+language. Consequently, when Don Pedro's ar<span class="pagenum" id="Page_155">[Pg 155]</span>rangements
 were all completed and the new
 house occupied, Madame Sevier used to drop in
 for a few minutes' chat every day. As she was
@@ -5283,7 +5283,7 @@ she paused a moment to see who was with
 Donna Lucia. The room was in a very retired
 part of the house, and she was able to take a position
 close to the partly open door without the
-probability of being noticed by any one. She<span class="pagenum"><a id="Page_156"></a>[Pg 156]</span>
+probability of being noticed by any one. She<span class="pagenum" id="Page_156">[Pg 156]</span>
 was thus enabled to overhear a highly interesting
 conversation between the Donna and Henry O.
 Mather, who had evidently arrived only a moment
@@ -5321,7 +5321,7 @@ the tones of the parties being of a
 really lover-like tenderness, Madame Sevier took
 a hasty glimpse through the door, and saw that
 she could watch as well as listen, unperceived.
-Mather was standing beside the Donna, bending<span class="pagenum"><a id="Page_157"></a>[Pg 157]</span>
+Mather was standing beside the Donna, bending<span class="pagenum" id="Page_157">[Pg 157]</span>
 over her and looking into her face, while she had
 her head half turned away, as if in coy indecision.</p>
 
@@ -5362,7 +5362,7 @@ that caused your troubles."</p>
 
 <p>"Well, Mr. Math&mdash;&mdash;"</p>
 
-<p><span class="pagenum"><a id="Page_158"></a>[Pg 158]</span></p>
+<p><span class="pagenum" id="Page_158">[Pg 158]</span></p>
 
 <p>"No, no; not 'Mr. Mather;' recollect your
 promise," interrupted Mather, as he saw she hesitated
@@ -5396,7 +5396,7 @@ has not arrived, and I am afraid to tell Pedro,
 because he will not forgive me for running in
 debt and disobeying him. Unfortunately, I have
 done both these things, and I am momentarily in
-fear that some of the bills will be sent to him.<span class="pagenum"><a id="Page_159"></a>[Pg 159]</span>
+fear that some of the bills will be sent to him.<span class="pagenum" id="Page_159">[Pg 159]</span>
 Now, my dear Henry, you see that I have good
 cause to look sad and cry."</p>
 
@@ -5434,7 +5434,7 @@ money comes from," said Mather, again kissing
 her hand.</p>
 
 <p>"Oh! you dear, good fellow!" exclaimed the
-Donna; and, overcome by his generous response<span class="pagenum"><a id="Page_160"></a>[Pg 160]</span>
+Donna; and, overcome by his generous response<span class="pagenum" id="Page_160">[Pg 160]</span>
 to her request, she threw her arms about his neck
 and kissed him several times.</p>
 
@@ -5470,7 +5470,7 @@ She knew very little about housekeeping, and
 every domestic in her employ took advantage of
 her. She added that, as soon as her housewarming
 was over, she intended to get, if possible, a
-lady who would be a member of the family, and<span class="pagenum"><a id="Page_161"></a>[Pg 161]</span>
+lady who would be a member of the family, and<span class="pagenum" id="Page_161">[Pg 161]</span>
 who would relieve her of the management of the
 house.</p>
 
@@ -5504,7 +5504,7 @@ Finally, Madame Sevier said that she saw
 no objection to accepting the offer, as she really
 enjoyed taking care of a large establishment, but
 she was not prepared to accept it at once, and
-she would wait a few days to reflect upon it. It<span class="pagenum"><a id="Page_162"></a>[Pg 162]</span>
+she would wait a few days to reflect upon it. It<span class="pagenum" id="Page_162">[Pg 162]</span>
 was then agreed that she should give her decision
 at the grand reception to be given as a housewarming.</p>
 
@@ -5538,7 +5538,7 @@ fit.</p>
 all Gloster's best society were filled with
 pleasurable excitement and anticipation, as the
 preparations were known to be far more magnificent
-than those for any similar entertainment<span class="pagenum"><a id="Page_163"></a>[Pg 163]</span>
+than those for any similar entertainment<span class="pagenum" id="Page_163">[Pg 163]</span>
 since Gloster was settled. As Monsieur Lesparre
 had already made Don Pedro's acquaintance,
 and had received an invitation, I felt sure that
@@ -5571,7 +5571,7 @@ discreet and cautious agents, in order that I should
 quickly learn whether the Senator's suspicions
 were based on fact; in case I should find that the
 suspected parties were innocent, I was determined
-to withdraw instantly. They would not then<span class="pagenum"><a id="Page_164"></a>[Pg 164]</span>
+to withdraw instantly. They would not then<span class="pagenum" id="Page_164">[Pg 164]</span>
 suffer any injustice, for my employés would keep
 their discoveries secret from every one except myself,
 and no one would ever know that they had
@@ -5610,7 +5610,7 @@ guests a charming prospect when alighting from
 their carriages. The rooms of the house needed
 no decoration beyond that already given by the
 frescoes and paintings adorning the walls and
-ceilings. Nevertheless, flowers were abundantly<span class="pagenum"><a id="Page_165"></a>[Pg 165]</span>
+ceilings. Nevertheless, flowers were abundantly<span class="pagenum" id="Page_165">[Pg 165]</span>
 distributed about the spacious apartments. The
 beautiful conservatory contained a superb fountain,
 whose jets and sprays gave forth exquisite
@@ -5643,7 +5643,7 @@ He had a very retentive memory, and, when once
 introduced to any gentleman, he immediately
 took pains to learn everything possible about him.
 By careful observation and perseverance, he had
-learned the general history of a very large num<span class="pagenum"><a id="Page_166"></a>[Pg 166]</span>ber
+learned the general history of a very large num<span class="pagenum" id="Page_166">[Pg 166]</span>ber
 of the leading people in society, and his droll
 comments and half-sarcastic criticism of them,
 expressed <i>sotto voce</i> to the Don on various occasions,
@@ -5678,7 +5678,7 @@ a gentleman of Continental education and tastes.
 It is wonderful how keen these Americans are in
 their pursuit of the 'Almighty Dollar.' Why,
 only a week or two ago, I happened to mention
-to Mr. Mather and a few others, that some of my<span class="pagenum"><a id="Page_167"></a>[Pg 167]</span>
+to Mr. Mather and a few others, that some of my<span class="pagenum" id="Page_167">[Pg 167]</span>
 estates in the Peruvian Andes contained extensive
 diamond fields, when they began to upbraid me
 for not working them and adding to my already
@@ -5712,7 +5712,7 @@ to be tied down to regular duties."</p>
 while this conversation was going on, and
 were about to take a glass of wine together.
 Lesparre's last remark seemed to give a sudden
-idea to Don Pedro, and he sipped his wine in<span class="pagenum"><a id="Page_168"></a>[Pg 168]</span>
+idea to Don Pedro, and he sipped his wine in<span class="pagenum" id="Page_168">[Pg 168]</span>
 silence for a moment or two. Then he said,
 inquiringly:</p>
 
@@ -5749,7 +5749,7 @@ source of her revenue, but that may be pure gossip.
 At any rate, she is always elegantly dressed,
 and she moves in the best society."</p>
 
-<p>"If people suspect her of improper intimacy<span class="pagenum"><a id="Page_169"></a>[Pg 169]</span>
+<p>"If people suspect her of improper intimacy<span class="pagenum" id="Page_169">[Pg 169]</span>
 with McIntyre, why do they admit her to their
 houses?" asked Don Pedro.</p>
 
@@ -5783,7 +5783,7 @@ appear accidental, and in a few days Mr. McIntyre
 was willing to renew the merchant's note."</p>
 
 <p>"Well, she certainly does carry things with a
-high hand," replied Don Pedro, smiling. "I<span class="pagenum"><a id="Page_170"></a>[Pg 170]</span>
+high hand," replied Don Pedro, smiling. "I<span class="pagenum" id="Page_170">[Pg 170]</span>
 wonder how she would have retaliated upon me
 if I had struck her name off my list to-night?
 However, it is not my business to question her
@@ -5816,7 +5816,7 @@ upon her. Her most attentive cavalier was a
 young bachelor named Harry Bertram, who
 seemed infatuated with her. Indeed, their preference
 for each other's society was so marked
-that the tongue of scandal had already begun to<span class="pagenum"><a id="Page_171"></a>[Pg 171]</span>
+that the tongue of scandal had already begun to<span class="pagenum" id="Page_171">[Pg 171]</span>
 wag, although no overt act could be cited against
 them. The Don, on leaving Lesparre, chanced
 to meet Mrs. Arlington, and she readily accorded
@@ -5850,7 +5850,7 @@ closely-fitting black clothes, and he was fond of
 displaying an unusual amount of jewelry. He
 had obtained the office of judge of the criminal
 court by currying favor with the very classes
-<span class="pagenum"><a id="Page_172"></a>[Pg 172]<br /><a id="Page_173"></a>[Pg 173]<br /><a id="Page_174"></a>[Pg 174]</span>most likely to be brought before him for trial,
+<span class="pagenum" id="Page_174">[Pg 174]</span>most likely to be brought before him for trial,
 and his judicial ermine was not considered free
 from the foulest stains. His private life was, in
 many respects, a counterpart of his official conduct;
@@ -5884,7 +5884,7 @@ his back a moment groaning, and it was thought
 that he might be seriously injured, as his fall had
 jarred the whole house. Several gentlemen carefully
 lifted him upright, and the ladies gathered
-about to condole with him, when it was suddenly<span class="pagenum"><a id="Page_175"></a>[Pg 175]</span>
+about to condole with him, when it was suddenly<span class="pagenum" id="Page_175">[Pg 175]</span>
 discovered that, if the Judge's person had not
 suffered, his clothing had. His tight dress coat
 was split several inches down the back, while a
@@ -5917,7 +5917,7 @@ passed off with the most perfect success,
 and the unanimous verdict was that there had
 never been a more thoroughly enjoyable entertainment
 given in the city. During the evening,
-Madame Sevier informed Donna Lucia of her<span class="pagenum"><a id="Page_176"></a>[Pg 176]</span>
+Madame Sevier informed Donna Lucia of her<span class="pagenum" id="Page_176">[Pg 176]</span>
 willingness to take charge of the Morito establishment,
 and agreed to begin her reign the next
 day. Donna Lucia was delighted at this news,
@@ -5946,7 +5946,7 @@ The Don had invited Monsieur Lesparre to dine
 with him at six o'clock, and so it was arranged
 that they should all meet at that hour.</p>
 
-<p><span class="pagenum"><a id="Page_177"></a>[Pg 177]</span></p>
+<p><span class="pagenum" id="Page_177">[Pg 177]</span></p>
 
 
 
@@ -5987,7 +5987,7 @@ necessary, Madame Sevier paid this woman her
 wages and discharged her without a moment's
 warning. The effect upon the other servants
 was most satisfactory, and although the Madame
-was obliged to make some minor changes after<span class="pagenum"><a id="Page_178"></a>[Pg 178]<br /><a id="Page_179"></a>[Pg 179]<br /><a id="Page_180"></a>[Pg 180]</span>ward,
+was obliged to make some minor changes after<span class="pagenum" id="Page_180">[Pg 180]</span>ward,
 she was never again annoyed by impertinence
 or presumption. The dinner for that day
 was prepared by the assistant cook, under
@@ -6027,7 +6027,7 @@ services at once; when you have nothing for him
 to do, he will be an agreeable companion for us.
 What say you, Madame Sevier?"</p>
 
-<p><span class="pagenum"><a id="Page_181"></a>[Pg 181]</span></p>
+<p><span class="pagenum" id="Page_181">[Pg 181]</span></p>
 
 <p>"I quite agree with you," replied the Madame,
 casting down her eyes coquettishly; "but I
@@ -6067,7 +6067,7 @@ hence to invest your capital to advantage."</p>
 puffing his cigar thoughtfully, "and I feel disposed
 to accept it. What would be my duties?"</p>
 
-<p><span class="pagenum"><a id="Page_182"></a>[Pg 182]</span></p>
+<p><span class="pagenum" id="Page_182">[Pg 182]</span></p>
 
 <p>"Well, I will explain what I wish fully, and
 then you can judge how the position would suit
@@ -6102,7 +6102,7 @@ Lesparre.</p>
 Mather, Perkins, and some others were anxious
 to have me explore and open up the diamond
 fields which, I have reason to believe, constitute
-a large part of one of my estates in Peru? Some<span class="pagenum"><a id="Page_183"></a>[Pg 183]</span>
+a large part of one of my estates in Peru? Some<span class="pagenum" id="Page_183">[Pg 183]</span>
 time after I spoke to you, toward the end of the
 party, I missed Mather, Perkins, McIntyre, Sanders,
 and several others from the rooms, and
@@ -6136,7 +6136,7 @@ before you were sent for?"</p>
 <p>"Yes, indeed; the very minor details were provided
 for, and I could not raise an objection
 which had not already been discussed and removed.
-Both propositions provided for the for<span class="pagenum"><a id="Page_184"></a>[Pg 184]</span>mation
+Both propositions provided for the for<span class="pagenum" id="Page_184">[Pg 184]</span>mation
 of a stock company for the mining, cutting,
 and sale of diamonds. According to the first
 plan, I was to fix a price upon my diamond fields,
@@ -6168,7 +6168,7 @@ gentleman remarked. After the gentlemen had
 left the room, Mather urged the matter upon
 me very strongly. He apologized for having
 acted with such precipitation, but, he said, the
-others were so eager, as soon as they heard that<span class="pagenum"><a id="Page_185"></a>[Pg 185]</span>
+others were so eager, as soon as they heard that<span class="pagenum" id="Page_185">[Pg 185]</span>
 I owned a vast tract of unworked diamond fields,
 that he could not restrain them. He begged me
 to make some arrangement with the proposed
@@ -6202,7 +6202,7 @@ turn over this property to a body of men who
 will squeeze it like a sponge, leaving it a mere
 waste. There are a large body of tenants occupying
 portions of it, whose rights must be
-respected. They will make willing and honest<span class="pagenum"><a id="Page_186"></a>[Pg 186]</span>
+respected. They will make willing and honest<span class="pagenum" id="Page_186">[Pg 186]</span>
 laborers if properly treated, and I wish to protect
 them as far as possible from cruelty and extortion.
 Hence, I desire to learn all I can about the
@@ -6237,7 +6237,7 @@ to Don Pedro were correct. I immediately visited
 the Senator, and laid the latest developments
 before him. We could not help admiring the consummate
 knowledge of human nature which the
-Don displayed; he had baited his hook so skill<span class="pagenum"><a id="Page_187"></a>[Pg 187]</span>fully
+Don displayed; he had baited his hook so skill<span class="pagenum" id="Page_187">[Pg 187]</span>fully
 that the gudgeons were actually fearful lest
 something should prevent them from swallowing
 it; but there seemed to be no probability of defeating
@@ -6270,7 +6270,7 @@ the Don was apparently anxious to decline all
 offers, saying that the property had been in the
 possession of his family for about two hundred
 years, and that he considered himself in honor
-bound to retain an interest in it. Also, he tried<span class="pagenum"><a id="Page_188"></a>[Pg 188]</span>
+bound to retain an interest in it. Also, he tried<span class="pagenum" id="Page_188">[Pg 188]</span>
 to cool the ardor of the would-be purchasers by
 telling them that he had no positive certainty
 that there were valuable diamond fields on the
@@ -6303,7 +6303,7 @@ was fast approaching.</p>
 
 <p>Neither Monsieur Lesparre nor Madame Sevier
 had learned much about the private affairs of the
-Moritos, for, whenever the latter had anything<span class="pagenum"><a id="Page_189"></a>[Pg 189]</span>
+Moritos, for, whenever the latter had anything<span class="pagenum" id="Page_189">[Pg 189]</span>
 important to say to each other, they usually
 spoke Spanish. The Don's remaining funds
 amounted to only about eight thousand dollars,
@@ -6336,7 +6336,7 @@ was a man of great ability and force; but, possessing
 little ambition, he was not nearly so well
 known as many of those who were his inferiors
 in point of intellect and morals. We had a great
-deal of business between us at one time, and our<span class="pagenum"><a id="Page_190"></a>[Pg 190]</span>
+deal of business between us at one time, and our<span class="pagenum" id="Page_190">[Pg 190]</span>
 relations to each other were of the most cordial
 character, partaking more of the nature of personal
 friendship than mere business acquaintance.
@@ -6371,7 +6371,7 @@ I shall be pleased to tell him all that I know with
 regard to it."</p>
 
 <p>Mr. Edward Ashley Warne was an <i>attaché</i> of
-the British diplomatic service, and having been<span class="pagenum"><a id="Page_191"></a>[Pg 191]</span>
+the British diplomatic service, and having been<span class="pagenum" id="Page_191">[Pg 191]</span>
 entrusted with the settlement of some questions
 relative to commerce between the United States
 and Great Britain, he had executed his mission
@@ -6406,7 +6406,7 @@ Warne. "He was then moving in the most
 aristocratic society, and his wealth was reputed
 enormous. I saw a great deal of him at times,
 and, indeed, I was better acquainted with him
-than I was with many of my countrymen; but I<span class="pagenum"><a id="Page_192"></a>[Pg 192]</span>
+than I was with many of my countrymen; but I<span class="pagenum" id="Page_192">[Pg 192]</span>
 was recalled to London about that time, and I
 soon forgot all about Don José Arias."</p>
 
@@ -6440,7 +6440,7 @@ hunted small game, it is true, but this was probably
 a part of his whole scheme. So far as I
 could learn, he had left no unpaid bills in the
 hands of tradesmen, but he had taken enough
-out of bankers and capitalists to pay his<span class="pagenum"><a id="Page_193"></a>[Pg 193]</span>
+out of bankers and capitalists to pay his<span class="pagenum" id="Page_193">[Pg 193]</span>
 tradesmen's bills for half a century. The aggregate
 fraudulently obtained by him was never known,
 for many of his victims refused to state their
@@ -6472,7 +6472,7 @@ to glance at me casually, as any stranger
 would do, and then went on with his conversation
 without hesitation or embarrassment. I have
 met him several times since then, and he always
-acts with the same natural ease of manner, as if<span class="pagenum"><a id="Page_194"></a>[Pg 194]</span>
+acts with the same natural ease of manner, as if<span class="pagenum" id="Page_194">[Pg 194]</span>
 we had always been perfect strangers to each
 other; but, Mr. Pinkerton, the more I see of
 him, the more fully am I convinced that Don
@@ -6507,7 +6507,7 @@ hinted anything about it except to you gentlemen."</p>
 
 <p>"Nevertheless, I have suspected for some time
 that this Don Pedro was an impostor, and have
-been trying to obtain positive proof of my<span class="pagenum"><a id="Page_195"></a>[Pg 195]</span>
+been trying to obtain positive proof of my<span class="pagenum" id="Page_195">[Pg 195]</span>
 opinion, in order to save many persons here from
 being swindled by him. You are acquainted
 with Senator Muirhead, Judge?"</p>
@@ -6544,7 +6544,7 @@ in an official capacity, and, while I am personally
 perfectly satisfied of the truth of the statements
 I have made to you, I cannot prove them; hence,
 I must be careful not to involve myself in a difficulty
-which would compromise my position as a<span class="pagenum"><a id="Page_196"></a>[Pg 196]</span>
+which would compromise my position as a<span class="pagenum" id="Page_196">[Pg 196]</span>
 diplomatic agent of Great Britain. I shall immediately
 give to the police, on my arrival in London,
 a description of this man, and I presume
@@ -6577,7 +6577,7 @@ somewhat delayed in his return home, and meantime,
 the Don would probably obtain a large
 advance payment for his fictitious mines. If
 anything should occur to prevent us from sending
-him to England, he might succeed in getting<span class="pagenum"><a id="Page_197"></a>[Pg 197]</span>
+him to England, he might succeed in getting<span class="pagenum" id="Page_197">[Pg 197]</span>
 away with his plunder before we could find any
 new grounds upon which to hold him. I therefore
 instructed Mr. Bangs to write to the proper
@@ -6603,7 +6603,7 @@ afterward was uncertain, but I determined to use
 every means in my power to accomplish such a
 result.</p>
 
-<p><span class="pagenum"><a id="Page_198"></a>[Pg 198]</span></p>
+<p><span class="pagenum" id="Page_198">[Pg 198]</span></p>
 
 
 
@@ -6645,7 +6645,7 @@ Mather sent me to-day," said the Donna.</p>
 <p>"Yes, it is very elegant and valuable," said Don
 Pedro, with a yawn; "but what we most need is
 money. However, I do not imagine we shall
-have any difficulty, for I expect a large sum in a<span class="pagenum"><a id="Page_199"></a>[Pg 199]</span>
+have any difficulty, for I expect a large sum in a<span class="pagenum" id="Page_199">[Pg 199]</span>
 few days from the stockholders in this Diamond
 Company. Still, you may as well get all you can
 out of Mather and the others, for we must keep
@@ -6679,7 +6679,7 @@ the performance of his regular tasks, and even
 when caught in a place where he had no right to
 be, he could invent a plausible reason on the instant,
 which would divert all suspicion from him.
-On his arrival in Gloster, he was sent to ask em<span class="pagenum"><a id="Page_200"></a>[Pg 200]</span>ployment
+On his arrival in Gloster, he was sent to ask em<span class="pagenum" id="Page_200">[Pg 200]</span>ployment
 of Monsieur Lesparre, and, of course,
 the latter was so pleased with him as to engage
 him at once. He made himself very useful in
@@ -6713,7 +6713,7 @@ title-deeds were received from Peru and delivered
 to the directors.</p>
 
 <p>Don Pedro passed the checks over to Lesparre,
-and informed the meeting that he had already<span class="pagenum"><a id="Page_201"></a>[Pg 201]</span>
+and informed the meeting that he had already<span class="pagenum" id="Page_201">[Pg 201]</span>
 sent to Peru for the deeds, and that the directors
 should be informed the moment they should arrive;
 thereafter, all business matters relative to
@@ -6750,7 +6750,7 @@ having been paid in coin. Lesparre and Salter
 carried all the money up to the Don's dressing-room,
 where the Don and Donna were sitting.</p>
 
-<p>"There, my dear," said Don Pedro to his wife,<span class="pagenum"><a id="Page_202"></a>[Pg 202]</span>
+<p>"There, my dear," said Don Pedro to his wife,<span class="pagenum" id="Page_202">[Pg 202]</span>
 "this is the first installment of the purchase
 money of the diamond fields, so that now it will
 not be long before they will be thoroughly worked.
@@ -6785,7 +6785,7 @@ packed them away, the gold at the bottom.</p>
 <p>"Now, you can check against my bank accounts
 for our current expenses, Lesparre," said
 Don Pedro, with a complacent smile; "and when
-the funds on deposit are exhausted, I will give<span class="pagenum"><a id="Page_203"></a>[Pg 203]</span>
+the funds on deposit are exhausted, I will give<span class="pagenum" id="Page_203">[Pg 203]</span>
 you cash monthly to pay all bills as heretofore. I
 intend to give a grand <i>fête champêtre</i> soon, as a
 lesson to these Gloster people how to enjoy life.
@@ -6820,7 +6820,7 @@ invitations for three weeks from to-day?"</p>
 <p>"Better say five weeks, if not six," replied Lesparre,
 anxious to delay Don Pedro's departure as
 much as possible in order to obtain an answer to
-our letters to Peru and Brazil. "You see, the<span class="pagenum"><a id="Page_204"></a>[Pg 204]</span>
+our letters to Peru and Brazil. "You see, the<span class="pagenum" id="Page_204">[Pg 204]</span>
 people here are not accustomed to such gayeties,
 and it will take some time to prepare their minds
 to appreciate it."</p>
@@ -6855,7 +6855,7 @@ including every individual having any
 claims to be regarded as a member of good society.
 From that time forward, Lesparre was so busy
 with the preparations for the <i>fête</i> that he was
-able to see very little of the rest of the family except<span class="pagenum"><a id="Page_205"></a>[Pg 205]</span>
+able to see very little of the rest of the family except<span class="pagenum" id="Page_205">[Pg 205]</span>
 in the evening. The Don and Donna and Madame
 Sevier continued their usual round of dissipation
 and gayety, however, and "all went merry as a
@@ -6889,7 +6889,7 @@ Peru or England.</p>
 
 <p>In company with Judge Key I called upon Senator
 Muirhead, on the return of that gentleman
-from the session of Congress, and we discussed<span class="pagenum"><a id="Page_206"></a>[Pg 206]</span>
+from the session of Congress, and we discussed<span class="pagenum" id="Page_206">[Pg 206]</span>
 together the best plan to pursue, to foil the
 schemes of Don Pedro. The Senator was very
 anxious to proceed against him immediately,
@@ -6924,7 +6924,7 @@ such as bore upon the specific act alleged in your
 complaint; all other testimony would be ruled
 out. But, even suppose that such testimony
 were admissible, can you produce any witness to
-his crimes in other countries? Indeed, admitting<span class="pagenum"><a id="Page_207"></a>[Pg 207]</span>
+his crimes in other countries? Indeed, admitting<span class="pagenum" id="Page_207">[Pg 207]</span>
 again that these crimes were proven, can we establish
 the identity of Don Pedro P. L. de Morito
 as the perpetrator of those crimes? No, sir; we
@@ -6961,7 +6961,7 @@ only result in hastening his departure with all
 the money he has gained, for I am certain that
 we could not hold him."</p>
 
-<p><span class="pagenum"><a id="Page_208"></a>[Pg 208]</span></p>
+<p><span class="pagenum" id="Page_208">[Pg 208]</span></p>
 
 <p>"Well, I see that nothing can be done now,"
 said the Senator, despondently; "but do not lose
@@ -6998,7 +6998,7 @@ then related how much less pleasure they
 had, now that Madame Sevier was in charge of
 the household.</p>
 
-<p><span class="pagenum"><a id="Page_209"></a>[Pg 209]</span></p>
+<p><span class="pagenum" id="Page_209">[Pg 209]</span></p>
 
 <p>"Why," said she, "before this French woman
 came, the servants here had as good a time as
@@ -7035,7 +7035,7 @@ to try, so you all stay here while I make search."</p>
 
 <p>Accordingly, Salter went straight to the Don's
 room, to which he had a key. Having received
-from Lesparre an impression of the locks of the<span class="pagenum"><a id="Page_210"></a>[Pg 210]</span>
+from Lesparre an impression of the locks of the<span class="pagenum" id="Page_210">[Pg 210]</span>
 house several days before, I had had a skeleton
 key made, which would open almost any door
 about the place. While apparently engaged in
@@ -7067,7 +7067,7 @@ the other servants in fine style.</p>
 <p>Meanwhile, the Don and his party had been
 received with the utmost cordiality by Judge
 Taylor and his wife, who felt quite proud to be
-the first to entertain such distinguished guests<span class="pagenum"><a id="Page_211"></a>[Pg 211]</span>
+the first to entertain such distinguished guests<span class="pagenum" id="Page_211">[Pg 211]</span>
 after the sale of the diamond mines, and the issue
 of the invitations to the Don's grand <i>fête</i>.</p>
 
@@ -7103,7 +7103,7 @@ species of gayety and social recreation. It is our
 intention to embark in the forenoon and proceed
 by steamer to one of the large islands in the river.
 There everything will be prepared for outdoor
-<span class="pagenum"><a id="Page_212"></a>[Pg 212]<br /><a id="Page_213"></a>[Pg 213]<br /><a id="Page_214"></a>[Pg 214]</span>enjoyment; there will be boats and bathing-houses;
+<span class="pagenum" id="Page_214">[Pg 214]</span>enjoyment; there will be boats and bathing-houses;
 swings and archery-grounds; billiard-tables
 and bowling-alleys; in short, opportunities
 will be provided for the gratification of every
@@ -7138,7 +7138,7 @@ in this country.</p>
 "that we Americans must learn the art of enjoying
 life from foreigners, and I think there is no
 doubt that Don Pedro is a most adept master of
-its mysteries. Is there not something said in the<span class="pagenum"><a id="Page_215"></a>[Pg 215]</span>
+its mysteries. Is there not something said in the<span class="pagenum" id="Page_215">[Pg 215]</span>
 invitations about appearing in masks, Don
 Pedro?"</p>
 
@@ -7174,7 +7174,7 @@ possession, and as he had already obtained the
 greater portion of his plunder in coin, it was not
 long before he had accomplished his object.</p>
 
-<p>Meantime, the preparations for the <i>fête</i> went<span class="pagenum"><a id="Page_216"></a>[Pg 216]</span>
+<p>Meantime, the preparations for the <i>fête</i> went<span class="pagenum" id="Page_216">[Pg 216]</span>
 on apace, and the time of the Don and Lesparre
 was quite fully occupied in planning and arranging
 the details. The Senator called to see me
@@ -7216,7 +7216,7 @@ and his dark eyes were piercing and brilliant.</p>
 <p>"Good morning," he said to Salter, with a
 haughty nod; "is Don Juan at home?"</p>
 
-<p><span class="pagenum"><a id="Page_217"></a>[Pg 217]</span></p>
+<p><span class="pagenum" id="Page_217">[Pg 217]</span></p>
 
 <p>"No such person lives here," replied Salter,
 partially closing the door upon the wolfish-appearing
@@ -7257,7 +7257,7 @@ said Salter, who was following the stranger.</p>
 <p>"That is not the gentleman I asked for," the
 latter replied.</p>
 
-<p><span class="pagenum"><a id="Page_218"></a>[Pg 218]</span></p>
+<p><span class="pagenum" id="Page_218">[Pg 218]</span></p>
 
 <p>At this instant Don Pedro came into the hall,
 and, as his eyes fell upon the stranger, he gave a
@@ -7297,7 +7297,7 @@ evident; but how did it happen?"</p>
 <p>"You are right; I have had bad luck," replied
 Pietro. "It is the old story; I have had thousands
 of dollars at times, and have lived like a
-prince; and again I have been badly treated by<span class="pagenum"><a id="Page_219"></a>[Pg 219]</span>
+prince; and again I have been badly treated by<span class="pagenum" id="Page_219">[Pg 219]</span>
 Dame Fortune, and have lived as I could; but I
 have never before been so very miserable and
 poor as now. Positively, it is most providential
@@ -7333,7 +7333,7 @@ My luck was bad from the start, and, on arriving
 here, I had nothing except my clothing and
 jewelry; these I pawned gradually, and soon I
 was reduced to my present condition. Yesterday
-I met you as you were entering the Globe Hotel<span class="pagenum"><a id="Page_220"></a>[Pg 220]</span>
+I met you as you were entering the Globe Hotel<span class="pagenum" id="Page_220">[Pg 220]</span>
 with a party of gentlemen, but I did not want to
 mortify you by speaking to you in company; so I
 waited until you came to this house, intending
@@ -7374,7 +7374,7 @@ must ask you to excuse me now."</p>
 and underclothing for fifty dollars," replied
 Pietro.</p>
 
-<p><span class="pagenum"><a id="Page_221"></a>[Pg 221]</span></p>
+<p><span class="pagenum" id="Page_221">[Pg 221]</span></p>
 
 <p>"Well, here are fifty dollars," said the Don
 handing a roll of bills to Pietro, "and my secretary,
@@ -7412,7 +7412,7 @@ me, as I can get it down town just as well."</p>
 Salter out of the closet, and sent him out on an
 errand ostensibly; of course, his real duty was to
 "shadow" Mr. Pietro Bernardi, and report the
-occurrences of the morning to me. Salter kept<span class="pagenum"><a id="Page_222"></a>[Pg 222]</span>
+occurrences of the morning to me. Salter kept<span class="pagenum" id="Page_222">[Pg 222]</span>
 his man in view until he was seated at a popular
 restaurant table, and then, knowing that some
 time would be required before the Peruvian's appetite
@@ -7445,7 +7445,7 @@ very much. You see, it is not impossible that
 we may be forced to use threats to make him disgorge,
 for I shall not let him escape with his
 plunder without a struggle, even though no news
-whatever should come from Peru or England. At<span class="pagenum"><a id="Page_223"></a>[Pg 223]</span>
+whatever should come from Peru or England. At<span class="pagenum" id="Page_223">[Pg 223]</span>
 present, however, we will devote some time to
 this Pietro Bernardi, and see what he can tell
 us."</p>
@@ -7479,7 +7479,7 @@ which was sent to his lodgings. He then appeared
 to have relieved his mind of all care, and
 he spent the afternoon playing pool and billiards
 in a fashionable saloon. After dining at a restaurant,
-he went to a minstrel entertainment,<span class="pagenum"><a id="Page_224"></a>[Pg 224]</span>
+he went to a minstrel entertainment,<span class="pagenum" id="Page_224">[Pg 224]</span>
 after which he returned to his lodgings to retire
 for the night. When I went to bed at eleven
 o'clock, after having followed Bernardi most of
@@ -7518,7 +7518,7 @@ imagine you were again in the real estate
 business in Peru. Ha! ha! that was a speculation
 that paid well, eh?"</p>
 
-<p><span class="pagenum"><a id="Page_225"></a>[Pg 225]</span></p>
+<p><span class="pagenum" id="Page_225">[Pg 225]</span></p>
 
 <p>"Pietro, you must be careful not to drop a
 hint of those times to any one, or I should be
@@ -7553,7 +7553,7 @@ are you really married as you said? Is she as
 handsome as the other was?"</p>
 
 <p>"Yes, she is very handsome," replied the Don,
-curtly; "but she knows nothing about my his<span class="pagenum"><a id="Page_226"></a>[Pg 226]</span>tory
+curtly; "but she knows nothing about my his<span class="pagenum" id="Page_226">[Pg 226]</span>tory
 previous to our meeting, and I do not wish
 that she should; so let us leave her out of our
 discussion. I have some money left, though it is
@@ -7590,7 +7590,7 @@ much money as I can possibly spare; you must
 be prepared to go then."</p>
 
 <p>"All right, my dear Pedro," replied Bernardi,
-rising to go; "I shall be ready at that time. You<span class="pagenum"><a id="Page_227"></a>[Pg 227]</span>
+rising to go; "I shall be ready at that time. You<span class="pagenum" id="Page_227">[Pg 227]</span>
 can trust my discretion, however, as long as I
 stay here, and no one shall ever hear a word
 from me to your discredit. I may call to see you
@@ -7628,7 +7628,7 @@ door leading into the Don's dressing-room,
 and when Pietro had gone, she entered the Don's
 presence.</p>
 
-<p><span class="pagenum"><a id="Page_228"></a>[Pg 228]</span></p>
+<p><span class="pagenum" id="Page_228">[Pg 228]</span></p>
 
 <p>"Who was that person, Don Pedro?" she
 asked, with a sharp tone to her voice, foreboding
@@ -7665,7 +7665,7 @@ understand that you cannot treat me like a doll,
 to be thrown away when you are tired of me.
 I am able and anxious to help you in all your
 plans, but I must have your full confidence. You
-know that I love you, and you say that you re<span class="pagenum"><a id="Page_229"></a>[Pg 229]</span>turn
+know that I love you, and you say that you re<span class="pagenum" id="Page_229">[Pg 229]</span>turn
 my love, but sometimes I distrust you. You
 deserted a señorita in Lima, and some day you
 may try to desert me; but I warn you that I
@@ -7702,7 +7702,7 @@ bell. On entering the dressing-room, Salter found
 his employer seated in a large easy-chair, looking
 quite pale and agitated.</p>
 
-<p><span class="pagenum"><a id="Page_230"></a>[Pg 230]</span></p>
+<p><span class="pagenum" id="Page_230">[Pg 230]</span></p>
 
 <p>"I wish you would bring me a decanter of
 brandy and a glass, George," said the Don; "I
@@ -7742,7 +7742,7 @@ he sauntered downtown in a
 leisurely manner, with Newton carefully following
 at a safe distance. Bernardi was evidently
 vain of his personal appearance, for he was dissatisfied
-with his ready-made outfit, and, entering<span class="pagenum"><a id="Page_231"></a>[Pg 231]</span>
+with his ready-made outfit, and, entering<span class="pagenum" id="Page_231">[Pg 231]</span>
 a fashionable tailoring establishment, he was
 measured for a complete suit of clothes. The
 rest of the forenoon was spent in buying shirts,
@@ -7774,7 +7774,7 @@ was soon seated at it with the air of an old
 <i>habitué</i>. He was thenceforward so deeply interested
 in the game as to pay no attention to anything
 else, and, as he was unusually lucky, his
-pile of gold pieces rapidly increased. Newton<span class="pagenum"><a id="Page_232"></a>[Pg 232]</span>
+pile of gold pieces rapidly increased. Newton<span class="pagenum" id="Page_232">[Pg 232]</span>
 took a position at his elbow and watched the
 game in silence for some minutes. At length,
 seeing Bernardi win a large stake, he said in a
@@ -7815,7 +7815,7 @@ for old acquaintance' sake."</p>
 and as the two stood before the sideboard
 clicking glasses together, a stranger would have
 supposed them to be old cronies, as indeed Bernardi
-actually believed to be the case. Newton<span class="pagenum"><a id="Page_233"></a>[Pg 233]</span>
+actually believed to be the case. Newton<span class="pagenum" id="Page_233">[Pg 233]</span>
 instantly saw that Bernardi's frequent drinks during
 the day and his later potations in the evening
 had rendered him somewhat intoxicated; he was
@@ -7850,7 +7850,7 @@ Newton, therefore, he left the room, and entered
 a bar-room below. They drank and chatted together
 a short time, and then separated, Bernardi
 going to a well-known house of ill-repute, while
-Newton carefully dogged his footsteps unseen.<span class="pagenum"><a id="Page_234"></a>[Pg 234]</span>
+Newton carefully dogged his footsteps unseen.<span class="pagenum" id="Page_234">[Pg 234]</span>
 Knowing that Bernardi intended to spend the
 night where he was, Newton returned to his own
 lodgings. They had agreed to meet at the post-office
@@ -7886,7 +7886,7 @@ she stole several thousand dollars from me,
 and disappeared with a Mississippi gambler, whom
 she had never seen but twice. I didn't care for
 the money, but I loved her passionately, and I
-cannot think of her without becoming enraged.<span class="pagenum"><a id="Page_235"></a>[Pg 235]</span>
+cannot think of her without becoming enraged.<span class="pagenum" id="Page_235">[Pg 235]</span>
 Come, let us go get some brandy; I always have
 to drink when I think of her."</p>
 
@@ -7926,7 +7926,7 @@ when I am ready to go South again."</p>
 
 <p>"Is he a Southerner too?" asked Newton.</p>
 
-<p>"Oh! yes," Bernardi replied, "he is from Peru,<span class="pagenum"><a id="Page_236"></a>[Pg 236]</span>
+<p>"Oh! yes," Bernardi replied, "he is from Peru,<span class="pagenum" id="Page_236">[Pg 236]</span>
 where I first met him, and we have had many
 a gay time together. I used to keep a fine
 suite of gambling rooms, which he frequented,
@@ -7963,7 +7963,7 @@ him," suggested Newton.</p>
 <p>"I'd like to see him try it," Bernardi exclaimed,
 with a volley of oaths. "I guess two
 could play at the game of swearing out warrants,
-and when the account was balanced, his impris<span class="pagenum"><a id="Page_237"></a>[Pg 237]</span>onment
+and when the account was balanced, his impris<span class="pagenum" id="Page_237">[Pg 237]</span>onment
 would be twenty times as long as mine.
 No, no; I have no fear that he will attempt such
 a thing."</p>
@@ -7997,7 +7997,7 @@ gambling-rooms where they had met the night
 before, and Bernardi was soon absorbed in the
 game of faro. His luck still clung to him, and,
 on leaving the place at midnight, he had won
-three hundred dollars more. As before, Bernardi<span class="pagenum"><a id="Page_238"></a>[Pg 238]</span>
+three hundred dollars more. As before, Bernardi<span class="pagenum" id="Page_238">[Pg 238]</span>
 went to enjoy the society of his New Orleans
 charmer, and Newton went to his own lodgings.</p>
 
@@ -8033,7 +8033,7 @@ for his crimes committed elsewhere."</p>
 "Besides, this fellow, Bernardi, knows nothing
 of the Don's forgeries and frauds except those
 committed in Peru, and as we have before shown,
-we could make no use of those accusations until<span class="pagenum"><a id="Page_239"></a>[Pg 239]</span>
+we could make no use of those accusations until<span class="pagenum" id="Page_239">[Pg 239]</span>
 we hear from Peru. Indeed, it is questionable
 how far we can proceed even then, for we have
 no extradition treaty with that country."</p>
@@ -8070,7 +8070,7 @@ and get the advices from London afterward?"
 asked the Senator, who was very anxious to
 hasten matters.</p>
 
-<p>"Because we could not present a sufficient case<span class="pagenum"><a id="Page_240"></a>[Pg 240]</span>
+<p>"Because we could not present a sufficient case<span class="pagenum" id="Page_240">[Pg 240]</span>
 to hold him under the preliminary examination,"
 replied Judge Key. "When we get official news
 of the fellow's character from Peru, we shall
@@ -8106,7 +8106,7 @@ place the previous evening.</p>
 <p>The Don had remained at home entertaining
 various guests until nine o'clock. He had then
 gone out with Lesparre and several other gentlemen,
-to attend a banquet and ball given by a<span class="pagenum"><a id="Page_241"></a>[Pg 241]</span>
+to attend a banquet and ball given by a<span class="pagenum" id="Page_241">[Pg 241]</span>
 semi-political club at one of the hotels. The
 affair was attended by many highly respectable
 ladies, particularly by those whose husbands had
@@ -8141,7 +8141,7 @@ herself.</p>
 <p>Poor Mather was quite astonished, for, having
 kissed her several times before, he supposed that
 he could continue doing so whenever he wished;
-but the Donna was an expert fisher of men, and<span class="pagenum"><a id="Page_242"></a>[Pg 242]</span>
+but the Donna was an expert fisher of men, and<span class="pagenum" id="Page_242">[Pg 242]</span>
 she recognized the force of that old proverb,
 "Familiarity breeds contempt;" besides, she
 wanted some more money, and she knew that
@@ -8179,7 +8179,7 @@ answered, tenderly, bending over her.</p>
 feebly, as he showered kisses on her cheeks
 and lips; "suppose any one should come in!"</p>
 
-<p><span class="pagenum"><a id="Page_243"></a>[Pg 243]</span></p>
+<p><span class="pagenum" id="Page_243">[Pg 243]</span></p>
 
 <p>As she spoke, a carriage stopped in front of the
 house, and their affectionate <i>tête-à-tête</i> was interrupted
@@ -8220,7 +8220,7 @@ met at the post-office, and the latter remarked
 that he intended making a short call
 upon his wealthy friend.</p>
 
-<p>"Come along with me," he said, "and you will<span class="pagenum"><a id="Page_244"></a>[Pg 244]</span>
+<p>"Come along with me," he said, "and you will<span class="pagenum" id="Page_244">[Pg 244]</span>
 see what a fine place he has. I shall not remain
 very long, and if you will wait for me outside,
 we can pass the day together. I hate to go
@@ -8257,7 +8257,7 @@ again?" asked the Don, in a vexed tone.</p>
 
 <p>"Yes, and I have won constantly, so that I
 don't like to change my luck by making a move
-right away. You know gamblers are superst<span class="pagenum"><a id="Page_245"></a>[Pg 245]</span>itious,
+right away. You know gamblers are superst<span class="pagenum" id="Page_245">[Pg 245]</span>itious,
 and I have a strong feeling that it will be
 for my interest to remain here for some time
 yet."</p>
@@ -8294,7 +8294,7 @@ you; but I confess I should feel easier if you were
 out of Gloster for the present."</p>
 
 <p>"Well, I will be ready to go in a few days, if
-you insist upon it, but I don't see the necessity<span class="pagenum"><a id="Page_246"></a>[Pg 246]</span>
+you insist upon it, but I don't see the necessity<span class="pagenum" id="Page_246">[Pg 246]</span>
 of such haste. However, I will come in again
 and talk about it before the end of the week. I
 want to win a little more before I go."</p>
@@ -8340,7 +8340,7 @@ in the end."</p>
 I shall be ready to talk with you about going
 South. I want to run my luck while it is good,"
 and so saying, Bernardi rose to go.</p>
-<p><span class="pagenum"><a id="Page_247"></a>[Pg 247]</span></p>
+<p><span class="pagenum" id="Page_247">[Pg 247]</span></p>
 <p>"All right, Pietro," said Don Pedro, "be careful
 not to get swindled, and to keep silent about
 me."</p>
@@ -8376,7 +8376,7 @@ promise until he is ready."</p>
 <p>"Would he go, do you think, if he should lose
 all he has?" asked Lesparre.</p>
 
-<p>"Oh! yes, indeed; he would be forced to yield<span class="pagenum"><a id="Page_248"></a>[Pg 248]</span>
+<p>"Oh! yes, indeed; he would be forced to yield<span class="pagenum" id="Page_248">[Pg 248]</span>
 to my terms then, and I should give him nothing
 until he started."</p>
 
@@ -8415,7 +8415,7 @@ not be such a novelty that I need take a great
 deal of trouble about it. The 'bank' often wins
 more than that in a single evening."</p>
 
-<p><span class="pagenum"><a id="Page_249"></a>[Pg 249]</span></p>
+<p><span class="pagenum" id="Page_249">[Pg 249]</span></p>
 
 <p>"Well, there is a South American who has
 been playing here recently, against whom I have
@@ -8451,7 +8451,7 @@ again lost. He waited a few deals and then placed
 two hundred dollars on the queen to win, and one
 hundred dollars on the jack to lose. The cards
 fell as he had hoped, and gathering in his stakes
-<span class="pagenum"><a id="Page_250"></a>[Pg 250]<br /><a id="Page_251"></a>[Pg 251]<br /><a id="Page_252"></a>[Pg 252]</span>and winnings, he began betting in earnest. His
+<span class="pagenum" id="Page_252">[Pg 252]</span>and winnings, he began betting in earnest. His
 luck was wonderful, and as all his bets were for
 fifty dollars or more, he soon had quite a large
 sum. Presently he stopped betting, and went to
@@ -8490,7 +8490,7 @@ Bernardi narrowly. "He came in about noon,
 and wanted the cards put up so that you should
 be cleaned out of all your money."</p>
 
-<p><span class="pagenum"><a id="Page_253"></a>[Pg 253]</span></p>
+<p><span class="pagenum" id="Page_253">[Pg 253]</span></p>
 
 <p>"The devil you say!" ejaculated Bernardi;
 "why did he want to clean me out?"</p>
@@ -8529,7 +8529,7 @@ I have a sort of feeling that Don Juan is at the
 bottom of it. I don't fear him one bit, but I want
 to solve the mystery, and if he has been plotting
 against me, I will have my revenge upon him.
-But, no; I can't see what he could gain by it, and<span class="pagenum"><a id="Page_254"></a>[Pg 254]</span>
+But, no; I can't see what he could gain by it, and<span class="pagenum" id="Page_254">[Pg 254]</span>
 I think, perhaps, this gang despair of breaking
 my luck, and are planning to rob me by force."</p>
 
@@ -8566,7 +8566,7 @@ Bernardi, "and, when I am satisfied
 about the truth of the matter, I will consult with
 you as to the best course to pursue. It is a good
 thing to have a friend to advise with, especially
-among such a gang of thieves as seem to hang<span class="pagenum"><a id="Page_255"></a>[Pg 255]</span>
+among such a gang of thieves as seem to hang<span class="pagenum" id="Page_255">[Pg 255]</span>
 'round these rooms. Meet me to-morrow, as
 usual, and I will go see my friend again."</p>
 
@@ -8608,7 +8608,7 @@ matter with you? What makes you look at me
 so strangely?"</p>
 
 <p>"I want to find out whether it was you who
-sent a man to tell Dave Carter, the gambler, how<span class="pagenum"><a id="Page_256"></a>[Pg 256]</span>
+sent a man to tell Dave Carter, the gambler, how<span class="pagenum" id="Page_256">[Pg 256]</span>
 I was playing, and to ask him to fix the cards so
 that I should lose all I had."</p>
 
@@ -8644,7 +8644,7 @@ been trying to get him to play a trick on me,
 and I determined to find out who it was."</p>
 
 <p>"Well, Pietro, I don't think you would have
-thought of suspecting me if your head had not<span class="pagenum"><a id="Page_257"></a>[Pg 257]</span>
+thought of suspecting me if your head had not<span class="pagenum" id="Page_257">[Pg 257]</span>
 been fuddled with liquor. Why can't you stop
 drinking for a month or two?"</p>
 
@@ -8681,7 +8681,7 @@ should like to go back to New Orleans, if I could
 fit up a good place there, and deal a first-class
 game."</p>
 
-<p>"How much would you need for that pur<span class="pagenum"><a id="Page_258"></a>[Pg 258]</span>pose?"
+<p>"How much would you need for that pur<span class="pagenum" id="Page_258">[Pg 258]</span>pose?"
 asked the Don. "If I can let you have it,
 I will do so, and you can stay here or go back to
 New Orleans, as you may prefer; only I shall
@@ -8720,7 +8720,7 @@ took his departure.</p>
 spirits, and he talked very freely of his intended
 plans.</p>
 
-<p><span class="pagenum"><a id="Page_259"></a>[Pg 259]</span></p>
+<p><span class="pagenum" id="Page_259">[Pg 259]</span></p>
 
 <p>"My friend convinced me that he had nothing
 to do with the trick which the gambler said some
@@ -8757,7 +8757,7 @@ possible while the latter remained in the city,
 and to be sure to obtain his address in New Orleans.
 I then called upon Senator Muirhead and
 informed him of the proposed departure of Bernardi.
-The Senator was very anxious to detain<span class="pagenum"><a id="Page_260"></a>[Pg 260]</span>
+The Senator was very anxious to detain<span class="pagenum" id="Page_260">[Pg 260]</span>
 him in some way, in order to get his testimony,
 in case we should fail to hear from England or
 Peru in time; but I was unable to suggest any
@@ -8792,7 +8792,7 @@ him a hint in Spanish before I came away, and I
 hope he will stop before they fleece him. Now
 let us go to the theatre."</p>
 
-<p>They attended one of the theatres, and then<span class="pagenum"><a id="Page_261"></a>[Pg 261]</span>
+<p>They attended one of the theatres, and then<span class="pagenum" id="Page_261">[Pg 261]</span>
 had a glorious supper at Bernardi's expense after
 the performance was over. About midnight,
 they parted with mutual good wishes, and Bernardi
@@ -8818,7 +8818,7 @@ exultantly. "When it is over, my dear Lesparre,
 we will make a tour of the fashionable
 watering-places, and enjoy life to the full."</p>
 
-<p><span class="pagenum"><a id="Page_262"></a>[Pg 262]</span></p>
+<p><span class="pagenum" id="Page_262">[Pg 262]</span></p>
 
 
 
@@ -8859,7 +8859,7 @@ dispatched to Gloster at once, to obtain the arrest
 of Don Pedro, though there were a great many
 difficulties in the way, owing to the lack of an
 extradition treaty. Every effort would be made,
-however, to bring him to justice, and the Peru<span class="pagenum"><a id="Page_263"></a>[Pg 263]</span>vian
+however, to bring him to justice, and the Peru<span class="pagenum" id="Page_263">[Pg 263]</span>vian
 Minister at Washington would be instructed
 to confer with me.</p>
 
@@ -8894,7 +8894,7 @@ York. Before proceeding to business, I informed
 the Minister that I was acting under the instructions
 of Senator Muirhead, and that I should like
 to send for that gentleman, and for my legal adviser,
-Judge Key. The Peruvian officials made<span class="pagenum"><a id="Page_264"></a>[Pg 264]</span>
+Judge Key. The Peruvian officials made<span class="pagenum" id="Page_264">[Pg 264]</span>
 no objection, and both Judge Key and the Senator
 were soon with us, ready for consultation.
 As the new arrivals were tired and dusty after
@@ -8929,7 +8929,7 @@ it.</p>
 <i>can</i> be gained; but it is possible that my
 friend, Mr. Pinkerton, may have a plan which
 will induce Don Pedro, as he now calls himself,
-to surrender voluntarily rather than stand trial<span class="pagenum"><a id="Page_265"></a>[Pg 265]</span>
+to surrender voluntarily rather than stand trial<span class="pagenum" id="Page_265">[Pg 265]</span>
 here or in Great Britain. Let us hear your opinion,
 then, Mr. Pinkerton."</p>
 
@@ -8963,7 +8963,7 @@ will regard a surrender to the Peruvian authorities
 as preferable to a long trial and detention
 here, with the possibility of being sent to California
 or Great Britain for trial on a more serious
-charge. When he knows that we are fully ac<span class="pagenum"><a id="Page_266"></a>[Pg 266]</span>quainted
+charge. When he knows that we are fully ac<span class="pagenum" id="Page_266">[Pg 266]</span>quainted
 with his past career, he may be willing
 to accept our terms rather than to defy us."</p>
 
@@ -9001,7 +9001,7 @@ in Peru."</p>
 expression, as if he thought he had hit upon a
 very easy way of solving the problem. The Senator,
 Judge Key, and I exchanged looks of astonishment
-and amusement at this cool proposal to<span class="pagenum"><a id="Page_267"></a>[Pg 267]</span>
+and amusement at this cool proposal to<span class="pagenum" id="Page_267">[Pg 267]</span>
 take our citizens' money to reimburse the Peruvians;
 it was a case of "robbing Peter to pay
 Paul" which we could not appreciate. Finally,
@@ -9036,7 +9036,7 @@ trouble enough already."</p>
 
 <p>"I will arrange that matter satisfactorily," I
 replied; "as for the question of payment, I am
-acting wholly in the interest of Senator Muirhead,<span class="pagenum"><a id="Page_268"></a>[Pg 268]</span>
+acting wholly in the interest of Senator Muirhead,<span class="pagenum" id="Page_268">[Pg 268]</span>
 and under his instructions, so that I can accept
 nothing except from him."</p>
 
@@ -9070,7 +9070,7 @@ any attempt should be made to remove the box
 containing Don Pedro's coin, he must send Salter
 to me instantly with the news. I also suggested
 that the servants be kept out of the way that
-evening, so that no one should know of our visit.<span class="pagenum"><a id="Page_269"></a>[Pg 269]</span>
+evening, so that no one should know of our visit.<span class="pagenum" id="Page_269">[Pg 269]</span>
 Lesparre departed to attend to his duties, and I
 remained to complete the details of my plans
 with Mr. Bangs, who had arrived from Chicago
@@ -9108,7 +9108,7 @@ of that name; do I, Lesparre?"</p>
 business with you in connection with the <i>fête</i>,"
 suggested Lesparre.</p>
 
-<p><span class="pagenum"><a id="Page_270"></a>[Pg 270]</span></p>
+<p><span class="pagenum" id="Page_270">[Pg 270]</span></p>
 
 <p>"Ah! very true; where is he, George? I will
 see him at once," said the Don, unsuspectingly.</p>
@@ -9148,7 +9148,7 @@ in your past life and actions."</p>
 entered, and the former, seeing the abject appearance
 of her husband, asked what was the matter.</p>
 
-<p>"Your husband is a prisoner, madam," I re<span class="pagenum"><a id="Page_271"></a>[Pg 271]</span>plied;
+<p>"Your husband is a prisoner, madam," I re<span class="pagenum" id="Page_271">[Pg 271]</span>plied;
 "and as our interview would be painful to
 you, I must ask you to withdraw for the present
 at least."</p>
@@ -9188,7 +9188,7 @@ of Madame Sevier. On the way thither, the Don
 made one more effort to appear in the <i>rôle</i> of an
 injured innocent.</p>
 
-<p><span class="pagenum"><a id="Page_272"></a>[Pg 272]</span></p>
+<p><span class="pagenum" id="Page_272">[Pg 272]</span></p>
 
 <p>"I don't understand this proceeding at all," he
 said, "and I claim my liberty. What authority
@@ -9228,7 +9228,7 @@ and by what right you send me to Peru. I am
 entitled to a hearing, and a lawyer to defend
 me."</p>
 
-<p><span class="pagenum"><a id="Page_273"></a>[Pg 273]</span></p>
+<p><span class="pagenum" id="Page_273">[Pg 273]</span></p>
 
 <p>"My friend, Judge Key, who is present, is a
 most able lawyer," I replied, "and you can consult
@@ -9261,7 +9261,7 @@ an extradition treaty; but while you are under
 arrest here, we can easily get warrants from
 either California, England, or France, and then
 you can take your choice between being shot by
-vigilantes in California, transported to Van<span class="pagenum"><a id="Page_274"></a>[Pg 274]</span>
+vigilantes in California, transported to Van<span class="pagenum" id="Page_274">[Pg 274]</span>
 Dieman's Land by England, or sent to work in the
 galleys by France. This is your present situation,
 and I am perfectly indifferent which course
@@ -9294,7 +9294,7 @@ but I accompanied the two to another room,
 where they conversed in Spanish for some time.
 The Minister told me that the Don offered the
 whole of his money and property to allow him to
-escape; but, finding his offers useless, he agreed to<span class="pagenum"><a id="Page_275"></a>[Pg 275]</span>
+escape; but, finding his offers useless, he agreed to<span class="pagenum" id="Page_275">[Pg 275]</span>
 go to Peru for trial. No pledges were made to him
 to influence his decision, though he begged so hard
 that the Minister would intercede for him with
@@ -9326,7 +9326,7 @@ date. This provision was, of course, necessary to
 shut out the bills for supplies and services at the
 <i>fête</i> on the following day. Evidently it was too
 late to interfere with that interesting entertainment
-without throwing a heavy loss on many<span class="pagenum"><a id="Page_276"></a>[Pg 276]</span>
+without throwing a heavy loss on many<span class="pagenum" id="Page_276">[Pg 276]</span>
 persons who could not afford to be the sufferers,
 and I saw only one way to prevent this, namely;
 to let the <i>fête</i> go on, and make those who danced
@@ -9361,7 +9361,7 @@ kept her money entirely separate from his, and
 that I could trust to Madame Sevier's acuteness
 to discover how much the Donna had on hand.
 I was not disappointed, for, while packing, the
-Donna told the Madame that she had about nine<span class="pagenum"><a id="Page_277"></a>[Pg 277]</span>
+Donna told the Madame that she had about nine<span class="pagenum" id="Page_277">[Pg 277]</span>
 thousand dollars, the remains of her gifts from
 Mather, but that she could secure an immense
 sum out of the iron box if she could get it open.
@@ -9396,7 +9396,7 @@ you as he may think proper; but, until then, I
 alone have the right to determine what shall be
 done with you."</p>
 
-<p>In a moment, I had placed a light set of<span class="pagenum"><a id="Page_278"></a>[Pg 278]</span>
+<p>In a moment, I had placed a light set of<span class="pagenum" id="Page_278">[Pg 278]</span>
 shackles on his feet, and handcuffs on his wrists;
 he was quite submissive now, and only seemed
 anxious to avoid observation.</p>
@@ -9436,7 +9436,7 @@ the weather was so lovely that nothing could
 have been more auspicious for the grand occasion.
 As the hour approached for the departure
 of the steamer, carriage after carriage drew up
-at the dock to discharge its load of brilliantly-<span class="pagenum"><a id="Page_279"></a>[Pg 279]</span>dressed
+at the dock to discharge its load of brilliantly-<span class="pagenum" id="Page_279">[Pg 279]</span>dressed
 and masked ladies and gentlemen. The
 only person who was not completely protected
 from recognition was Monsieur Lesparre, who
@@ -9470,7 +9470,7 @@ substituted an identification of each person with
 the character which that person represented. The
 balmy airs of a perfect spring day wafted to them
 the sounds of country life along the shores of the
-river, and gave sensations both novel and pleas<span class="pagenum"><a id="Page_280"></a>[Pg 280]<br /><a id="Page_281"></a>[Pg 281]<br /><a id="Page_282"></a>[Pg 282]</span>ing
+river, and gave sensations both novel and pleas<span class="pagenum" id="Page_282">[Pg 282]</span>ing
 to the gay denizens of the city, who rarely
 experienced any change from their routine of
 fashionable entertainments. During the trip by
@@ -9504,7 +9504,7 @@ was an enclosed dancing-hall, to be used in the
 evening. Two bands were in attendance to play
 dance music constantly, one resting while the
 other played. It was understood that dinner
-would be served, at four o'clock exactly, in a long<span class="pagenum"><a id="Page_283"></a>[Pg 283]</span>
+would be served, at four o'clock exactly, in a long<span class="pagenum" id="Page_283">[Pg 283]</span>
 dining-room near the dancing-hall, and at that
 time every one was to unmask.</p>
 
@@ -9538,7 +9538,7 @@ had been made, though large numbers still
 carefully and successfully preserved their own
 secrets; some, however, had already abandoned
 their masks, still retaining the fancy costumes.
-Among these was Mr. Mather, who wandered<span class="pagenum"><a id="Page_284"></a>[Pg 284]</span>
+Among these was Mr. Mather, who wandered<span class="pagenum" id="Page_284">[Pg 284]</span>
 over the island half distraught. He had vainly
 searched for the Donna all day, and had been unable
 to enjoy anything because he could not distinguish
@@ -9576,7 +9576,7 @@ astonishment.</p>
 
 <p>"No, I have not seen him since last night,"
 said Lesparre. "You see, the Don and I made
-all arrangements yesterday afternoon, and I<span class="pagenum"><a id="Page_285"></a>[Pg 285]</span>
+all arrangements yesterday afternoon, and I<span class="pagenum" id="Page_285">[Pg 285]</span>
 came down to the island to superintend the placing
 of the fireworks in the evening. I spent the
 night down here, and have not gone back to the
@@ -9612,7 +9612,7 @@ and addressed the whole company:</p>
 <p>"Ladies and gentlemen, somewhere among us
 are the host and hostess of this, the most elegant
 entertainment ever given in Gloster; they have
-been successful not only in producing here a<span class="pagenum"><a id="Page_286"></a>[Pg 286]</span>
+been successful not only in producing here a<span class="pagenum" id="Page_286">[Pg 286]</span>
 fairy spectacle of unequaled beauty, but also in
 effectually hiding themselves from discovery in
 their assumed characters. So far as I know, not
@@ -9650,7 +9650,7 @@ suspicion. At length, Mather again spoke up, in
 a husky voice:</p>
 
 <p>"As our host is so retiring, I will take the
-liberty of asking those present to unmask, and<span class="pagenum"><a id="Page_287"></a>[Pg 287]</span>
+liberty of asking those present to unmask, and<span class="pagenum" id="Page_287">[Pg 287]</span>
 we shall then discover his disguise. Tap the bell,
 Morgan."</p>
 
@@ -9685,7 +9685,7 @@ panic seized every one. No movement toward
 the dining-room was made, but all stood irresolute,
 anxiously waiting for some one to determine
 what to do, and set them an example. Lesparre
-was sought for and questioned closely as to the<span class="pagenum"><a id="Page_288"></a>[Pg 288]</span>
+was sought for and questioned closely as to the<span class="pagenum" id="Page_288">[Pg 288]</span>
 reason for his employer's absence, but he could
 give no satisfactory answer. He told all inquirers
 that he had not seen the Don since the
@@ -9718,7 +9718,7 @@ proceeded toward the dining-room, headed by
 Henry O. Mather with Mrs. Simon, and Richard
 Perkins with Miss Benson.</p>
 
-<p>But now occurred the most humiliating part of<span class="pagenum"><a id="Page_289"></a>[Pg 289]</span>
+<p>But now occurred the most humiliating part of<span class="pagenum" id="Page_289">[Pg 289]</span>
 the changed programme: Mr. George P. Westerfield,
 the caterer, refused to admit the guests to
 the dining-room unless the payment of his bill
@@ -9753,7 +9753,7 @@ caterer.</p>
 <p>"Why, he is probably accidentally detained in
 Gloster," replied Mather. "I have every confidence
 in him, and when he explains his unfortunate
-absence to-day, those who have suspected<span class="pagenum"><a id="Page_290"></a>[Pg 290]</span>
+absence to-day, those who have suspected<span class="pagenum" id="Page_290">[Pg 290]</span>
 him will regret their hasty remarks derogatory
 to his character."</p>
 
@@ -9787,7 +9787,7 @@ seemed quite unable to decide what to do. Mr.
 Westerfield's proposition was reasonable enough,
 and he was willing to accept the guarantee of any
 other gentleman of known responsibility; but
-singularly, there was not one among all who had<span class="pagenum"><a id="Page_291"></a>[Pg 291]</span>
+singularly, there was not one among all who had<span class="pagenum" id="Page_291">[Pg 291]</span>
 been intimate with the Don who would make himself
 liable for the cost of the dinner; consequently
 the caterer refused to admit the throng
@@ -9820,7 +9820,7 @@ when the last course had been served, they proposed
 to go on with the entertainment the same
 as though nothing had happened.</p>
 
-<p>On entering the dancing-hall, therefore, the<span class="pagenum"><a id="Page_292"></a>[Pg 292]</span>
+<p>On entering the dancing-hall, therefore, the<span class="pagenum" id="Page_292">[Pg 292]</span>
 greater portion of the young people prepared to
 enjoy the evening in dancing; but here again an
 obstacle presented itself: the bandsmen had taken
@@ -9857,7 +9857,7 @@ the example of the caterer, and demand payment
 for his services before admitting the excursionists
 on board his steamer.</p>
 
-<p><span class="pagenum"><a id="Page_293"></a>[Pg 293]</span></p>
+<p><span class="pagenum" id="Page_293">[Pg 293]</span></p>
 
 <p>"Pay you" exclaimed the horrified Ethan
 Allen Benson, who had paid so much for his dinner
@@ -9894,7 +9894,7 @@ This threat brought the party to his terms, and
 he was ordered to bring his steamer over. He
 refused to make more than one trip, however,
 and so the dancers were called away from the
-ballroom at the end of the first waltz, thus spoil<span class="pagenum"><a id="Page_294"></a>[Pg 294]<br /><a id="Page_295"></a>[Pg 295]<br /><a id="Page_296"></a>[Pg 296]</span>ing
+ballroom at the end of the first waltz, thus spoil<span class="pagenum" id="Page_296">[Pg 296]</span>ing
 their gayety almost ere it had begun. As the
 motley groups gathered on shore awaiting the
 steamer's approach, a more deeply disgusted and
@@ -9929,7 +9929,7 @@ them home.</p>
 <p>Thus ended the <i>fête champêtre</i> which had been
 anticipated so fondly as a new departure in the
 social world of Gloster. In this, however, it was
-a success; for, certainly, its like had never been<span class="pagenum"><a id="Page_297"></a>[Pg 297]</span>
+a success; for, certainly, its like had never been<span class="pagenum" id="Page_297">[Pg 297]</span>
 seen before, and the guests were profoundly hopeful
 that they never should see its like again.</p>
 
@@ -9964,7 +9964,7 @@ this money and property?" was the question
 which was asked in various forms nearly a score
 of times.</p>
 
-<p>"I cannot give you any particulars," replied<span class="pagenum"><a id="Page_298"></a>[Pg 298]</span>
+<p>"I cannot give you any particulars," replied<span class="pagenum" id="Page_298">[Pg 298]</span>
 the Judge; "you must be satisfied to know that
 he made this assignment in due legal form, and
 that the amount which I shall realize will pay
@@ -9999,7 +9999,7 @@ Sevier, and the detectives, leaving the Don in
 charge of the captain, then returned to New
 York in the tug.</p>
 
-<p><span class="pagenum"><a id="Page_299"></a>[Pg 299]</span></p>
+<p><span class="pagenum" id="Page_299">[Pg 299]</span></p>
 
 <p>Two days later, Mr. Mather also arrived in
 that city, and quickly found his way to the Donna's
@@ -10034,7 +10034,7 @@ de Morito.</p>
 <p class="center">THE END.
 </p>
 
-<p><span class="pagenum"><a id="Page_300"></a>[Pg 300]</span></p>
+<p><span class="pagenum" id="Page_300">[Pg 300]</span></p>
 
 
 
@@ -10076,7 +10076,7 @@ Among those whom I thus noticed was a lady,
 about forty-five years of age, and her son, who
 was about twenty-six years old. The mother,
 Mrs. R. S. Trafton, was a pleasant woman, well
-preserved, and comparatively youthful in appear<span class="pagenum"><a id="Page_301"></a>[Pg 301]</span>ance.
+preserved, and comparatively youthful in appear<span class="pagenum" id="Page_301">[Pg 301]</span>ance.
 She was afflicted by a rheumatic affection,
 which caused her to visit these springs for relief;
 and her son accompanied her partly to look after
@@ -10110,7 +10110,7 @@ quite thoroughly.</p>
 <p>He was about five feet ten inches in height, of
 compact, muscular build, full chest, stout limbs,
 and erect carriage. His complexion was clear
-and healthy, his features regular, his expression<span class="pagenum"><a id="Page_302"></a>[Pg 302]</span>
+and healthy, his features regular, his expression<span class="pagenum" id="Page_302">[Pg 302]</span>
 intelligent and open, and his manners were very
 frank and attractive to most people. His general
 appearance was that of an intelligent, handsome
@@ -10145,7 +10145,7 @@ tragical and sorrowful circumstances.</p>
 <p>Early in the winter of the following year, I
 was deeply engrossed in business, having an accumulation
 of cases on hand which taxed my ingenuity
-and energies to the utmost. I therefore<span class="pagenum"><a id="Page_303"></a>[Pg 303]</span>
+and energies to the utmost. I therefore<span class="pagenum" id="Page_303">[Pg 303]</span>
 placed almost all of the less important operations
 in the hands of my superintendent, Mr. Francis
 Warner, though I kept a general supervisory
@@ -10178,7 +10178,7 @@ money and negotiable paper. He had about
 eight hundred dollars in currency, two thousand
 five hundred dollars in United States five-twenty
 bonds, and a letter from his father authorizing
-him to draw upon him for a large amount. The<span class="pagenum"><a id="Page_304"></a>[Pg 304]</span>
+him to draw upon him for a large amount. The<span class="pagenum" id="Page_304">[Pg 304]</span>
 bonds were the usual coupon bonds of the denomination
 of five hundred dollars each, and fortunately
 Mr. Trafton, senior, had the numbers of
@@ -10212,7 +10212,7 @@ in Chicago, announcing that Stanley D. Trafton
 had been found dead in his bed. Mr. Updike,
 who was a warm friend of the family, and Captain
 Dalton, then visited Chicago, arriving December
-8. They found the body of Mr. Trafton<span class="pagenum"><a id="Page_305"></a>[Pg 305]</span>
+8. They found the body of Mr. Trafton<span class="pagenum" id="Page_305">[Pg 305]</span>
 at the Morgue awaiting claimants, together with
 a quantity of valuables which had been in his
 possession when he died. There were two five-twenty
@@ -10248,7 +10248,7 @@ by business offices. A covered stairway on the
 side led to the upper story, and, while the front
 hall bedroom, the front parlor and the next
 room back, were used as offices, the rear portion
-<span class="pagenum"><a id="Page_306"></a>[Pg 306]<br /><a id="Page_307"></a>[Pg 307]<br /><a id="Page_308"></a>[Pg 308]</span>was occupied by Mrs. Sanford, who rented most
+<span class="pagenum" id="Page_308">[Pg 308]</span>was occupied by Mrs. Sanford, who rented most
 of her rooms as sleeping apartments.</p>
 
 <p>[Illustration: <i>"He was lying in bed with froth about his mouth and a ghastly look on his face."&mdash;Page&mdash;</i>]</p>
@@ -10282,7 +10282,7 @@ pushed the door open, the bolt being a very slight
 one. She then found Mr. Trafton lying diagonally
 across the bed, with his head hanging down
 and froth on his lips. Becoming alarmed at his
-appearance, she called in a gentleman named<span class="pagenum"><a id="Page_309"></a>[Pg 309]</span>
+appearance, she called in a gentleman named<span class="pagenum" id="Page_309">[Pg 309]</span>
 Taylor G. Pratt, who occupied her back parlor as
 a real estate office and sleeping-room. Mr. Pratt
 examined the body of Mr. Trafton and told her
@@ -10315,7 +10315,7 @@ the story was related by her, there was nothing
 suspicious about the affair except the suddenness
 of his death.</p>
 
-<p>Having heard all that Mrs. Sanford and the<span class="pagenum"><a id="Page_310"></a>[Pg 310]</span>
+<p>Having heard all that Mrs. Sanford and the<span class="pagenum" id="Page_310">[Pg 310]</span>
 County Physician had to say on the subject, Mr.
 Updike and Captain Dalton took charge of the
 body, and shipped it to Cleveland, where they
@@ -10347,7 +10347,7 @@ lungs. They found the body to be healthy in
 every part, except the external bruises; and,
 while these were not of a sufficiently serious
 character to account for the death of so robust a
-man, they could find no other cause whatever.<span class="pagenum"><a id="Page_311"></a>[Pg 311]</span>
+man, they could find no other cause whatever.<span class="pagenum" id="Page_311">[Pg 311]</span>
 These facts, together with the disappearance of
 fifteen hundred dollars in bonds, and about five
 hundred dollars in currency, which Trafton was
@@ -10382,7 +10382,7 @@ additional information:</p>
 had again visited Mrs. Sanford, and found that
 she had taken every particle of furniture out of
 the room where Trafton had died. At the time
-of their call, they saw a policeman whom she<span class="pagenum"><a id="Page_312"></a>[Pg 312]</span>
+of their call, they saw a policeman whom she<span class="pagenum" id="Page_312">[Pg 312]</span>
 called Charlie, with whom she seemed to be very
 intimate. She said that Charlie was the first
 person to see Trafton after she found he was
@@ -10418,7 +10418,7 @@ The story that Trafton had borrowed money of
 her was absurd on its face, and she acted as if
 she hardly expected to be believed.</p>
 
-<p><span class="pagenum"><a id="Page_313"></a>[Pg 313]</span></p>
+<p><span class="pagenum" id="Page_313">[Pg 313]</span></p>
 
 <p>Before coming to Chicago this time, Mr. Updike
 had written to Mr. T. B. Vernon, of Buffalo,
@@ -10453,7 +10453,7 @@ their suspicions to a member of the city detective
 force, who was inclined to make light of them, I
 suggested that they inform him that they had
 changed their minds in the matter, having
-learned from the Cleveland physicians that death<span class="pagenum"><a id="Page_314"></a>[Pg 314]</span>
+learned from the Cleveland physicians that death<span class="pagenum" id="Page_314">[Pg 314]</span>
 was surely caused by congestion of the lungs.
 They then took their departure, saying that they
 would lay my plan before Mr. Richard S. Trafton,
@@ -10487,7 +10487,7 @@ were sometimes almost stifling. To venture, at
 any time, into the waste of ruins, which stretched
 more than three miles in one direction, through
 the formerly richest portion of the city, was not
-a pleasant undertaking; but to make such an ex<span class="pagenum"><a id="Page_315"></a>[Pg 315]</span>cursion
+a pleasant undertaking; but to make such an ex<span class="pagenum" id="Page_315">[Pg 315]</span>cursion
 at night was attended with more hazard
 than most peaceably-disposed men would care to
 run. There were no gaslights, no sidewalks, no
@@ -10521,7 +10521,7 @@ investigate.</p>
 
 <p>The destruction of thousands of business blocks
 and dwellings left the city without adequate accommodations
-for offices and residences, even for<span class="pagenum"><a id="Page_316"></a>[Pg 316]</span>
+for offices and residences, even for<span class="pagenum" id="Page_316">[Pg 316]</span>
 its own regular population; but when the rush of
 strangers swelled the aggregate nearly twenty
 per cent., there seemed hardly sleeping-rooms for
@@ -10554,7 +10554,7 @@ Mr. Trafton, if they had not had their hands full
 of other business to an unprecedented extent;
 and, lastly, when I came to work up the case, I
 should not have had so much difficulty in finding
-witnesses, if it had not been that people came<span class="pagenum"><a id="Page_317"></a>[Pg 317]</span>
+witnesses, if it had not been that people came<span class="pagenum" id="Page_317">[Pg 317]</span>
 and went through Chicago like the waves of the
 sea in mid-ocean, leaving no trace by which they
 could be followed or identified.</p>
@@ -10591,7 +10591,7 @@ for the lady of the house. Mrs. Sanford soon
 entered the sitting-room, and the stranger said
 that, having seen the sign, "Furnished Rooms
 to Rent," he had called to engage lodgings. He
-introduced himself as John Ingham, and said<span class="pagenum"><a id="Page_318"></a>[Pg 318]</span>
+introduced himself as John Ingham, and said<span class="pagenum" id="Page_318">[Pg 318]</span>
 that he was a bookkeeper, temporarily out of
 employment. Mrs. Sanford received him with
 great cordiality, and seemed much pleased to have
@@ -10624,7 +10624,7 @@ their room on the way to the other rooms in the
 rear.</p>
 
 <p>Mrs. Sanford was a good-looking woman, about
-thirty-two years old. Her features were quite<span class="pagenum"><a id="Page_319"></a>[Pg 319]</span>
+thirty-two years old. Her features were quite<span class="pagenum" id="Page_319">[Pg 319]</span>
 pretty, and her expression was pleasing. She
 was very plump, and her skin was smooth and
 soft. She had brown hair, a nose slightly
@@ -10657,7 +10657,7 @@ of compounds, however, and while her thirst
 for money seemed to overpower all other considerations
 with her as a general rule, on some occasions
 she would be as wasteful and careless of
-expense as the most prodigal woman in the<span class="pagenum"><a id="Page_320"></a>[Pg 320]</span>
+expense as the most prodigal woman in the<span class="pagenum" id="Page_320">[Pg 320]</span>
 world. But when she had set her mind on the
 acquisition of any particular money or piece of
 personal property, there was no length to which
@@ -10692,7 +10692,7 @@ After he had gone, she began to converse very
 confidentially with Ingham, telling him that she
 was engaged to be married to Charlie, the policeman.</p>
 
-<p><span class="pagenum"><a id="Page_321"></a>[Pg 321]</span></p>
+<p><span class="pagenum" id="Page_321">[Pg 321]</span></p>
 
 <p>"Don't you think a policeman is good enough
 to marry?" she asked.</p>
@@ -10733,7 +10733,7 @@ upon them.</p>
 queried; "could any one who found them make
 use of them without being discovered?"</p>
 
-<p><span class="pagenum"><a id="Page_322"></a>[Pg 322]</span></p>
+<p><span class="pagenum" id="Page_322">[Pg 322]</span></p>
 
 <p>"Yes, I think so," said Ingham. "There is no
 means of learning how they came into the bearer's
@@ -10775,7 +10775,7 @@ well."</p>
 
 <p>"Perhaps you could get employment from the
 Relief and Aid Society," she said, "and then you
-could get lots of nice things for me. This man,<span class="pagenum"><a id="Page_323"></a>[Pg 323]</span>
+could get lots of nice things for me. This man,<span class="pagenum" id="Page_323">[Pg 323]</span>
 Graves, whose room you are to have, is employed
 there, and he steals enough to keep the
 woman who is with him in good style."</p>
@@ -10818,7 +10818,7 @@ months. I used to live in Cleveland before I
 separated from my husband, and we had a fine
 stone-front house there."</p>
 
-<p><span class="pagenum"><a id="Page_324"></a>[Pg 324]</span></p>
+<p><span class="pagenum" id="Page_324">[Pg 324]</span></p>
 
 <p>"How did you happen to leave your husband?"
 asked Ingham.</p>
@@ -10857,7 +10857,7 @@ took the back room in my house. He was very
 kind to me, and wanted to marry me; but he
 drank hard for a week and began to show the
 effects of his dissipation. Finally, he came home
-one evening quite drunk, and he complained of<span class="pagenum"><a id="Page_325"></a>[Pg 325]</span>
+one evening quite drunk, and he complained of<span class="pagenum" id="Page_325">[Pg 325]</span>
 feeling sick. I boiled a chicken for him, but he
 could not eat it, and he went to bed. Next
 morning he did not call me as usual, and I went
@@ -10894,7 +10894,7 @@ have been the wiser. I tell you, I wouldn't have
 let such a chance as that slip."</p>
 
 <p>"Well, I know I might have taken some of it,"
-she answered, thoughtfully, "but I couldn't steal<span class="pagenum"><a id="Page_326"></a>[Pg 326]</span>
+she answered, thoughtfully, "but I couldn't steal<span class="pagenum" id="Page_326">[Pg 326]</span>
 from him. Oh! I have mighty good credit
 among people here now, for every one knows
 about that money, and that I could have taken
@@ -10930,7 +10930,7 @@ raise.</p>
 
 <p>"Oh! any kind," he replied; "I'm not particular,
 provided I can get enough to pay for the
-trouble. If I knew of any good hiding place, I<span class="pagenum"><a id="Page_327"></a>[Pg 327]</span>
+trouble. If I knew of any good hiding place, I<span class="pagenum" id="Page_327">[Pg 327]</span>
 could get a lot of valuable goods some night without
 much work, and with no danger."</p>
 
@@ -10969,7 +10969,7 @@ replied; "but I guess we can do nearly as well,
 if you will be true to me and help me."</p>
 
 <p>"You can depend upon me for anything," she
-answered, with great determination, but adding<span class="pagenum"><a id="Page_328"></a>[Pg 328]</span>
+answered, with great determination, but adding<span class="pagenum" id="Page_328">[Pg 328]</span>
 suddenly, in a cautious tone, "that is, anything
 except murder, you know. I shouldn't like to do
 that. But I would protect you even if you should
@@ -11010,7 +11010,7 @@ are you?"</p>
 in there since Mr. Trafton died there. I cannot
 help recollecting the way he looked when I
 first saw him hanging over the bedside, with the
-froth on his lips. I took out all the furniture on<span class="pagenum"><a id="Page_329"></a>[Pg 329]</span>
+froth on his lips. I took out all the furniture on<span class="pagenum" id="Page_329">[Pg 329]</span>
 that account, but I am going to furnish it again
 next week, as I can get a good rent for it."</p>
 
@@ -11051,7 +11051,7 @@ want to tackle a sober man, if I can help it."</p>
 whisper; "I can give him something to keep him
 quiet."</p>
 
-<p><span class="pagenum"><a id="Page_330"></a>[Pg 330]</span></p>
+<p><span class="pagenum" id="Page_330">[Pg 330]</span></p>
 
 <p>"How can you do that?" he inquired, with apparent
 astonishment.</p>
@@ -11090,7 +11090,7 @@ without being suspected?" she asked. "Wouldn't
 his friends catch you if they had the numbers of
 the bonds?"</p>
 
-<p>"Oh! that wouldn't make any difference.<span class="pagenum"><a id="Page_331"></a>[Pg 331]</span>
+<p>"Oh! that wouldn't make any difference.<span class="pagenum" id="Page_331">[Pg 331]</span>
 There are millions of dollars afloat of these bonds,
 and they cannot be traced any more than money."</p>
 
@@ -11126,7 +11126,7 @@ she had stolen some of Mrs. Sanford's towels and
 other things. She then went to the trunk, opened
 it, and took out a number of articles, which she
 said belonged to her. She took the articles into
-the kitchen, and secreted them in a hole in the<span class="pagenum"><a id="Page_332"></a>[Pg 332]</span>
+the kitchen, and secreted them in a hole in the<span class="pagenum" id="Page_332">[Pg 332]</span>
 floor, where she was able to take up a board.
 Ingham thought it rather strange that she should
 hide these things, if they were her own property,
@@ -11164,7 +11164,7 @@ and figure. She was stylish and graceful
 in her appearance, and her dress showed remarkably
 good taste. She was very vivacious
 and merry, but a close observer would have
-noticed that she was not endowed with much<span class="pagenum"><a id="Page_333"></a>[Pg 333]</span>
+noticed that she was not endowed with much<span class="pagenum" id="Page_333">[Pg 333]</span>
 sentiment, and a physiognomist would have said
 that she was more interested in the size of a man's
 fortune than in his looks or powers to please.
@@ -11198,7 +11198,7 @@ and Mrs. Sanford were quite excited over the
 former's adventure. After Miss Ida had gone
 home, Ingham gave Mrs. Sanford ten dollars, and
 told her that he and another man had followed a
-stranger into the "Burnt District" just at dusk,<span class="pagenum"><a id="Page_334"></a>[Pg 334]</span>
+stranger into the "Burnt District" just at dusk,<span class="pagenum" id="Page_334">[Pg 334]</span>
 and while the other man choked the stranger,
 Ingham had "gone through" his pockets. Owing
 to the fact that there were very few persons and
@@ -11230,7 +11230,7 @@ and had only just returned. She had told
 him that Ingham was her brother from Detroit,
 and that he was going to remain with her for
 some time. Ingham was then introduced to Mr
-Pratt, and they talked with each other until<span class="pagenum"><a id="Page_335"></a>[Pg 335]</span>
+Pratt, and they talked with each other until<span class="pagenum" id="Page_335">[Pg 335]</span>
 supper-time. Pratt was a middle-aged man, with
 a mean-looking face and suspicious manner.
 They went to a restaurant for supper, and the
@@ -11264,7 +11264,7 @@ bother her any longer.</p>
 <p>Ingham told her that she certainly ought to
 have Mrs. Graves arrested and punished severely,
 and he petted her so nicely that she said
-he was her best friend, and that she would do<span class="pagenum"><a id="Page_336"></a>[Pg 336]</span>
+he was her best friend, and that she would do<span class="pagenum" id="Page_336">[Pg 336]</span>
 anything for him. He prepared a dressing for
 her black eye, and got some supper for her, telling
 her that on Monday&mdash;that day being Saturday&mdash;she
@@ -11301,7 +11301,7 @@ in distress, but they resembled the efforts of some
 stage ghost in a blood-and-thunder drama. Suddenly
 Mrs. Sanford stepped out, with her revolver
 in her hand, and began to walk toward the hall.
-He instantly overtook her and asked her, in a<span class="pagenum"><a id="Page_337"></a>[Pg 337]</span>
+He instantly overtook her and asked her, in a<span class="pagenum" id="Page_337">[Pg 337]</span>
 whisper, what she was going to do. She made a
 significant motion with her revolver, and again
 stopped to listen. He then took the pistol away
@@ -11334,7 +11334,7 @@ she asked whether the numbers on government
 bonds were all different. He said that there were
 different series, which were exactly alike except
 the letter, and he tried to explain the matter to
-her, but she could not understand it. She also<span class="pagenum"><a id="Page_338"></a>[Pg 338]</span>
+her, but she could not understand it. She also<span class="pagenum" id="Page_338">[Pg 338]</span>
 wanted to know whether the bonds could be sold
 in a foreign country, and he told her yes; that
 that was the best way to sell them, if there was
@@ -11373,7 +11373,7 @@ and manners at times showed that she had once
 been a member of good society, while her reading
 and declamations from Shakespeare and other
 poets gave evidence of great natural talents.
-Combined with her greed for money was a strong<span class="pagenum"><a id="Page_339"></a>[Pg 339]</span>
+Combined with her greed for money was a strong<span class="pagenum" id="Page_339">[Pg 339]</span>
 element of sensuality, and though she usually
 granted her favors only where she expected a
 large pecuniary reward, still, at times, she was
@@ -11409,7 +11409,7 @@ sum of money, and he will get drunk. Then, if
 she tries to rob him, I shall be certain that she
 did the same with young Trafton."</p>
 
-<p><span class="pagenum"><a id="Page_340"></a>[Pg 340]</span></p>
+<p><span class="pagenum" id="Page_340">[Pg 340]</span></p>
 
 <p>I therefore arranged that Ingham should pretend
 that he had made the acquaintance of a
@@ -11445,7 +11445,7 @@ that he should come.</p>
 A. Pinkerton, who assumed the name of
 Adamson for the occasion.</p>
 
-<p>Accordingly, the two detectives met at my<span class="pagenum"><a id="Page_341"></a>[Pg 341]</span>
+<p>Accordingly, the two detectives met at my<span class="pagenum" id="Page_341">[Pg 341]</span>
 office, and Adamson was given five hundred dollars
 in fifty dollar bonds. They then went to
 Mrs. Sanford's house, and, on arriving there,
@@ -11483,7 +11483,7 @@ fifty dollars. This he was to lose, and he was to
 become angry and go away. Adamson then gave
 Ingham about fifty dollars to show as his winnings,
 and presently Mrs. Sanford came in. She
-<span class="pagenum"><a id="Page_342"></a>[Pg 342]<br /><a id="Page_343"></a>[Pg 343]<br /><a id="Page_344"></a>[Pg 344]</span>had been introduced to Adamson under the assumed
+<span class="pagenum" id="Page_344">[Pg 344]</span>had been introduced to Adamson under the assumed
 name of Mrs. Robertson, and he therefore
 addressed her by that name.</p>
 
@@ -11526,7 +11526,7 @@ games. You've won more'n fiffy doll'rs fr'm me
 now, 'n I wan' m' revenge. You goin' ter gimme
 a (hic) chance t'win it back?"</p>
 
-<p><span class="pagenum"><a id="Page_345"></a>[Pg 345]</span></p>
+<p><span class="pagenum" id="Page_345">[Pg 345]</span></p>
 
 <p>"All right," said Ingham; "I'll play you just
 one game for fifty dollars, and then we'll stop, no
@@ -11567,7 +11567,7 @@ for deal."</p>
 <p>As the game progressed, Mrs. Sanford felt the
 strength of the gin more and more, and she soon
 became quite sick. Ingham got her some warm
-water, and she went into her own room to vomit.<span class="pagenum"><a id="Page_346"></a>[Pg 346]</span>
+water, and she went into her own room to vomit.<span class="pagenum" id="Page_346">[Pg 346]</span>
 She soon returned, feeling much better, and the
 game went on, Ingham winning by one point.
 Adamson then became very angry, and said he
@@ -11600,7 +11600,7 @@ could seize him again.</p>
 this scene from the top of the stairs, where he
 stood holding the lamp. As soon as Adamson was
 out, Ingham rushed down and told Mrs. Sanford
-that he intended to have those bonds anyhow.<span class="pagenum"><a id="Page_347"></a>[Pg 347]</span>
+that he intended to have those bonds anyhow.<span class="pagenum" id="Page_347">[Pg 347]</span>
 He told her to sit up for him, and then ran out
 after Adamson. In less than an hour, he returned
 and saw Mrs. Sanford watching for him
@@ -11645,7 +11645,7 @@ present shape."</p>
 she replied. "Come, hand over; I don't want
 half, but I want my share now."</p>
 
-<p><span class="pagenum"><a id="Page_348"></a>[Pg 348]</span></p>
+<p><span class="pagenum" id="Page_348">[Pg 348]</span></p>
 
 <p>"What is your hurry?" he demanded. "Can't
 you wait until to-morrow?"</p>
@@ -11686,7 +11686,7 @@ for the night.</p>
 <p>In the Chicago <i>Tribune</i> of January 14, 1872,
 the following item appeared:</p>
 
-<p><span class="pagenum"><a id="Page_349"></a>[Pg 349]</span></p>
+<p><span class="pagenum" id="Page_349">[Pg 349]</span></p>
 
 <span style="margin-left: 9em;">"<span class="smcap">Highway Robbery</span>.</span><br />
 
@@ -11728,7 +11728,7 @@ you seen that fellow that was here last night?"</p>
 <p>"No, I have not seen him," he replied. "Why
 do you ask? Has he been here looking for me?"</p>
 
-<p><span class="pagenum"><a id="Page_350"></a>[Pg 350]</span></p>
+<p><span class="pagenum" id="Page_350">[Pg 350]</span></p>
 
 <p>"Yes, he came here this morning, and asked
 me all kinds of questions about you; and now, if
@@ -11765,7 +11765,7 @@ she said, presently. "I thought a great deal of
 you, and I expected to assist you when I received
 my money; but now I have lost confidence in
 you. I suppose, if you got a chance at my
-money, you would take that too. I begin to<span class="pagenum"><a id="Page_351"></a>[Pg 351]</span>
+money, you would take that too. I begin to<span class="pagenum" id="Page_351">[Pg 351]</span>
 think I know where my watch went; the detective
 wanted to search you for it two or three
 times, but I wouldn't let him, and this is the way
@@ -11805,7 +11805,7 @@ again to-morrow."</p>
 replied, perfectly white with anger. "You may
 find yourself in jail before you know it."</p>
 
-<p><span class="pagenum"><a id="Page_352"></a>[Pg 352]</span></p>
+<p><span class="pagenum" id="Page_352">[Pg 352]</span></p>
 
 <p>"I know it," he answered, carelessly; "but it's
 my nature to take things cool, and so, if you
@@ -11845,7 +11845,7 @@ on the corner of State and Washington streets,
 he having been beaten and robbed of several hundred
 dollars in greenbacks. The police were looking
 for him yesterday, but failed to find him. It
-was ascertained that he had been boarding at No.<span class="pagenum"><a id="Page_353"></a>[Pg 353]</span>
+was ascertained that he had been boarding at No.<span class="pagenum" id="Page_353">[Pg 353]</span>
 92 West Madison street, and that, on Saturday
 night, he indulged in several games of euchre
 with a man who also boarded at the place. While
@@ -11878,7 +11878,7 @@ being the assailant of Robert Adamson. She denied
 ever having done so, and offered to swear
 that she had never betrayed him. He replied
 that he felt sure there must be a mistake, as he
-could not believe it possible that she would be<span class="pagenum"><a id="Page_354"></a>[Pg 354]</span>tray
+could not believe it possible that she would be<span class="pagenum" id="Page_354">[Pg 354]</span>tray
 him. He felt perfect confidence in her, and
 had no fears that she would try to have him arrested.</p>
 
@@ -11917,7 +11917,7 @@ there is no fear of getting into trouble."</p>
 "but I must have a living, and if I can't get it
 one way, I will another."</p>
 
-<p>Just then some one knocked at the door, and<span class="pagenum"><a id="Page_355"></a>[Pg 355]</span>
+<p>Just then some one knocked at the door, and<span class="pagenum" id="Page_355">[Pg 355]</span>
 presently Charlie Stokes, the policeman, walked
 in. They talked together a few minutes, and
 then Stokes said:</p>
@@ -11962,7 +11962,7 @@ station, and I must obey orders."</p>
 <p>"Well, you must go to the station with me to
 see the captain."</p>
 
-<p><span class="pagenum"><a id="Page_356"></a>[Pg 356]</span></p>
+<p><span class="pagenum" id="Page_356">[Pg 356]</span></p>
 
 <p>"Not unless you arrest me," replied Ingham.
 "I want to know whether I am to consider myself
@@ -12008,7 +12008,7 @@ time, and you will have an examination soon."</p>
 
 <p>"Why not?" asked the station-keeper.</p>
 
-<p><span class="pagenum"><a id="Page_357"></a>[Pg 357]</span></p>
+<p><span class="pagenum" id="Page_357">[Pg 357]</span></p>
 
 <p>"Because I have no business here unless I am
 a prisoner," was Ingham's reply.</p>
@@ -12062,7 +12062,7 @@ mean."</p>
 <p>"Then what are you asking me for?" said
 Ingham. "Am I under arrest?"</p>
 
-<p><span class="pagenum"><a id="Page_358"></a>[Pg 358]</span></p>
+<p><span class="pagenum" id="Page_358">[Pg 358]</span></p>
 
 <p>"I guess you will have to stay here awhile,"
 was the sergeant's reply.</p>
@@ -12104,7 +12104,7 @@ about the fact of your having played cards with
 this young fellow, and then having followed him
 out."</p>
 
-<p><span class="pagenum"><a id="Page_359"></a>[Pg 359]</span></p>
+<p><span class="pagenum" id="Page_359">[Pg 359]</span></p>
 
 <p>"Well, if you can prove that, you had better
 do it," said Ingham; then, changing his tone, and
@@ -12147,7 +12147,7 @@ Ingham his name, the captain said:</p>
 
 <p>"That is none of your business," said Ingham.</p>
 
-<p><span class="pagenum"><a id="Page_360"></a>[Pg 360]</span></p>
+<p><span class="pagenum" id="Page_360">[Pg 360]</span></p>
 
 <p>"Come, now, you needn't put on any airs,"
 said the captain; "I want to know all about
@@ -12175,7 +12175,7 @@ would let him go. This proved true, for the
 captain very soon came out, and told Ingham
 that he was at liberty.</p>
 
-<p><span class="pagenum"><a id="Page_361"></a>[Pg 361]</span></p>
+<p><span class="pagenum" id="Page_361">[Pg 361]</span></p>
 
 
 
@@ -12219,7 +12219,7 @@ at all!"</p>
 <p>"You don't suspect that I had any hand in it,
 I hope?" asked Mrs. Sanford.</p>
 
-<p><span class="pagenum"><a id="Page_362"></a>[Pg 362]</span></p>
+<p><span class="pagenum" id="Page_362">[Pg 362]</span></p>
 
 <p>"Oh, no indeed! I trust you perfectly; but I
 think that one of those bindery girls may have
@@ -12255,7 +12255,7 @@ room for him the next day. The next
 afternoon he called again, and Mrs. Sanford said
 that Charlie had been there, and had told her all
 about their visit to the theatre the night before.
-She said that he knew exactly where they had<span class="pagenum"><a id="Page_363"></a>[Pg 363]</span>
+She said that he knew exactly where they had<span class="pagenum" id="Page_363">[Pg 363]</span>
 been, what they had had for supper, and what
 they had paid. Ingham was thus made aware
 that he was being watched, and his position,
@@ -12294,7 +12294,7 @@ for him to sleep there, however, and
 so he went to a small hotel for the night. When
 he reported at my office the following day, I gave
 him four hundred dollars in money, and told him
-to show it to Mrs. Sanford as the proceeds of the<span class="pagenum"><a id="Page_364"></a>[Pg 364]</span>
+to show it to Mrs. Sanford as the proceeds of the<span class="pagenum" id="Page_364">[Pg 364]</span>
 sale of the stolen bonds. Accordingly, when he
 went there in the afternoon, he counted over a
 large pile of bills before her astonished eyes, and
@@ -12333,7 +12333,7 @@ Ingham then left her, and came to my
 office to return the money. In the evening he
 took Mrs. Sanford and Miss Ida Musgrove to the
 theatre, and the latter, evidently having heard
-of his improved fortunes, treated him with great<span class="pagenum"><a id="Page_365"></a>[Pg 365]</span>
+of his improved fortunes, treated him with great<span class="pagenum" id="Page_365">[Pg 365]</span>
 cordiality. They returned to the rooms of Miss
 Ida after the theatre was out, and Mrs. Sanford
 gave some fine imitations of different actors and
@@ -12369,7 +12369,7 @@ with Mrs. Sanford, I had decided to relieve him
 from this operation, and to put another man in
 his place. His story about gambling was a part
 of my plan; and the next day, when he called
-upon her, he was under instructions to announce<span class="pagenum"><a id="Page_366"></a>[Pg 366]</span>
+upon her, he was under instructions to announce<span class="pagenum" id="Page_366">[Pg 366]</span>
 his intended departure from the city. Accordingly,
 he did so, giving as a reason the fact that
 he had lost all his money, and that the police
@@ -12406,7 +12406,7 @@ store below, came in, looking rather tipsy.
 Mrs. Sanford introduced the two men, and Mr.
 Bruce said something about being an Irishman.</p>
 
-<p><span class="pagenum"><a id="Page_367"></a>[Pg 367]</span></p>
+<p><span class="pagenum" id="Page_367">[Pg 367]</span></p>
 
 <p>"Why, what a strange coincidence," said Mr.
 Morton. "Here are three persons, each representing
@@ -12440,7 +12440,7 @@ language toward each other. Finally,
 Mrs. Sanford, who was ironing, rushed at the
 young man with a flatiron in her hand, and she
 would undoubtedly have seriously injured him if
-he had not escaped into his own room at the<span class="pagenum"><a id="Page_368"></a>[Pg 368]</span>
+he had not escaped into his own room at the<span class="pagenum" id="Page_368">[Pg 368]</span>
 head of the stairs. She then laid a heavy poker
 on the table beside her, and said that she would
 mash his skull if he came near her again. In
@@ -12474,7 +12474,7 @@ away, and did not recover for nearly two hours.</p>
 
 <p>While she was running on in her story, a loud
 noise was heard, and she explained to Morton
-that Mr. Bruce had been drinking all day, until<span class="pagenum"><a id="Page_369"></a>[Pg 369]</span>
+that Mr. Bruce had been drinking all day, until<span class="pagenum" id="Page_369">[Pg 369]</span>
 he was afraid to go home, and that now he was
 quite drunk in her room. She said that he had
 been very kind to her in letting her have furniture
@@ -12509,7 +12509,7 @@ Stanley Trafton did the night he died.</p>
 longer."</p>
 
 <p>She then lay down on the table and covered
-herself with a bedspread she had brought from<span class="pagenum"><a id="Page_370"></a>[Pg 370]</span>
+herself with a bedspread she had brought from<span class="pagenum" id="Page_370">[Pg 370]</span>
 her own room. About six o'clock they were
 awakened by a loud noise at the outer door, and
 Mrs. Sanford said that those drunken loafers had
@@ -12541,7 +12541,7 @@ Bruce's money was. She said she had put it
 away for safe keeping, and, lifting the mattress,
 she took out two pocket-books and a box containing
 her watch, trinkets, etc. Having given
-Bruce his pocket-book, she went out, and he then<span class="pagenum"><a id="Page_371"></a>[Pg 371]</span>
+Bruce his pocket-book, she went out, and he then<span class="pagenum" id="Page_371">[Pg 371]</span>
 counted his money. He said he ought to have
 eighty-one dollars, but that she had helped herself
 to ten dollars; it was not worth while making
@@ -12579,7 +12579,7 @@ were crammed in pretty tight.</p>
 <p>She merely laughed, and closed the pocket-book,
 whispering that she didn't want Graves
 and Bruce to see her money. She said she did
-not wish to be left alone with Graves, for fear he<span class="pagenum"><a id="Page_372"></a>[Pg 372]</span>
+not wish to be left alone with Graves, for fear he<span class="pagenum" id="Page_372">[Pg 372]</span>
 should rob her; so Morton asked him to go out
 and play a game of billiards. Bruce was in a
 great state of anxiety, lest his wife should have
@@ -12617,7 +12617,7 @@ it?"</p>
 from England very soon, and I don't know where
 to keep it."</p>
 
-<p><span class="pagenum"><a id="Page_373"></a>[Pg 373]</span></p>
+<p><span class="pagenum" id="Page_373">[Pg 373]</span></p>
 
 <p>"Well, I shall put my three thousand dollars
 into bonds," she said. "They can be registered,
@@ -12655,7 +12655,7 @@ day," she said, "as I want to draw the interest on
 some of my coupons, and then you will see what
 good securities American bonds are."</p>
 
-<p>"I shall be very glad to go with you," said<span class="pagenum"><a id="Page_374"></a>[Pg 374]</span>
+<p>"I shall be very glad to go with you," said<span class="pagenum" id="Page_374">[Pg 374]</span>
 Morton; "for, if they are really good securities,
 I will invest some money in them."</p>
 
@@ -12697,7 +12697,7 @@ these bonds to the bank."</p>
 would have to give an account of the way in
 which you obtained them."</p>
 
-<p><span class="pagenum"><a id="Page_375"></a>[Pg 375]</span></p>
+<p><span class="pagenum" id="Page_375">[Pg 375]</span></p>
 
 <p>"Oh! well," he replied, "you could give me an
 order, and that would make it all right."</p>
@@ -12735,7 +12735,7 @@ to get money out of him," said Mrs. Sanford.
 <p>"Well, that isn't my style," said Morton, contemptuously.
 "Do you suppose I am going to
 have a scuffle and struggle, ending perhaps in
-murder, when I can make ten times as much by<span class="pagenum"><a id="Page_376"></a>[Pg 376]</span>
+murder, when I can make ten times as much by<span class="pagenum" id="Page_376">[Pg 376]</span>
 a little skillful work with my pen? I don't want
 the police to be snuffing 'round my heels on account
 of highway robbery and such small game;
@@ -12769,7 +12769,7 @@ became quiet, and about midnight she fell asleep.</p>
 
 <p>Morton said to me, on making one of his
 reports, that she would often determine to give
-up morphine and liquor, and live more respect<span class="pagenum"><a id="Page_377"></a>[Pg 377]</span>ably.
+up morphine and liquor, and live more respect<span class="pagenum" id="Page_377">[Pg 377]</span>ably.
 Then she would become excited from the
 craving for the drug, and would take a dose,
 which would soothe her, make her amiable, and
@@ -12810,7 +12810,7 @@ gave him explicit instructions as to the course
 which he was to pursue in connection with Mrs.
 Sanford.</p>
 
-<p><span class="pagenum"><a id="Page_378"></a>[Pg 378]</span></p>
+<p><span class="pagenum" id="Page_378">[Pg 378]</span></p>
 
 <p>On the first day of February, therefore, a young
 fellow called at Mrs. Sanford's about five o'clock
@@ -12844,7 +12844,7 @@ first, Barlow refused, but she insisted so urgently,
 that he finally consented to go. He went away
 for an hour to get his valise, and when he returned,
 Mrs. Sanford was dressed in her most
-stylish clothes, as if determined to make the best<span class="pagenum"><a id="Page_379"></a>[Pg 379]</span>
+stylish clothes, as if determined to make the best<span class="pagenum" id="Page_379">[Pg 379]</span>
 possible impression upon him. He was very
 good-natured and boyish, apparently believing all
 she told him, and laughing at all her attempts to
@@ -12880,7 +12880,7 @@ about young Trafton, who had died in her house,
 boots." She told Barlow that she had some bonds,
 and he would do well to get the same kind.</p>
 
-<p><span class="pagenum"><a id="Page_380"></a>[Pg 380]</span></p>
+<p><span class="pagenum" id="Page_380">[Pg 380]</span></p>
 
 <p>"I don't know much about them," he replied,
 "but if <i>you</i> think they are good, I guess they are
@@ -12920,7 +12920,7 @@ when I go to buy."</p>
 go to buy yours."</p>
 
 <p>She then put the bonds into the pocket-book
-again and went into her bedroom. On her re<span class="pagenum"><a id="Page_381"></a>[Pg 381]</span>turn,
+again and went into her bedroom. On her re<span class="pagenum" id="Page_381">[Pg 381]</span>turn,
 Barlow told her that he must go down town
 to get paid for his cattle, and he asked Morton to
 go with him. Accordingly, the two men went
@@ -12958,7 +12958,7 @@ getting a large sum out of him."</p>
 affectionate toward Barlow, and she learned all
 about him. He told his story in such a way, that
 she believed him to be an innocent country boy
-from Texas, whose most dangerous experiences<span class="pagenum"><a id="Page_382"></a>[Pg 382]</span>
+from Texas, whose most dangerous experiences<span class="pagenum" id="Page_382">[Pg 382]</span>
 had hitherto consisted of hairbreath 'scapes from
 steer and bull. He showed her a check on the
 First National Bank for about four thousand dollars,
@@ -12995,7 +12995,7 @@ asked what they wanted.</p>
 <p>"I would like to engage rooms, if there are
 any to rent," said Mr. Warner.</p>
 
-<p><span class="pagenum"><a id="Page_383"></a>[Pg 383]</span></p>
+<p><span class="pagenum" id="Page_383">[Pg 383]</span></p>
 
 <p>"I will speak to the landlady," said Morton,
 going to the door of her room.</p>
@@ -13036,7 +13036,7 @@ were looking for a murdered man."</p>
 we might have found one," he replied, quickly,
 giving her a sharp glance.</p>
 
-<p>As nothing had been said to her or to any one<span class="pagenum"><a id="Page_384"></a>[Pg 384]</span>
+<p>As nothing had been said to her or to any one<span class="pagenum" id="Page_384">[Pg 384]</span>
 else about any charge except that of larceny, this
 remark was highly significant; and, on her trial,
 it undoubtedly had great weight with the jury.</p>
@@ -13070,7 +13070,7 @@ was never more clearly shown than in this plea,
 which was undoubtedly invented on the spur of
 the moment. She claimed that young Trafton
 had given her the bonds to support her child,
-whose father he was, and she spoke with so much<span class="pagenum"><a id="Page_385"></a>[Pg 385]</span>
+whose father he was, and she spoke with so much<span class="pagenum" id="Page_385">[Pg 385]</span>
 vigor and cunning that many persons believed her
 statement to be true. Thus, without consultation
 or legal advice, she invented in a moment
@@ -13104,7 +13104,7 @@ to pay the lawyer she had engaged, but finally
 she gave him a retaining fee of fifty dollars.</p>
 
 <p>She was very anxious to learn who were the
-detectives employed in working up the case, and<span class="pagenum"><a id="Page_386"></a>[Pg 386]</span>
+detectives employed in working up the case, and<span class="pagenum" id="Page_386">[Pg 386]</span>
 she said that she believed Barlow had had something
 to do with her arrest. Morton agreed with
 her, and, as the papers had said that there were
@@ -13136,7 +13136,7 @@ perjury when the murder trial should take place.
 His testimony was to the effect that he had overheard
 a conversation between Mrs. Sanford and
 young Trafton, in which the latter acknowledged
-that he was the father of Mrs. Sanford's child,<span class="pagenum"><a id="Page_387"></a>[Pg 387]</span>
+that he was the father of Mrs. Sanford's child,<span class="pagenum" id="Page_387">[Pg 387]</span>
 having been intimate with her in Buffalo about
 eighteen months before. The question of a support
 for the child was discussed between them,
@@ -13170,7 +13170,7 @@ murder took place.</p>
 
 <p>The testimony in this trial was highly interesting
 on many accounts. The County Physician,
-who had made the first post-mortem examination<span class="pagenum"><a id="Page_388"></a>[Pg 388]</span>
+who had made the first post-mortem examination<span class="pagenum" id="Page_388">[Pg 388]</span>
 of the remains, and who had given congestion of
 the lungs as the cause of death, stated that he
 found the deceased lying dead in Mrs. Sanford's
@@ -13204,7 +13204,7 @@ her pocket-book.</p>
 was called, and gave his testimony in the
 most direct and convincing manner, like a man
 who knew perfectly well what he was talking
-about, and who was not guessing at any of the<span class="pagenum"><a id="Page_389"></a>[Pg 389]</span>
+about, and who was not guessing at any of the<span class="pagenum" id="Page_389">[Pg 389]</span>
 facts as stated by him. He declared that death
 resulted from the blow on the right side, aided
 by the violence on the throat and neck. There
@@ -13237,7 +13237,7 @@ been planned in advance by me to induce Mrs.
 Sanford to give him her confidence. After her
 arrest for larceny, he had visited her in jail, and
 she had tried to get him to swear that he had
-heard Trafton promise to give her the bonds to<span class="pagenum"><a id="Page_390"></a>[Pg 390]</span>
+heard Trafton promise to give her the bonds to<span class="pagenum" id="Page_390">[Pg 390]</span>
 support her child. When he objected, on the
 ground that he might be arrested for perjury, she
 had told him that "her Billy," meaning William
@@ -13273,7 +13273,7 @@ asked a verdict on the following grounds:</p>
 <p>Young Trafton, as shown by the testimony of
 his father and others, visited Chicago to buy
 grain, and he was, therefore, under the necessity
-of carrying with him a large amount of money.<span class="pagenum"><a id="Page_391"></a>[Pg 391]</span>
+of carrying with him a large amount of money.<span class="pagenum" id="Page_391">[Pg 391]</span>
 Being unable to get a room at any hotel convenient
 to business, he probably entered the first
 place where he saw the sign, "Rooms to Rent,"
@@ -13306,7 +13306,7 @@ her. Suspecting no harm, he sat down and ate
 a hearty supper. In some way, either in his food
 or drink, a dose of morphine was given to him,
 and he soon fell fast asleep. The woman's opportunity
-was before her, and all the natural thirst<span class="pagenum"><a id="Page_392"></a>[Pg 392]</span>
+was before her, and all the natural thirst<span class="pagenum" id="Page_392">[Pg 392]</span>
 for money which characterized her came upon
 her with full force, urging her on and inciting
 her to any lengths necessary to accomplish her
@@ -13338,7 +13338,7 @@ then seized him by the throat. Her round, plump
 hands, though powerful enough to strangle him,
 left only slight marks of abrasion on the skin,
 and in a few minutes all was over. His property
-was at her mercy, and she gave no thought to<span class="pagenum"><a id="Page_393"></a>[Pg 393]</span>
+was at her mercy, and she gave no thought to<span class="pagenum" id="Page_393">[Pg 393]</span>
 the body of her victim until she had seized every
 piece of valuable paper in his possession.</p>
 
@@ -13372,7 +13372,7 @@ young Trafton were unsupported, save by the
 testimony of this William Simpson, her paramour.
 It was noticeable that, while this man
 had testified in the trial for larceny that he had
-overheard Mr. Trafton's acknowledgment of<span class="pagenum"><a id="Page_394"></a>[Pg 394]</span>
+overheard Mr. Trafton's acknowledgment of<span class="pagenum" id="Page_394">[Pg 394]</span>
 being the father of Mrs. Sanford's child, in the
 murder trial he was not asked to give any such
 testimony, nor was the existence of such a child
@@ -13406,7 +13406,7 @@ quantities.</p>
 
 <p>The jury retired at three o'clock, and, on the
 first ballot, they stood nine for conviction and
-three for acquittal. After discussing the testi<span class="pagenum"><a id="Page_395"></a>[Pg 395]</span>mony
+three for acquittal. After discussing the testi<span class="pagenum" id="Page_395">[Pg 395]</span>mony
 for more than four hours, a compromise
 was reached, and the judge having been informed
 that the jury had agreed upon a verdict,
@@ -13443,7 +13443,7 @@ Jones, and this lady visited her quite frequently
 in her cell, bringing her books and papers.</p>
 
 <p>One morning, Mrs. Jones complained of feeling
-unwell, and Mrs. Sanford immediately gave<span class="pagenum"><a id="Page_396"></a>[Pg 396]</span>
+unwell, and Mrs. Sanford immediately gave<span class="pagenum" id="Page_396">[Pg 396]</span>
 her a glass of water. Soon after drinking it,
 Mrs. Jones became very sleepy, and in a few
 minutes, she was in a sound slumber. This effect
@@ -13478,7 +13478,7 @@ sentence was pronounced in accordance with the
 verdict of the jury, and Mrs. Sanford was consigned
 to the Illinois State Penitentiary at Joliet.</p>
 
-<p>In regard to the manner in which young Traf<span class="pagenum"><a id="Page_397"></a>[Pg 397]</span>ton
+<p>In regard to the manner in which young Traf<span class="pagenum" id="Page_397">[Pg 397]</span>ton
 was murdered, I have always had a theory of
 my own; and, while of course I do not pretend to
 any surgical learning, I give it for what it is
@@ -13514,7 +13514,7 @@ she probably let him alone, and the drug again
 took effect to the extent of putting him to sleep.
 She then resorted to a subcutaneous injection of
 morphine, knowing that the soporific influence of
-the drug would thus be made more rapid and<span class="pagenum"><a id="Page_398"></a>[Pg 398]</span>
+the drug would thus be made more rapid and<span class="pagenum" id="Page_398">[Pg 398]</span>
 powerful. This operation was performed on the
 side, and then near the large veins of the leg, and
 thus were caused the apparent bruises filled with


### PR DESCRIPTION
1. Add checkbox to HTML generate dialog to skip all but the last when several
pagenums are in the same place, which happens with blank pages. In general
these do not need page numbers and the PPer has to go through and delete them
after autogeneration.
2. If that toggle is turned on (the default), there will only be one page number within
the pagenum span, so instead of needing an `<a>` element adding just to provide
an anchor so the page can be linked to, just add an id to the pagenum `<span>`
3. Saved by the tests! Needed a tiny change to the regex used when trying to
place chapter headings intelligently round pagenums.

Fixes #102