### PR TITLE
Replace Latin-1 chart with Commonly-Used Characters Chart

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -214,7 +214,7 @@ our @replace_history;
 our @search_history;
 our @sopt = ( 0, 0, 0, 0, 0 );    # default is not whole word search
 our @wfsearchopt;
-our @userchars = ();              # user defined chars for common characters dialog
+our @userchars;                   # user defined chars for common characters dialog
 
 # html markup dialog
 our @htmlentry = ('') x 4;        # class/attributes for each div, span, i button

--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -214,6 +214,7 @@ our @replace_history;
 our @search_history;
 our @sopt = ( 0, 0, 0, 0, 0 );    # default is not whole word search
 our @wfsearchopt;
+our @userchars = ();              # user defined chars for common characters dialog
 
 # html markup dialog
 our @htmlentry = ('') x 4;        # class/attributes for each div, span, i button

--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -552,7 +552,7 @@ sub utfcharentrypopup {
                 }
                 $outentry->delete( '1.0', 'end' );
                 $outentry->insert( 'end', $char );
-                $charlbl->configure( -text => $name );
+                $charlbl->configure( -text => $name ) if $name;
                 return 1;
             },
         )->grid( -row => 1, -column => 2, -pady => 5 );

--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -168,6 +168,8 @@ sub usercharconfig {
     charbind3( $w, $text );                                            # Right-click button copies text to clipboard
     charbuttonballoon( $w, $blln, $ord );                              # Balloon message if user hovers over button
 
+    ::savesettings();                                                  # Ensure new button definition saved to setting file
+
     # stop class callback being called - possible due to binding reordering during button creation above
     $w->break;
 }

--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -6,87 +6,197 @@ BEGIN {
     use Exporter();
     our ( @ISA, @EXPORT );
     @ISA    = qw(Exporter);
-    @EXPORT = qw(&latinpopup &utfpopup &utfcharentrypopup &utfcharsearchpopup &cp1252toUni);
+    @EXPORT = qw(&commoncharspopup &utfpopup &utfcharentrypopup &utfcharsearchpopup &cp1252toUni);
 }
 
-sub latinpopup {
+#
+# Create popup containing commonly used characters
+# Buttons inserting a space can be defined by user, configured by Ctrl-click, stored in $::userchars
+# This allows as many as possible of user's definitions to be preserved if in a future upgrade,
+# more buttons are defined, preferably keeping at least as many user-defined buttons
+sub commoncharspopup {
     my $top = $::top;
-    if ( defined( $::lglobal{latinpop} ) ) {
-        $::lglobal{latinpop}->deiconify;
-        $::lglobal{latinpop}->raise;
-        $::lglobal{latinpop}->focus;
+    if ( defined( $::lglobal{comchars} ) ) {
+        $::lglobal{comchars}->deiconify;
+        $::lglobal{comchars}->raise;
+        $::lglobal{comchars}->focus;
     } else {
         my @lbuttons;
-        $::lglobal{latinpop} = $top->Toplevel;
-        $::lglobal{latinpop}->title('Latin-1 ISO 8859-1');
-        ::initialize_popup_with_deletebinding('latinpop');
-        my $b       = $::lglobal{latinpop}->Balloon( -initwait => 750 );
-        my $tframe  = $::lglobal{latinpop}->Frame->pack;
-        my $default = $tframe->Radiobutton(
-            -variable    => \$::lglobal{latoutp},
+        $::lglobal{comchars} = $top->Toplevel;
+        $::lglobal{comchars}->title('Commonly Used Characters');
+        ::initialize_popup_with_deletebinding('comchars');
+        my $blln      = $::lglobal{comchars}->Balloon( -initwait => 750 );
+        my $tframe    = $::lglobal{comchars}->Frame->pack;
+        my $charradio = $tframe->Radiobutton(
+            -variable    => \$::lglobal{comcharoutp},
             -selectcolor => $::lglobal{checkcolor},
-            -value       => 'l',
-            -text        => 'Latin-1 Character',
+            -value       => 'c',
+            -text        => 'Character',
         )->grid( -row => 1, -column => 1 );
         $tframe->Radiobutton(
-            -variable    => \$::lglobal{latoutp},
+            -variable    => \$::lglobal{comcharoutp},
             -selectcolor => $::lglobal{checkcolor},
             -value       => 'h',
-            -text        => 'HTML Named Entity',
+            -text        => 'HTML Entity',
         )->grid( -row => 1, -column => 2 );
-        $tframe->Label( -text => 'Click to insert', )
-          ->grid( -row => 2, -column => 1, -columnspan => 2 );
-        my $frame      = $::lglobal{latinpop}->Frame( -background => $::bkgcolor )->pack;
-        my @latinchars = (
-            [ 'À', 'Á', 'Â', 'Ã', 'Ä', 'Å', 'Æ',      'Ç' ],
-            [ 'à', 'á', 'â', 'ã', 'ä', 'å', 'æ',      'ç' ],
-            [ 'È', 'É', 'Ê', 'Ë', 'Ì', 'Í', 'Î',      'Ï' ],
-            [ 'è', 'é', 'ê', 'ë', 'ì', 'í', 'î',      'ï' ],
-            [ 'Ò', 'Ó', 'Ô', 'Õ', 'Ö', 'Ø', 'Ñ',      'Þ' ],
-            [ 'ò', 'ó', 'ô', 'õ', 'ö', 'ø', 'ñ',      'þ' ],
-            [ 'Ù', 'Ú', 'Û', 'Ü', 'Ð', 'ß', 'Ý',      '×' ],
-            [ 'ù', 'ú', 'û', 'ü', 'ð', 'ÿ', 'ý',      '÷' ],
-            [ '¡', '¿', '«', '»', '¼', '½', '¾',      '¬' ],
-            [ '°', 'µ', '©', '®', '¹', '²', '³',      '±' ],
-            [ '£', '¢', '¦', '§', '¶', 'º', 'ª',      '·' ],
-            [ '¤', '¥', '¯', '¸', '¨', '´', "\x{A0}", '' ],
+        $charradio->select;
+        my $frame       = $::lglobal{comchars}->Frame( -background => $::bkgcolor )->pack;
+        my @commonchars = (
+            [ 'À', 'Á', 'Â', 'Ã', 'Ä', 'Å', 'Æ', 'Ç', 'È', 'É', 'Ê', 'Ë', 'Ì', 'Í', 'Î', 'Ï', ],
+            [    # Capital Y with diaresis isn't in allowed range for Perl source code
+                'Ò', 'Ó', 'Ô', 'Õ', 'Ö', 'Ø', 'Ñ',       'ß',
+                'Ù', 'Ú', 'Û', 'Ü', 'Ð', 'þ', "\x{178}", 'Ý',
+            ],
+            [ 'à', 'á', 'â', 'ã', 'ä', 'å', 'æ', 'ç', 'è', 'é', 'ê', 'ë', 'ì', 'í', 'î', 'ï', ],
+            [ 'ò', 'ó', 'ô', 'õ', 'ö', 'ø', 'ñ', '',  'ù', 'ú', 'û', 'ü', 'ð', 'Þ', 'ÿ', 'ý', ],
+            [    # Invert ! ?, angle quotes, curly single/double, low/high single/double, pointers
+                "\x{A1}",   "\x{BF}",   "\x{AB}",   "\x{BB}",   "\x{2018}", "\x{2019}",
+                "\x{201C}", "\x{201D}", "\x{201A}", "\x{201B}", "\x{201E}", "\x{201F}",
+                "\x{261E}", "\x{261B}", "\x{261C}", "\x{261A}",
+            ],
+            [    # +-, mid-dot, mult & div, deg, 1,2,3 prime, per mille, super 1,2,3, pound, cent, (C), nbsp
+                "\x{B1}",   "\x{B7}",   "\x{D7}",   "\x{F7}", "\x{B0}", "\x{2032}",
+                "\x{2033}", "\x{2034}", "\x{2030}", "\x{B9}", "\x{B2}", "\x{B3}",
+                "\x{A3}",   "\x{A2}",   "\x{A9}",   "\x{A0}",
+            ],
+            [    # fractions, ordered by denominator then numerator
+                "\x{BD}",   "\x{2153}", "\x{BC}",   "\x{BE}",   "\x{2155}", "\x{2156}",
+                "\x{2157}", "\x{2158}", "\x{2159}", "\x{215A}", "\x{2150}", "\x{215B}",
+                "\x{215C}", "\x{215D}", "\x{215E}", "\x{2151}",
+            ],
+            [    # emdash, endash, footnote markers, asterism, o&a ordinals, 5 x user-defined buttons
+                "\x{2014}", "\x{2013}", "\x{2020}", "\x{2021}", "\x{A7}", "\x{2016}",
+                "\x{B6}",   "\x{A6}",   "\x{2042}", "\x{BA}",   "\x{AA}", " ",
+                " ",        " ",        " ",        " ",
+            ],
         );
 
-        for my $y ( 0 .. 11 ) {
-            for my $x ( 0 .. 7 ) {
-                $lbuttons[ ( $y * 16 ) + $x ] = $frame->Button(
-                    -activebackground   => $::activecolor,
-                    -text               => $latinchars[$y][$x],
-                    -font               => 'unicode',
-                    -relief             => 'flat',
-                    -borderwidth        => 0,
-                    -background         => $::bkgcolor,
-                    -command            => \&putlatin,
+        my $ucidx = 0;    # Index into user-defined characters
+        for my $y ( 0 .. $#commonchars ) {
+            for my $x ( 0 .. $#{ $commonchars[$y] } ) {
+                my $text = $commonchars[$y][$x];
+                next if $text eq '';    # No text, don't even create a button
+
+                # User can override 'space' buttons - simply fill them in order, not via row/column
+                my $userbutton = ( $text eq ' ' );
+                if ( $userbutton and $ucidx <= $#::userchars and $::userchars[$ucidx] ) {
+                    $text = $::userchars[$ucidx];
+                }
+
+                my $ord = ord($text);
+
+                # Define simple flat button to save space
+                my $w = $frame->Button(
+                    -activebackground => $::activecolor,
+                    -text             => $text,
+                    -font             => 'unicode',
+                    -relief           => 'flat',
+                    -borderwidth      => 0,
+                    -background       => $::bkgcolor,
+                    -command =>
+                      sub { insertit( $::lglobal{comcharoutp} eq 'h' ? ::entity($ord) : $text ); },
                     -highlightthickness => 0,
-                )->grid( -row => $y, -column => $x, -padx => 2 );
-                my $name  = ord( $latinchars[$y][$x] );
-                my $hex   = uc sprintf( "%04x", $name );
-                my $msg   = "Dec. $name, Hex. $hex";
-                my $cname = charnames::viacode($name);
-                $msg .= ", $cname" if $cname;
-                $b->attach( $lbuttons[ ( $y * 16 ) + $x ], -balloonmsg => $msg, );
+                    -width              => 1,
+                )->grid( -row => $y, -column => $x );
+
+                charbind3( $w, $text );    # Bind Mouse-3 to copy character to clipboard
+
+                # For user buttons, bind Ctrl/Meta Mouse-1 to pop a dialog to set character
+                if ($userbutton) {
+                    $w->eventAdd( '<<config>>' => '<Control-ButtonRelease-1>' );
+                    $w->eventAdd( '<<config>>' => '<Meta-ButtonRelease-1>' ) if $::OS_MAC;
+                    $w->bind( '<<config>>' => [ \&usercharconfig, $ucidx, $blln ] );
+                    ++$ucidx;              # Keep count of number of user buttons defined
+                }
+
+                # re-order bindings so that widget's binding precedes class binding
+                # meaning we can break out of callbacks later before class callback is called
+                my @tags = $w->bindtags;
+                $w->bindtags( [ @tags[ 1, 0, 2, 3 ] ] );
+
+                charbuttonballoon( $w, $blln, $ord );    # Balloon message if user hovers over button
             }
         }
-        $default->select;
-
-        sub putlatin {
-            my @xy     = $::lglobal{latinpop}->pointerxy;
-            my $widget = $::lglobal{latinpop}->containing(@xy);
-            my $letter = $widget->cget( -text );
-            return unless $letter;
-            my $hex = sprintf( "%x", ord($letter) );
-            $letter = ::entity( '\x' . $hex ) if ( $::lglobal{latoutp} eq 'h' );
-            insertit($letter);
-        }
-        $::lglobal{latinpop}->resizable( 'no', 'no' );
-        $::lglobal{latinpop}->raise;
-        $::lglobal{latinpop}->focus;
+        $::lglobal{comchars}->resizable( 'no', 'no' );
+        $::lglobal{comchars}->raise;
+        $::lglobal{comchars}->focus;
     }
+}
+
+#
+# Pop a config dialog to set character for given button
+# Accepts a single character, e.g. '#'.
+# If more than 1 character entered, convert to a decimal ordinal if valid
+# If not valid decimal, try converting to a hex ordinal, optionally preceded by \x, 0x or x
+# Final fallback, just take first character from string entered
+sub usercharconfig {
+    my $w    = shift;
+    my $idx  = shift;
+    my $blln = shift;
+
+    $::lglobal{comcharsconfigpop} = $w->DialogBox(
+        -buttons => [qw[OK Cancel]],
+        -title   => "Define button",
+        -popover => 'cursor',
+    );
+    ::dialogboxcommonsetup(
+        'comcharsconfigpop',
+        \$::lglobal{comcharconfigval},
+        'Enter character, decimal or hex ordinal: '
+    );
+
+    # Replace empty string with space character
+    my $text = $::lglobal{comcharconfigval} ? $::lglobal{comcharconfigval} : ' ';
+
+    # If more than one character, interpret as decimal ordinal, hex ordinal or just take first char
+    if ( length($text) > 1 ) {
+        if ( $text =~ /^\d+$/ ) {    # decimal integer
+            $text = chr($text);
+        } elsif ( $text =~ s/([\\0]?[x])?([0-9a-f]+)/$2/i ) {    # hex (with x, \x, 0x or no prefix)
+            $text = chr( hex($text) );
+        } else {
+            $text = substr( $text, 0, 1 );                       # Just take first character of string
+        }
+    }
+
+    my $ord = ord($text);
+    $::userchars[$idx] = $text;                                  # Save user's new definition
+    $w->configure( -text => $text );                             # Update the label on the button
+    $w->configure(                                               # Button needs to insert the new character
+        -command => sub { insertit( $::lglobal{comcharoutp} eq 'h' ? ::entity($ord) : $text ); }
+    );
+    charbind3( $w, $text );                                      # Right-click button copies text to clipboard
+    charbuttonballoon( $w, $blln, $ord );                        # Balloon message if user hovers over button
+
+    # stop class callback being called - possible due to binding reordering during button creation above
+    $w->break;
+}
+
+#
+# Bind Mouse-3 to copy given text to clipboard
+sub charbind3 {
+    my $w    = shift;
+    my $text = shift;
+    $w->bind(
+        '<ButtonPress-3>',
+        sub {
+            my $textwindow = $::textwindow;
+            $textwindow->clipboardClear;
+            $textwindow->clipboardAppend($text);
+        }
+    );
+}
+
+#
+# Attach balloon to widget with message about character it will insert
+sub charbuttonballoon {
+    my $w     = shift;
+    my $blln  = shift;
+    my $ord   = shift;
+    my $cname = charnames::viacode($ord);
+    my $msg   = "Dec. $ord, Hex. " . sprintf( "%04X", $ord );
+    $msg .= ", $cname" if $cname;
+    $blln->attach( $w, -balloonmsg => $msg, );
 }
 
 sub insertit {
@@ -111,9 +221,8 @@ sub insertit {
 
 sub doutfbuttons {
     my ( $start, $end ) = @_;
-    my $textwindow = $::textwindow;
-    my $rows       = ( ( hex $end ) - ( hex $start ) + 1 ) / 16 - 1;
-    my $blln       = $::lglobal{utfpop}->Balloon( -initwait => 750 );
+    my $rows = ( ( hex $end ) - ( hex $start ) + 1 ) / 16 - 1;
+    my $blln = $::lglobal{utfpop}->Balloon( -initwait => 750 );
     ::killpopup('pframe');
     $::lglobal{pframe} =
       $::lglobal{utfpop}->Frame( -background => $::bkgcolor )
@@ -131,11 +240,6 @@ sub doutfbuttons {
             my $ord  = hex($start) + ( $y * 16 ) + $x;
             my $text = chr($ord);
 
-            my $cname = charnames::viacode($ord);
-            next unless $cname;    # Unnamed - don't create button
-            my $msg = "Dec. $ord, Hex. " . sprintf( "%04X", $ord ) . ", $cname";
-
-            # Use label instead of button since it takes less space
             my $w = $::lglobal{utfframe}->Button(
                 -activebackground => $::activecolor,
                 -text             => $text,
@@ -148,15 +252,8 @@ sub doutfbuttons {
                 -width              => 1,
             )->grid( -row => $y, -column => $x );
 
-            # Bind Mouse-3 to copy character to clipboard
-            $w->bind(
-                '<ButtonPress-3>',
-                sub {
-                    $textwindow->clipboardClear;
-                    $textwindow->clipboardAppend($text);
-                }
-            );
-            $blln->attach( $w, -balloonmsg => $msg, );
+            charbind3( $w, $text );                  # Right-click button copies text to clipboard
+            charbuttonballoon( $w, $blln, $ord );    # Balloon message if user hovers over button
         }
     }
     $::lglobal{utfpop}->update;
@@ -241,9 +338,8 @@ sub utfcharsearchpopup {
         # get lists of supported blocks and unicode characters at start
         my %blocks = %{ $::lglobal{utfblocks} };
 
-        # Add Basic Latin and Latin-1 Supplement blocks
-        $blocks{'Basic Latin'}        = [ '0000', '007F' ];
-        $blocks{'Latin-1 Supplement'} = [ '0080', '00FF' ];
+        # Add Basic Latin block - not in list of unicode blocks displayed
+        $blocks{'Basic Latin'} = [ '0000', '007F' ];
 
         my @lines = split /\n/, do 'unicore/Name.pl';
         $::lglobal{utfsearchpop} = $top->Toplevel;

--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -127,7 +127,7 @@ sub commoncharspopup {
 # Pop a config dialog to set character for given button
 # Accepts a single character, e.g. '#'.
 # If more than 1 character entered, convert to a decimal ordinal if valid
-# If not valid decimal, try converting to a hex ordinal, optionally preceded by \x, 0x or x
+# If not valid decimal, try converting to a hex ordinal, optionally preceded by \x, 0x, x or U+
 # Final fallback, just take first character from string entered
 sub usercharconfig {
     my $w    = shift;
@@ -152,21 +152,21 @@ sub usercharconfig {
     if ( length($text) > 1 ) {
         if ( $text =~ /^\d+$/ ) {    # decimal integer
             $text = chr($text);
-        } elsif ( $text =~ s/([\\0]?[x])?([0-9a-f]+)/$2/i ) {    # hex (with x, \x, 0x or no prefix)
+        } elsif ( $text =~ s/(([\\0]?[x])|U\+)?([0-9a-f]+)/$3/i ) {    # hex (with x, \x, 0x, U+ or no prefix)
             $text = chr( hex($text) );
         } else {
-            $text = substr( $text, 0, 1 );                       # Just take first character of string
+            $text = substr( $text, 0, 1 );                             # Just take first character of string
         }
     }
 
     my $ord = ord($text);
-    $::userchars[$idx] = $text;                                  # Save user's new definition
-    $w->configure( -text => $text );                             # Update the label on the button
-    $w->configure(                                               # Button needs to insert the new character
+    $::userchars[$idx] = $text;                                        # Save user's new definition
+    $w->configure( -text => $text );                                   # Update the label on the button
+    $w->configure(                                                     # Button needs to insert the new character
         -command => sub { insertit( $::lglobal{comcharoutp} eq 'h' ? ::entity($ord) : $text ); }
     );
-    charbind3( $w, $text );                                      # Right-click button copies text to clipboard
-    charbuttonballoon( $w, $blln, $ord );                        # Balloon message if user hovers over button
+    charbind3( $w, $text );                                            # Right-click button copies text to clipboard
+    charbuttonballoon( $w, $blln, $ord );                              # Balloon message if user hovers over button
 
     # stop class callback being called - possible due to binding reordering during button creation above
     $w->break;

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -939,6 +939,13 @@ EOM
         }
         print $save_handle ");\n\n";
 
+        print $save_handle ("\@userchars = (\n");
+        for (@::userchars) {
+            my $hstr = ( $_ ? '\x{' . ( sprintf "%x", ord($_) ) . '}' : ' ' );
+            print $save_handle "\t\"", $hstr, "\",\n";
+        }
+        print $save_handle ");\n\n";
+
         print $save_handle ("\@htmlentry = (\n");
         for (@::htmlentry) {
             print $save_handle "\t'", ::escape_problems($_), "',\n";

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -95,8 +95,7 @@ sub html_convert_emdashes {
 sub html_convert_latin1 {
     ::working("Converting Latin-1 Characters...");
     for ( 128 .. 255 ) {
-        my $from = lc sprintf( "%x", $_ );
-        ::named( '\x' . $from, ::entity( '\x' . $from ) );
+        ::named( chr($_), ::entity($_) );
     }
     return;
 }
@@ -3374,142 +3373,38 @@ sub linkpopulate {
     $linklistbox->yviewScroll( -1, 'units' );
 }
 
+#
+# Convert ordinal to a named or number HTML entity
 sub entity {
-    my $char       = shift;
-    my %markuphash = (
-        '\x80' => '&#8364;',
-        '\x81' => '&#129;',
-        '\x82' => '&#8218;',
-        '\x83' => '&#402;',
-        '\x84' => '&#8222;',
-        '\x85' => '&#8230;',
-        '\x86' => '&#8224;',
-        '\x87' => '&#8225;',
-        '\x88' => '&#710;',
-        '\x89' => '&#8240;',
-        '\x8a' => '&#352;',
-        '\x8b' => '&#8249;',
-        '\x8c' => '&#338;',
-        '\x8d' => '&#141;',
-        '\x8e' => '&#381;',
-        '\x8f' => '&#143;',
-        '\x90' => '&#144;',
-        '\x91' => '&#8216;',
-        '\x92' => '&#8217;',
-        '\x93' => '&#8220;',
-        '\x94' => '&#8221;',
-        '\x95' => '&#8226;',
-        '\x96' => '&#8211;',
-        '\x97' => '&#8212;',
-        '\x98' => '&#732;',
-        '\x99' => '&#8482;',
-        '\x9a' => '&#353;',
-        '\x9b' => '&#8250;',
-        '\x9c' => '&#339;',
-        '\x9d' => '&#157;',
-        '\x9e' => '&#382;',
-        '\x9f' => '&#376;',
-        '\xa0' => '&nbsp;',
-        '\xa1' => '&iexcl;',
-        '\xa2' => '&cent;',
-        '\xa3' => '&pound;',
-        '\xa4' => '&curren;',
-        '\xa5' => '&yen;',
-        '\xa6' => '&brvbar;',
-        '\xa7' => '&sect;',
-        '\xa8' => '&uml;',
-        '\xa9' => '&textcopy;',
-        '\xaa' => '&ordf;',
-        '\xab' => '&laquo;',
-        '\xac' => '&not;',
-        '\xad' => '&shy;',
-        '\xae' => '&reg;',
-        '\xaf' => '&macr;',
-        '\xb0' => '&deg;',
-        '\xb1' => '&plusmn;',
-        '\xb2' => '&sup2;',
-        '\xb3' => '&sup3;',
-        '\xb4' => '&acute;',
-        '\xb5' => '&micro;',
-        '\xb6' => '&para;',
-        '\xb7' => '&middot;',
-        '\xb8' => '&cedil;',
-        '\xb9' => '&sup1;',
-        '\xba' => '&ordm;',
-        '\xbb' => '&raquo;',
-        '\xbc' => '&frac14;',
-        '\xbd' => '&frac12;',
-        '\xbe' => '&frac34;',
-        '\xbf' => '&iquest;',
-        '\xc0' => '&Agrave;',
-        '\xc1' => '&Aacute;',
-        '\xc2' => '&Acirc;',
-        '\xc3' => '&Atilde;',
-        '\xc4' => '&Auml;',
-        '\xc5' => '&Aring;',
-        '\xc6' => '&AElig;',
-        '\xc7' => '&Ccedil;',
-        '\xc8' => '&Egrave;',
-        '\xc9' => '&Eacute;',
-        '\xca' => '&Ecirc;',
-        '\xcb' => '&Euml;',
-        '\xcc' => '&Igrave;',
-        '\xcd' => '&Iacute;',
-        '\xce' => '&Icirc;',
-        '\xcf' => '&Iuml;',
-        '\xd0' => '&ETH;',
-        '\xd1' => '&Ntilde;',
-        '\xd2' => '&Ograve;',
-        '\xd3' => '&Oacute;',
-        '\xd4' => '&Ocirc;',
-        '\xd5' => '&Otilde;',
-        '\xd6' => '&Ouml;',
-        '\xd7' => '&times;',
-        '\xd8' => '&Oslash;',
-        '\xd9' => '&Ugrave;',
-        '\xda' => '&Uacute;',
-        '\xdb' => '&Ucirc;',
-        '\xdc' => '&Uuml;',
-        '\xdd' => '&Yacute;',
-        '\xde' => '&THORN;',
-        '\xdf' => '&szlig;',
-        '\xe0' => '&agrave;',
-        '\xe1' => '&aacute;',
-        '\xe2' => '&acirc;',
-        '\xe3' => '&atilde;',
-        '\xe4' => '&auml;',
-        '\xe5' => '&aring;',
-        '\xe6' => '&aelig;',
-        '\xe7' => '&ccedil;',
-        '\xe8' => '&egrave;',
-        '\xe9' => '&eacute;',
-        '\xea' => '&ecirc;',
-        '\xeb' => '&euml;',
-        '\xec' => '&igrave;',
-        '\xed' => '&iacute;',
-        '\xee' => '&icirc;',
-        '\xef' => '&iuml;',
-        '\xf0' => '&eth;',
-        '\xf1' => '&ntilde;',
-        '\xf2' => '&ograve;',
-        '\xf3' => '&oacute;',
-        '\xf4' => '&ocirc;',
-        '\xf5' => '&otilde;',
-        '\xf6' => '&ouml;',
-        '\xf7' => '&divide;',
-        '\xf8' => '&oslash;',
-        '\xf9' => '&ugrave;',
-        '\xfa' => '&uacute;',
-        '\xfb' => '&ucirc;',
-        '\xfc' => '&uuml;',
-        '\xfd' => '&yacute;',
-        '\xfe' => '&thorn;',
-        '\xff' => '&yuml;',
+    my $ord      = shift;
+    my @entities = (
+        '&#8364;',  '&#129;',   '&#8218;',  '&#402;',   '&#8222;',  '&#8230;',
+        '&#8224;',  '&#8225;',  '&#710;',   '&#8240;',  '&#352;',   '&#8249;',
+        '&#338;',   '&#141;',   '&#381;',   '&#143;',   '&#144;',   '&#8216;',
+        '&#8217;',  '&#8220;',  '&#8221;',  '&#8226;',  '&#8211;',  '&#8212;',
+        '&#732;',   '&#8482;',  '&#353;',   '&#8250;',  '&#339;',   '&#157;',
+        '&#382;',   '&#376;',   '&nbsp;',   '&iexcl;',  '&cent;',   '&pound;',
+        '&curren;', '&yen;',    '&brvbar;', '&sect;',   '&uml;',    '&textcopy;',
+        '&ordf;',   '&laquo;',  '&not;',    '&shy;',    '&reg;',    '&macr;',
+        '&deg;',    '&plusmn;', '&sup2;',   '&sup3;',   '&acute;',  '&micro;',
+        '&para;',   '&middot;', '&cedil;',  '&sup1;',   '&ordm;',   '&raquo;',
+        '&frac14;', '&frac12;', '&frac34;', '&iquest;', '&Agrave;', '&Aacute;',
+        '&Acirc;',  '&Atilde;', '&Auml;',   '&Aring;',  '&AElig;',  '&Ccedil;',
+        '&Egrave;', '&Eacute;', '&Ecirc;',  '&Euml;',   '&Igrave;', '&Iacute;',
+        '&Icirc;',  '&Iuml;',   '&ETH;',    '&Ntilde;', '&Ograve;', '&Oacute;',
+        '&Ocirc;',  '&Otilde;', '&Ouml;',   '&times;',  '&Oslash;', '&Ugrave;',
+        '&Uacute;', '&Ucirc;',  '&Uuml;',   '&Yacute;', '&THORN;',  '&szlig;',
+        '&agrave;', '&aacute;', '&acirc;',  '&atilde;', '&auml;',   '&aring;',
+        '&aelig;',  '&ccedil;', '&egrave;', '&eacute;', '&ecirc;',  '&euml;',
+        '&igrave;', '&iacute;', '&icirc;',  '&iuml;',   '&eth;',    '&ntilde;',
+        '&ograve;', '&oacute;', '&ocirc;',  '&otilde;', '&ouml;',   '&divide;',
+        '&oslash;', '&ugrave;', '&uacute;', '&ucirc;',  '&uuml;',   '&yacute;',
+        '&thorn;',  '&yuml;',
     );
-    my %pukramhash = reverse %markuphash;
-    return $markuphash{$char} if $markuphash{$char};
-    return $pukramhash{$char} if $pukramhash{$char};
-    return $char;
+    return $entities[ $ord - 128 ] if $ord >= 128 and $ord <= 255;
+
+    # If we don't have an HTML name, return the number form
+    return '&#' . $ord . ';';
 }
 
 sub named {
@@ -3554,11 +3449,9 @@ sub fromnamed {
         ::named( '&mdash;', '--', $start, 'srchend' );
         ::named( ' &gt;',   ' >', $start, 'srchend' );
         ::named( '&lt; ',   '< ', $start, 'srchend' );
-        my $from;
 
         for ( 160 .. 255 ) {
-            $from = lc sprintf( "%x", $_ );
-            ::named( ::entity( '\x' . $from ), chr($_), $start, 'srchend' );
+            ::named( ::entity($_), chr($_), $start, 'srchend' );
         }
         while (
             $thisblockstart = $textwindow->search(
@@ -3599,11 +3492,9 @@ sub tonamed {
         ::named( '&c\.',                 '&amp;c.', $start, 'srchend' );
         ::named( ' >',                   ' &gt;',   $start, 'srchend' );
         ::named( '< ',                   '&lt; ',   $start, 'srchend' );
-        my $from;
 
         for ( 128 .. 255 ) {
-            $from = lc sprintf( "%x", $_ );
-            ::named( '\x' . $from, ::entity( '\x' . $from ), $start, 'srchend' );
+            ::named( chr($_), ::entity($_), $start, 'srchend' );
         }
         while ( $thisblockstart =
             $textwindow->search( '-regexp', '--', '[\x{100}-\x{65535}]', $start, 'srchend' ) ) {

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -2997,7 +2997,7 @@ sub makeanchor {
         my $phrase   = charnames::viacode($ord);
         my $case     = 'lc';
         my $notlatin = 1;
-        $phrase   = '-X-' unless ( $phrase =~ /(LETTER|DIGIT|LIGATURE)/ );
+        $phrase   = '-X-' unless ( $phrase and $phrase =~ /(LETTER|DIGIT|LIGATURE)/ );
         $case     = 'uc' if $phrase =~ /CAPITAL|^-X-$/;
         $notlatin = 0 if $phrase =~ /LATIN/;
         $phrase =~ s/.+(LETTER|DIGIT|LIGATURE) //;

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -2569,6 +2569,8 @@ sub markupconfig {
 
     markupconfiglabel( $w, $typ );                  # Adjust label to show presence of class/attributes
 
+    ::savesettings();                               # Ensure new definition gets saved in setting file
+
     # stop class callback being called - possible due to binding reordering in markupbindconfig
     $w->break;
 }

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -447,7 +447,7 @@ sub menu_tools_charactertools {
             -command => \&::cp1252toUni
         ],
         [ 'command',   'Search for ~Transliterations...', -command => \&::find_transliterations ],
-        [ 'command',   '~Latin-1 Chart',                  -command => \&::latinpopup ],
+        [ 'command',   'Common~ly-Used Characters Chart', -command => \&::commoncharspopup ],
         [ 'command',   'Unicode Character ~Entry',        -command => \&::utfcharentrypopup ],
         [ 'command',   'Unicode Character ~Search',       -command => \&::utfcharsearchpopup ],
         [ 'separator', '' ],
@@ -681,9 +681,9 @@ sub menu_unicode {
 sub menu_unicode_break {
     my $block = shift;
     if ( $::lglobal{utfrangesort} ) {
-        return ( $block eq 'Sinhala' or $block eq 'Miscellaneous Technical' ) ? 1 : 0;
+        return ( $block eq 'Malayalam' or $block eq 'Mathematical Operators' ) ? 1 : 0;
     } else {
-        return ( $block eq 'Ethiopic' or $block eq 'Mongolian' ) ? 1 : 0;
+        return ( $block eq 'Ethiopic' or $block eq 'Miscellaneous Technical' ) ? 1 : 0;
     }
 }
 

--- a/src/lib/Guiguts/Tests.pm
+++ b/src/lib/Guiguts/Tests.pm
@@ -32,7 +32,7 @@ sub runtests {
         "deaccentdisplay('ÀÁÂÃÄÅàáâãäåÇçÈÉÊËèéêëÌÍÎÏìíîïÒÓÔÕÖØòóôõöøÑñÙÚÛÜùúûüİÿı')"
     );
 
-    ok( ( ::entity('\xff') eq '&yuml;' ), "entity('\\xff') eq '&yuml;'" );
+    ok( ( ::entity(255) eq '&yuml;' ), "entity(255) eq '&yuml;'" );
 
     ok( $::debug == 0, "Do not release with \$debug = 1" );
 

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -673,6 +673,7 @@ sub initialize {
     $::geometryhash{alignpop}         = '+338+83'         unless $::geometryhash{alignpop};
     $::geometryhash{asciiboxpop}      = '+358+187'        unless $::geometryhash{asciiboxpop};
     $::positionhash{brkpop}           = '+482+131'        unless $::positionhash{brkpop};
+    $::positionhash{comcharspop}      = '+10+10'          unless $::positionhash{comcharspop};
     $::positionhash{defurlspop}       = '+150+150'        unless $::positionhash{defurlspop};
     $::geometryhash{elinkpop}         = '330x110+150+120' unless $::geometryhash{elinkpop};
     $::geometryhash{errorcheckpop}    = '+484+72'         unless $::geometryhash{errorcheckpop};
@@ -696,7 +697,6 @@ sub initialize {
     $::positionhash{htmlgenpop}       = '+145+37'         unless $::positionhash{htmlgenpop};
     $::positionhash{htmlimpop}        = '+45+37'          unless $::positionhash{htmlimpop};
     $::positionhash{intervalpop}      = '+300+137'        unless $::positionhash{intervalpop};
-    $::positionhash{latinpop}         = '+10+10'          unless $::positionhash{latinpop};
     $::geometryhash{linkpop}          = '+224+72'         unless $::geometryhash{linkpop};
     $::positionhash{marginspop}       = '+145+137'        unless $::positionhash{marginspop};
     $::positionhash{markpop}          = '+140+93'         unless $::positionhash{markpop};
@@ -725,14 +725,17 @@ sub initialize {
 
     # manualhash stores subpage of manual for each dialog
     # Where dialog is used in several contexts, use 'dialogname+context' as key
-    $::manualhash{'aboutpop'}                = '#Overview';
-    $::manualhash{'alignpop'}                = '/Guiguts_1.1_Text_Menu#Align_text_on_string';
-    $::manualhash{'asciiboxpop'}             = '/Guiguts_1.1_Text_Menu#Draw_ASCII_Boxes';
-    $::manualhash{'brkpop'}                  = '/Guiguts_1.1_Tools_Menu#Check_Orphaned_Brackets';
-    $::manualhash{'defurlspop'}              = '/Guiguts_1.1_Preferences_Menu#File_Paths';
-    $::manualhash{'elinkpop'}                = '/Guiguts_1.1_HTML#The_HTML_Markup_Dialog';
-    $::manualhash{'errorcheckpop+Bookloupe'} = '/Guiguts_1.1_Tools_Menu#Bookloupe';
-    $::manualhash{'errorcheckpop+Jeebies'}   = '/Guiguts_1.1_Tools_Menu#Jeebies';
+    $::manualhash{'aboutpop'}    = '#Overview';
+    $::manualhash{'alignpop'}    = '/Guiguts_1.1_Text_Menu#Align_text_on_string';
+    $::manualhash{'asciiboxpop'} = '/Guiguts_1.1_Text_Menu#Draw_ASCII_Boxes';
+    $::manualhash{'brkpop'}      = '/Guiguts_1.1_Tools_Menu#Check_Orphaned_Brackets';
+    $::manualhash{'comcharspop'} = '/Guiguts_1.1_Unicode_Menu#The_Commonly-Used_Characters_Dialog';
+    $::manualhash{'comcharsconfigpop'} =
+      '/Guiguts_1.1_Unicode_Menu#The_Commonly-Used_Characters_Dialog';
+    $::manualhash{'defurlspop'}                   = '/Guiguts_1.1_Preferences_Menu#File_Paths';
+    $::manualhash{'elinkpop'}                     = '/Guiguts_1.1_HTML#The_HTML_Markup_Dialog';
+    $::manualhash{'errorcheckpop+Bookloupe'}      = '/Guiguts_1.1_Tools_Menu#Bookloupe';
+    $::manualhash{'errorcheckpop+Jeebies'}        = '/Guiguts_1.1_Tools_Menu#Jeebies';
     $::manualhash{'errorcheckpop+Load Checkfile'} = '/Guiguts_1.1_Tools_Menu#Load_Checkfile';
     $::manualhash{'errorcheckpop+pptxt'}          = '/Guiguts_1.1_Text_Menu#PPtxt';
     $::manualhash{'errorcheckpop+W3C Validate Remote'} =
@@ -766,19 +769,19 @@ sub initialize {
     $::manualhash{'hpopup'}           = '/Guiguts_1.1_Tools_Menu#Harmonic_Searches';
     $::manualhash{'htmlgenpop'} = '/Guiguts_1.1_HTML#Convert_the_text_to_HTML_.28HTML_Generator.29';
     $::manualhash{'htmlimpop'}  = '/Guiguts_1.1_HTML#Add_Illustrations';
-    $::manualhash{'intervalpop'}    = '/Guiguts_1.1_Preferences_Menu#Backup';
-    $::manualhash{'latinpop'}       = '/Guiguts_1.1_Unicode_Menu#The_Latin-1_Dialog';
-    $::manualhash{'linkpop'}        = '/Guiguts_1.1_HTML#The_HTML_Markup_Dialog';
-    $::manualhash{'marginspop'}     = '/Guiguts_1.1_Preferences_Menu#Processing';
-    $::manualhash{'markpop'}        = '/Guiguts_1.1_HTML#The_HTML_Markup_Dialog';
-    $::manualhash{'markuppop'}      = '/Guiguts_1.1_Tools_Menu#Word_Frequency';
-    $::manualhash{'multispellpop'}  = '/Guiguts_1.1_Tools_Menu#Spell_Check_in_Multiple_Languages';
-    $::manualhash{'oppop'}          = '/Guiguts_1.1_File_Menu#View_Operations_History';
-    $::manualhash{'pagelabelpop'}   = '/Guiguts_1.1_File_Menu#Configure_Page_Labels';
-    $::manualhash{'pagemarkerpop'}  = '/Guiguts_1.1_File_Menu#Display.2FAdjust_Page_Markers';
-    $::manualhash{'pagesephelppop'} = '/Guiguts_1.1_Tools_Menu#Fixup_Page_Separators';
-    $::manualhash{'pageseppop'}     = '/Guiguts_1.1_Tools_Menu#Fixup_Page_Separators';
-    $::manualhash{'regexrefpop'}    = '/Guiguts_1.1_Searching#Regular_Expressions';
+    $::manualhash{'intervalpop'}     = '/Guiguts_1.1_Preferences_Menu#Backup';
+    $::manualhash{'linkpop'}         = '/Guiguts_1.1_HTML#The_HTML_Markup_Dialog';
+    $::manualhash{'marginspop'}      = '/Guiguts_1.1_Preferences_Menu#Processing';
+    $::manualhash{'markpop'}         = '/Guiguts_1.1_HTML#The_HTML_Markup_Dialog';
+    $::manualhash{'markupconfigpop'} = '/Guiguts_1.1_HTML#The_HTML_Markup_Dialog';
+    $::manualhash{'markuppop'}       = '/Guiguts_1.1_Tools_Menu#Word_Frequency';
+    $::manualhash{'multispellpop'}   = '/Guiguts_1.1_Tools_Menu#Spell_Check_in_Multiple_Languages';
+    $::manualhash{'oppop'}           = '/Guiguts_1.1_File_Menu#View_Operations_History';
+    $::manualhash{'pagelabelpop'}    = '/Guiguts_1.1_File_Menu#Configure_Page_Labels';
+    $::manualhash{'pagemarkerpop'}   = '/Guiguts_1.1_File_Menu#Display.2FAdjust_Page_Markers';
+    $::manualhash{'pagesephelppop'}  = '/Guiguts_1.1_Tools_Menu#Fixup_Page_Separators';
+    $::manualhash{'pageseppop'}      = '/Guiguts_1.1_Tools_Menu#Fixup_Page_Separators';
+    $::manualhash{'regexrefpop'}     = '/Guiguts_1.1_Searching#Regular_Expressions';
     $::manualhash{'searchpop+scannos'} = '/Guiguts_1.1_Tools_Menu#Stealth_Scannos';
     $::manualhash{'searchpop+search'}  = '/Guiguts_1.1_Searching#The_Search_Dialog';
     $::manualhash{'selectionpop'}      = '/Guiguts_1.1_Edit_Menu#Selection_Dialog';
@@ -1116,6 +1119,7 @@ sub initialize {
         'Latin Extended-A'          => [ '0100', '017F' ],
         'Latin Extended-B'          => [ '0180', '024F' ],
         'Latin IPA Extensions'      => [ '0250', '02AF' ],
+        'Latin-1 Supplement'        => [ '00A0', '00FF' ],
         'Letterlike Symbols'        => [ '2100', '214F' ],
 
         #'Limbu' => ['1900', '194F'],
@@ -2287,10 +2291,10 @@ sub toolbar_toggle {
         );
         $::lglobal{toptool}->separator;
         $::lglobal{toptool}->ToolButton(
-            -text    => 'Ltn-1',
+            -text    => 'Common',
             -font    => $::lglobal{toolfont},
-            -command => [ \&::latinpopup ],
-            -tip     => 'Latin-1 Popup'
+            -command => [ \&::commoncharspopup ],
+            -tip     => 'Commonly-Used Characters Chart'
         );
         $::lglobal{toptool}->ToolButton(
             -text    => 'Grk',


### PR DESCRIPTION
Since books are not generally Latin-1, more helpful to PPers to have common
characters, such as curly quotes, fractions, emdashes, etc., available in a chart.
1. Replace Latin-1 chart with Common Characters Chart
2. Mouse-3 copies to clipboard, like the Unicode Chart does
3. Spare buttons at the end are left blank (actually a space) which the user can
configure with Ctrl-Mouse-1
4. Config dialog accepts a single character, or a decimal ordinal, or a hex ordinal.
Prefix the hex ordinal with `0x`, `\x` or `x`, or if it has letters [a-f] in it, then prefix
may be omitted. For any other character string, just take the first character.
5. User-defined characters are stored between runs of the program, and in dialog
is upgraded in a future release, they should be preserved to fit into any unused
spaced in the new version.
6. Make a couple of helper functions common between new dialog and Unicode
dialog