### PR TITLE
Improve Unicode Character Entry dialog

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -179,6 +179,7 @@ our $txtfontsize           = 10;
 our $txtfontweight         = 'normal';
 our $txtfontsystemuse      = 1;               # Default to use system font
 our $twowordsinhyphencheck = 0;
+our $utfcharentrybase      = 'dec';           # 'dec' or 'hex' allowed
 our $utffontname           = 'Courier New';
 our $utffontsize           = 14;
 our $utffontweight         = 'normal';

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -873,7 +873,7 @@ EOM
             recentfile_size rmargin rmargindiff rwhyphenspace sc_char scannos_highlighted spellcheckwithenchant stayontop toolside
             trackoperations txt_conv_bold txt_conv_font txt_conv_gesperrt txt_conv_italic txt_conv_sc txt_conv_tb
             txtfontname txtfontsize txtfontweight txtfontsystemuse
-            twowordsinhyphencheck utf8save utffontname utffontsize utffontweight
+            twowordsinhyphencheck utf8save utfcharentrybase utffontname utffontsize utffontweight
             urlprojectpage urlprojectdiscussion
             verboseerrorchecks vislnnm w3cremote wfstayontop/
         ) {

--- a/src/lib/Guiguts/StatusBar.pm
+++ b/src/lib/Guiguts/StatusBar.pm
@@ -274,12 +274,16 @@ AAAAACH5BAAAAAAALAAAAAAMAAwAAwQfMMg5BaDYXiw178AlcJ6VhYFXoSoosm7KvrR8zfXHRQA7
             }
         }
     );
+
+    # Ordinal label
     $::lglobal{ordinallabel} = $::counter_frame->Label(
         -text       => '',
         -relief     => 'ridge',
         -background => 'gray',
         -anchor     => 'w',
     )->grid( -row => 1, -column => 10 );
+
+    # Left-click to toggle display of character's Unicode name
     $::lglobal{ordinallabel}->bind(
         '<1>',
         sub {
@@ -287,6 +291,10 @@ AAAAACH5BAAAAAAALAAAAAAMAAwAAwQfMMg5BaDYXiw178AlcJ6VhYFXoSoosm7KvrR8zfXHRQA7
             ::togglelongordlabel();
         }
     );
+
+    # Right-click to pop the Unicode Character Entry dialog
+    $::lglobal{ordinallabel}->bind( '<3>', sub { ::utfcharentrypopup(); } );
+
     _butbind($_)
       for (
         $::lglobal{insert_overstrike_mode_label}, $::lglobal{current_line_label},


### PR DESCRIPTION
1. Allow it to be popped by right clicking status bar ordinal label
2. Remember if entering via decimal or hex ordinal between uses and between runs
of the program
3. When popped, display previously used ordinal from this run of the program,
highlighted so user can just type over to enter a different character, or press Enter
to insert the same character
4. Allow Escape key to dismiss the dialog

#Fixes #134 