### PR TITLE
Save word count threshold for marked up phrases

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -868,7 +868,7 @@ EOM
             blocklmargin blockrmargin bold_char cssvalidationlevel defaultindent donotcenterpagemarkers epubpercentoverride failedsearch
             font_char fontname fontsize fontweight geometry
             gesperrt_char globalaspellmode highlightcolor history_size ignoreversionnumber
-            intelligentWF ignoreversions italic_char jeebiesmode lastversioncheck lastversionrun lmargin
+            intelligentWF ignoreversions italic_char jeebiesmode lastversioncheck lastversionrun lmargin markupthreshold
             multisearchsize multiterm nobell nohighlights projectfileslocation notoolbar oldspellchecklayout poetrylmargin projectfileslocation
             recentfile_size rmargin rmargindiff rwhyphenspace sc_char scannos_highlighted spellcheckwithenchant stayontop toolside
             trackoperations txt_conv_bold txt_conv_font txt_conv_gesperrt txt_conv_italic txt_conv_sc txt_conv_tb

--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -300,7 +300,7 @@ sub footnotepop {
         $::lglobal{fnmvinlinebutton} = $frame7->Button(
             -activebackground => $::activecolor,
             -command          => sub { footnotemoveinline() },
-            -text             => 'Move FNs to Para (beta)',
+            -text             => 'Move FNs to Para',
             -state            => 'disabled',
             -width            => 30
         )->grid( -row => 2, -column => 2, -padx => 3, -pady => 4 );

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -958,7 +958,14 @@ sub menu_preferences_processing {
             -offvalue   => 0
         ],
         [
-            Checkbutton => "Include Two Words ('flash light') in WF Hyphen Check (beta)",
+            'command',
+            'Set Threshold Word Count for Marked Up Phrases...',
+            -command => sub {
+                ::ital_adjust();
+            }
+        ],
+        [
+            Checkbutton => "Include Two Words ('flash light') in WF Hyphen Check",
             -variable   => \$::twowordsinhyphencheck,
             -onvalue    => 1,
             -offvalue   => 0


### PR DESCRIPTION
In the Word Frequency dialog, the Ital/Bold/SC button checks for the same phrase
occurring with and without markup. A configuration dialog is also popped that sets
the maximum number of words in such a phrase. Previously this was set to 4 on each
run of the program. Now save the value in the setting.rc file. Also, consider 0 to mean
no limit, rather than a limit of zero words which is not useful.

Also allow config dialog to be popped from the Prefs menu where other preferences
are set, and remove a couple of "beta" labels on menu options, since they have been
in "beta" for 10 years.

Fixes #112