### PR TITLE
Implement a form of Compose Key for Unicode characters

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -114,11 +114,12 @@ our $blockrmargin     = 72;
 our $poetrylmargin    = 4;
 our $blockwrap;
 our $booklang          = 'en';
-our $composepopbinding = 'Alt_R';    # Default key to pop the Compose dialog
-our %composehash;                    # Keystrokes to insert character
-our $cssvalidationlevel  = 'css3';          # CSS level checked by validator (css3 or css21)
+our $composepopbinding = 'Alt_R';    # Default key to pop the Compose dialog (Right hand Alt key, also labelled AltGr)
+$composepopbinding = 'Control-m' if $OS_MAC;    # Default to Ctrl+m on a Mac - Alt+RightArrow does the same indent operation
+our %composehash;                               # Keystrokes to insert character
+our $cssvalidationlevel  = 'css3';              # CSS level checked by validator (css3 or css21)
 our $defaultindent       = 2;
-our $epubpercentoverride = 1;               # True = override % img widths to 100% for epubs
+our $epubpercentoverride = 1;                   # True = override % img widths to 100% for epubs
 our $failedsearch        = 0;
 our $fontname            = 'Courier New';
 our $fontsize            = 10;

--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -113,7 +113,9 @@ our $blocklmargin     = 1;
 our $blockrmargin     = 72;
 our $poetrylmargin    = 4;
 our $blockwrap;
-our $booklang            = 'en';
+our $booklang          = 'en';
+our $composepopbinding = 'Alt_R';    # Default key to pop the Compose dialog
+our %composehash;                    # Keystrokes to insert character
 our $cssvalidationlevel  = 'css3';          # CSS level checked by validator (css3 or css21)
 our $defaultindent       = 2;
 our $epubpercentoverride = 1;               # True = override % img widths to 100% for epubs

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -865,7 +865,8 @@ EOM
         # otherwise we can't have a default value of 1 without overwriting the user's setting
         for (
             qw/alpha_sort activecolor auto_page_marks auto_show_images autobackup autosave autosaveinterval bkgcolor
-            blocklmargin blockrmargin bold_char cssvalidationlevel defaultindent donotcenterpagemarkers epubpercentoverride failedsearch
+            blocklmargin blockrmargin bold_char composepopbinding cssvalidationlevel
+            defaultindent donotcenterpagemarkers epubpercentoverride failedsearch
             font_char fontname fontsize fontweight geometry
             gesperrt_char globalaspellmode highlightcolor history_size ignoreversionnumber
             intelligentWF ignoreversions italic_char jeebiesmode lastversioncheck lastversionrun lmargin

--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -237,9 +237,6 @@ sub keybindings {
     # Help
     keybind( '<Control-Alt-r>', sub { ::regexref(); } );
 
-    # Compose
-    keybind( "<$::composepopbinding>", sub { ::composepopup(); } );
-
     # Mouse
     keybind( '<Shift-B1-Motion>', sub { $textwindow->shiftB1_Motion(@_); } );
     keybind( '<ButtonRelease-2>', sub { ::popscroll() unless $Tk::mouseMoved } );
@@ -285,6 +282,9 @@ sub keybindings {
     keybind( '<Control-KeyPress-4>',           sub { ::gotobookmark('4'); } );
     keybind( '<Control-KeyPress-5>',           sub { ::gotobookmark('5'); } );
 
+    # Compose - define last since user could set the compose key to one of the above that they never use
+    keybind( "<$::composepopbinding>", sub { ::composepopup(); } );
+
     # Override Paste binding, so that Entry widgets delete any selected text
     # in the field, just like happens in the main textwindow
     # Note that for this to work, a dummy Entry is created in initialize() routine previously,
@@ -325,6 +325,7 @@ sub keybind {
     my $subr       = shift;           # Subroutine to bind to key/event
     my $event      = shift;           # Optional event argument
 
+    $lkey =~ s/-([A-Z])>/-\l$1>/;     # Ensure key letter is lowercase
     my $ukey = $lkey;
     $ukey =~ s/-([a-z])>/-\u$1>/;     # Create uppercase version
 

--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -237,6 +237,9 @@ sub keybindings {
     # Help
     keybind( '<Control-Alt-r>', sub { ::regexref(); } );
 
+    # Compose
+    keybind( "<$::composepopbinding>", sub { ::composepopup(); } );
+
     # Mouse
     keybind( '<Shift-B1-Motion>', sub { $textwindow->shiftB1_Motion(@_); } );
     keybind( '<ButtonRelease-2>', sub { ::popscroll() unless $Tk::mouseMoved } );

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -516,7 +516,7 @@ sub menu_txt {
         [
             'command',
             'Indent Selection ~1',
-            -accelerator => 'Ctrl+m',
+            -accelerator => "Alt\x{2192},Ctrl+m",
             -command     => sub {
                 ::indent( $textwindow, 'in' );
             }
@@ -534,7 +534,7 @@ sub menu_txt {
         [
             'command',
             'In~dent Selection -1',
-            -accelerator => 'Ctrl+Shift+m',
+            -accelerator => "Alt\x{2190},Ctrl+Shift+m",
             -command     => sub {
                 ::indent( $textwindow, 'out' );
             }

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -1020,6 +1020,7 @@ sub menu_help {
         ],
         [ 'command',   '~Keyboard Shortcuts',    -command => \&::hotkeyshelp ],
         [ 'command',   '~Regex Quick Reference', -command => \&::regexref ],
+        [ 'command',   '~Compose Sequences',     -command => \&::composeref ],
         [ 'separator', '' ],
         [
             'command',

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1386,6 +1386,10 @@ sub searchpopup {
                 countmatches( $::lglobal{searchentry}->get );
             }
         );
+
+        # Compose
+        searchbind( "<$::composepopbinding>", sub { ::composepopup(); } );
+
         $::lglobal{searchentry}->{_MENU_}  = ();
         $::lglobal{replaceentry}->{_MENU_} = ();
         $::lglobal{searchentry}->bind(

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -674,6 +674,8 @@ sub initialize {
     $::geometryhash{asciiboxpop}      = '+358+187'        unless $::geometryhash{asciiboxpop};
     $::positionhash{brkpop}           = '+482+131'        unless $::positionhash{brkpop};
     $::positionhash{comcharspop}      = '+10+10'          unless $::positionhash{comcharspop};
+    $::positionhash{composepop}       = '+100+10'         unless $::positionhash{composepop};
+    $::geometryhash{composerefpop}    = '+300+72'         unless $::geometryhash{composerefpop};
     $::positionhash{defurlspop}       = '+150+150'        unless $::positionhash{defurlspop};
     $::geometryhash{elinkpop}         = '330x110+150+120' unless $::geometryhash{elinkpop};
     $::geometryhash{errorcheckpop}    = '+484+72'         unless $::geometryhash{errorcheckpop};
@@ -733,6 +735,8 @@ sub initialize {
     $::manualhash{'comcharspop'} = '/Guiguts_1.1_Unicode_Menu#The_Commonly-Used_Characters_Dialog';
     $::manualhash{'comcharsconfigpop'} =
       '/Guiguts_1.1_Unicode_Menu#The_Commonly-Used_Characters_Dialog';
+    $::manualhash{'composepop'}                   = '/Guiguts_1.1_Unicode_Menu#Compose_Character';
+    $::manualhash{'composerefpop'}                = '/Guiguts_1.1_Unicode_Menu#Compose_Character';
     $::manualhash{'defurlspop'}                   = '/Guiguts_1.1_Preferences_Menu#File_Paths';
     $::manualhash{'elinkpop'}                     = '/Guiguts_1.1_HTML#The_HTML_Markup_Dialog';
     $::manualhash{'errorcheckpop+Bookloupe'}      = '/Guiguts_1.1_Tools_Menu#Bookloupe';
@@ -800,6 +804,8 @@ sub initialize {
       '/Guiguts_1.1_Help_Menu#Guiguts_HELP_Menu:_Online_and_Built-in_Help';
     $::manualhash{'wfpop'}   = '/Guiguts_1.1_Tools_Menu#Word_Frequency';
     $::manualhash{'workpop'} = '#Overview';
+
+    ::composeinitialize();
 
     ::readsettings();
 


### PR DESCRIPTION
1. Default key is the Right Alt key (marked alt gr on some keyboards). At present there
is no UI to alter this, although you could manually edit the composepopbinding entry
in setting.rc
2. Once Compose key is pressed, small dialog appears and subsequent keys pressed
appear in an entry field.
3. If the keys match a defined sequence, the dialog disappears and the character
composed is entered into the main text window, search dialog field, etc.
4. Sequences are defined for most characters in the Commonly Used Characters
dialog.
5. In addition, the user can type 4 hex digits (optionally preceded by `U+, \x, 0x or x`)
which will be interpreted instantly as a hex ordinal and the character inserted
6. Alternatively, the user can type fewer than 4 hex digits, or can type # followed by
decimal digits, then type Enter or click OK, and relevant character will be inserted.
7. If OK is clicked, but field does not contain valid sequence, the characters from the
fields are inserted
8. If Cancel (or Escape) are used, the dialog is dismissed without inserting characters.
9. In the Help menu, it is possible to pop a dialog with a list of defined sequences.
10. Issues have been entered for a UI to configure the Compose button (#380) and
also to add, edit and delete sequences (#381)

Fixes #143