### PR TITLE
Fix Greek dialog size issues

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -797,6 +797,9 @@ sub readsettings {
         }
     }
 
+    # Greek dialog previously had position but now needs geometry
+    delete $::positionhash{grpop} if $::positionhash{grpop};
+
     # If someone just upgraded, reset the update counter
     unless ( $::lastversionrun eq $::VERSION ) {
         $::lastversioncheck = time();

--- a/src/lib/Guiguts/Greek.pm
+++ b/src/lib/Guiguts/Greek.pm
@@ -410,7 +410,6 @@ sub greekpopup {
         -background => $::bkgcolor,
         -font       => 'unicode',
         -wrap       => 'none',
-        -setgrid    => 'true',
         -scrollbars => 'se',
     )->pack(
         -expand => 'yes',

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -688,7 +688,7 @@ sub initialize {
     $::positionhash{gotolinepop}      = '+400+400'        unless $::positionhash{gotolinepop};
     $::positionhash{gotopagpop}       = '+400+400'        unless $::positionhash{gotopagpop};
     $::geometryhash{gcviewoptspop}    = '+264+72'         unless $::geometryhash{gcviewoptspop};
-    $::positionhash{grpop}            = '+144+153'        unless $::positionhash{grpop};
+    $::geometryhash{grpop}            = '750x540+100+100' unless $::geometryhash{grpop};
     $::positionhash{guesspgmarkerpop} = '+10+10'          unless $::positionhash{guesspgmarkerpop};
     $::positionhash{hilitepop}        = '+150+150'        unless $::positionhash{hilitepop};
     $::positionhash{hintpop}          = '+150+150'        unless $::positionhash{hintpop};

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -688,7 +688,7 @@ sub initialize {
     $::positionhash{gotolinepop}      = '+400+400'        unless $::positionhash{gotolinepop};
     $::positionhash{gotopagpop}       = '+400+400'        unless $::positionhash{gotopagpop};
     $::geometryhash{gcviewoptspop}    = '+264+72'         unless $::geometryhash{gcviewoptspop};
-    $::geometryhash{grpop}            = '700x500+100+100' unless $::geometryhash{grpop};
+    $::positionhash{grpop}            = '+144+153'        unless $::positionhash{grpop};
     $::positionhash{guesspgmarkerpop} = '+10+10'          unless $::positionhash{guesspgmarkerpop};
     $::positionhash{hilitepop}        = '+150+150'        unless $::positionhash{hilitepop};
     $::positionhash{hintpop}          = '+150+150'        unless $::positionhash{hintpop};


### PR DESCRIPTION
1. Revert edit made in #362, which shouldn't have been necessary
2. Change Greek dialog size to be determined in the normal way, rather than being
sized (in characters) via the scrolled text it contains (-setgrid option)
3. Since no releases have been made between #362 and now, it is not necessary to
cope with a setting.rc that has a geometryhash entry for grpop.

Fixes #360 hopefully without breaking #362