### PR TITLE
Fix bad text index error during sidenote fixup

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2031,12 +2031,13 @@ sub sidenotes {
         $textwindow->markSet( 'sidenote', $bracketendndx );
         $paragraphp =
           $textwindow->search( '-backwards', '-regexp', '--', '^$', $bracketstartndx, '1.0' );
+        $paragraphp = $bracketstartndx if not $paragraphp;
         $paragraphn = $textwindow->search( '-regexp', '--', '^$', $bracketstartndx, 'end' );
         $sidenote   = $textwindow->get( $bracketstartndx, $bracketendndx );
         if ( $textwindow->get( "$bracketstartndx-2c", $bracketstartndx ) ne "\n\n" ) {
             if (   ( $textwindow->get( $bracketendndx, "$bracketendndx+1c" ) eq ' ' )
                 || ( $textwindow->get( $bracketendndx, "$bracketendndx+1c" ) eq "\n" ) ) {
-                $textwindow->delete( $bracketendndx, "" );
+                $textwindow->delete( $bracketendndx, "$bracketendndx+1c" );
             }
             $textwindow->delete( $bracketstartndx, $bracketendndx );
             $textwindow->see($bracketstartndx);


### PR DESCRIPTION
Looks like the end point of a delete was omitted, possibly always like this, but it
only executes if the sidenote doesn't have a blank line before it, which they generally
should have.
Additional safety check also added - only necessary if sidenote is on the first line of
the file.

Fixes #236