### PR TITLE
Fix error pasting certain unicode strings

### DIFF
--- a/src/lib/Guiguts/TextUnicode.pm
+++ b/src/lib/Guiguts/TextUnicode.pm
@@ -227,6 +227,11 @@ sub ReplaceSelectionsWith {
         $first = $w->index( 'mark_sel_' . $i );
         $last  = $w->index( 'mark_sel_' . ( $i + 1 ) );
 
+        # If whole file is selected, $last ends up at the start of the line after
+        # the last actual line, which results in part of the inserted string being deleted.
+        # Bug is in the original TextUndo version too
+        $last = $w->index( $last . ' -1c' ) if $w->compare( $last, '==', 'end' );
+
         # First pass through page markers to store length of old string
         # from start to each page marker in @lengths.
         # In reverse order to avoid a replace affecting positions for the next

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1675,7 +1675,14 @@ sub paste {
         $textwindow->delete( 'insert', 'insert +' . ($length) . 'c' );
         $textwindow->insert( 'insert', $text );
     } else {
-        $textwindow->clipboardPaste;
+
+        # $textwindow->clipboardPaste;
+        # In Text.pm, routine clipboardPaste fails to handle all unicode strings correctly,
+        # sometimes pasting them as garbage Latin-1 characters. clipboardPaste essentially
+        # consists of the line below, but with Tk::catch instead of eval (which is necessary
+        # to avoid error if nothing in clipboard), so something about Tk::catch or the
+        # local environment in that routine must be causing the issue.
+        eval { $textwindow->Insert( $textwindow->clipboardGet ); };
     }
 }
 


### PR DESCRIPTION
Fixes #179
Certain unicode Greek strings were pasted either correctly or as Latin-1 garbage
depending on apparently random minor changes such as whether a terminating
end of line character was included. Two newlines followed by a lowercase iota
failed, but with just one newline preceding the iota it succeeded.
The bug appeared to occur within Tk::Text::clipboardPaste, possibly to do with the
use of Tk::catch or local $@. If the equivalent code is used instead of a call to
clipboardPaste, all the unicode strings appear to paste correctly.

Also, fixed a minor bug when selecting all text in a file (via Ctrl+a) and then pasting
some new text. The old text was deleted, but the first line of the new text was lost.
This bug is in the original TextUndo::ReplaceSelectionsWith, and also in the
overridden version used in GG.