### PR TITLE
Stop bookloupe error messages reappearing

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -16,7 +16,7 @@ my @errorchecklines;
 # pphtml, pptxt and Load External Checkfile,
 sub errorcheckpop_up {
     my ( $textwindow, $top, $errorchecktype ) = @_;
-    my ( $line,       $lincol );
+    my ( $line, $lincol );
     ::hidepagenums();
 
     # Destroy and start afresh if already popped
@@ -749,7 +749,7 @@ sub gcwindowpopulate {
     my $headr = 0;
     my $error = 0;
     $::lglobal{errorchecklistbox}->delete( '0', 'end' );
-    foreach my $line ( @errorchecklines ) {
+    foreach my $line (@errorchecklines) {
         next if $line =~ /^\s*$/;    # Skip blank lines
         next unless defined $::errors{$line};
 
@@ -782,7 +782,7 @@ sub gcwindowpopulate {
 }
 
 sub gcviewopts {
-    my $top      = $::top;
+    my $top = $::top;
     my @gsoptions;
     my $gcrows = int( ( @{ $::lglobal{gcarray} } / 3 ) + .9 );
     if ( defined( $::lglobal{gcviewoptspop} ) ) {

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -9,12 +9,13 @@ BEGIN {
     @EXPORT = qw(&errorcheckpop_up);
 }
 
+my @errorchecklines;
+
 # General error check window
 # Handles Bookloupe, Jeebies, HTML & CSS Validate, Tidy, Link Check
 # pphtml, pptxt and Load External Checkfile,
 sub errorcheckpop_up {
     my ( $textwindow, $top, $errorchecktype ) = @_;
-    my ( %errors,     @errorchecklines );
     my ( $line,       $lincol );
     ::hidepagenums();
 
@@ -61,7 +62,7 @@ sub errorcheckpop_up {
     } elsif ( $errorchecktype eq 'Bookloupe' ) {
         $ptopframe->Button(
             -activebackground => $::activecolor,
-            -command          => sub { gcviewopts( \@errorchecklines ) },
+            -command          => sub { gcviewopts(); },
             -text             => 'View Options',
             -width            => 16
         )->pack(
@@ -142,7 +143,6 @@ sub errorcheckpop_up {
     $::lglobal{errorcheckpop}->update;
 
     # End presentation; begin logic
-    %errors          = ();
     @errorchecklines = ();
     my $mark  = 0;
     my @marks = $textwindow->markNames;
@@ -371,7 +371,7 @@ sub errorcheckpop_up {
 
     ::working();
     if ( $errorchecktype eq 'Bookloupe' ) {
-        gcwindowpopulate( \@errorchecklines );
+        gcwindowpopulate();
     } else {
         $::lglobal{errorchecklistbox}->insert( 'end', @errorchecklines );
     }
@@ -745,12 +745,11 @@ sub errorcheckview {
 }
 
 sub gcwindowpopulate {
-    my $linesref = shift;
     return unless defined $::lglobal{errorcheckpop};
     my $headr = 0;
     my $error = 0;
     $::lglobal{errorchecklistbox}->delete( '0', 'end' );
-    foreach my $line ( @{$linesref} ) {
+    foreach my $line ( @errorchecklines ) {
         next if $line =~ /^\s*$/;    # Skip blank lines
         next unless defined $::errors{$line};
 
@@ -783,7 +782,6 @@ sub gcwindowpopulate {
 }
 
 sub gcviewopts {
-    my $linesref = shift;
     my $top      = $::top;
     my @gsoptions;
     my $gcrows = int( ( @{ $::lglobal{gcarray} } / 3 ) + .9 );
@@ -804,7 +802,7 @@ sub gcviewopts {
             $::gsopt[$_]   = 0 unless defined $::gsopt[$_];
             $gsoptions[$_] = $pframe1->Checkbutton(
                 -variable    => \$::gsopt[$_],
-                -command     => sub { gcwindowpopulate($linesref) },
+                -command     => sub { gcwindowpopulate(); },
                 -selectcolor => $::lglobal{checkcolor},
                 -text        => $::lglobal{gcarray}->[$_],
             )->grid( -row => $gcrow, -column => $gccol, -sticky => 'nw' );
@@ -816,7 +814,7 @@ sub gcviewopts {
                 for ( 0 .. $#gsoptions ) {
                     $gsoptions[$_]->select;
                 }
-                gcwindowpopulate($linesref);
+                gcwindowpopulate();
             },
             -text  => 'Hide All',
             -width => 14
@@ -832,7 +830,7 @@ sub gcviewopts {
                 for ( 0 .. $#gsoptions ) {
                     $gsoptions[$_]->deselect;
                 }
-                gcwindowpopulate($linesref);
+                gcwindowpopulate();
             },
             -text  => 'See All',
             -width => 14
@@ -853,7 +851,7 @@ sub gcviewopts {
                             $gsoptions[$_]->deselect;
                         }
                     }
-                    gcwindowpopulate($linesref);
+                    gcwindowpopulate();
                 },
                 -text  => "Load View: '$::booklang'",
                 -width => 14
@@ -870,7 +868,7 @@ sub gcviewopts {
                     for ( 0 .. $#gsoptions ) {
                         $gsoptions[$_]->toggle;
                     }
-                    gcwindowpopulate($linesref);
+                    gcwindowpopulate();
                 },
                 -text  => 'Toggle View',
                 -width => 14
@@ -891,7 +889,7 @@ sub gcviewopts {
                         $gsoptions[$_]->deselect;
                     }
                 }
-                gcwindowpopulate($linesref);
+                gcwindowpopulate();
             },
             -text  => 'Load Defaults',
             -width => 14


### PR DESCRIPTION
When the View Options dialog is kept visible to show/hide error types, old error
messages can re-show depsite having been fixed and bookloupe rerun.
Caused by a reference to the error message array being passed into the View Options
routine, where it remains. When bookloupe is rerun recursively from the main dialog,
a new array is created with the new messsages, but when the View Options dialog
is adjusted it refreshes the screen with its out-of-date saved list of messages.

Fixed by making the list of error messages globally available to the routines in
ErrorCheck, rather than creating a local array each time errorcheckpop_up is called
and handing around references to these local copies.

Also removed unused local errors hash left over from when the various error checks
were made to use common code.

Fixes #389