### PR TITLE
Stop image viewer being opened twice on first use

### DIFF
--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -354,7 +354,6 @@ sub textentryfontfieldsstate {
 sub setpngspath {
     my $textwindow = $::textwindow;
     my $top        = $::top;
-    my $pagenum    = shift;
 
     #print $pagenum.'';
     my $path = $textwindow->chooseDirectory(
@@ -366,7 +365,6 @@ sub setpngspath {
     $path       = ::os_normal($path);
     $::pngspath = $path;
     ::setedited(1);
-    ::openpng( $textwindow, $pagenum ) if defined $pagenum;
 }
 
 # Pop up a window where you can adjust the auto save interval

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -23,7 +23,6 @@ BEGIN {
 
 sub get_image_file {
     my $pagenum = shift;
-    my $number;
     my $imagefile;
     unless ($::pngspath) {
         if ($::OS_WIN) {
@@ -31,7 +30,7 @@ sub get_image_file {
         } else {
             $::pngspath = "${main::globallastpath}pngs/";
         }
-        ::setpngspath($pagenum) unless ( -e "$::pngspath$pagenum.png" );
+        ::setpngspath() unless ( -e "$::pngspath$pagenum.png" );
     }
     if ($::pngspath) {
         $imagefile = "$::pngspath$pagenum.png";
@@ -60,7 +59,7 @@ sub openpng {
     if ( $imagefile && $::globalviewerpath ) {
         ::runner( $::globalviewerpath, $imagefile );
     } else {
-        ::setpngspath($pagenum);
+        ::setpngspath();
     }
     return;
 }


### PR DESCRIPTION
When user tries to view a page image, if they have to select the folder, the image
viewer was being opened twice, due to a recursive call to openpng via setpngspath.
Removing the call to openpng still means the image viewer gets opened.

Fixes #240