### PR TITLE
Restore the `--> nnn queries` line output by Jeebies

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -375,6 +375,9 @@ sub errorcheckpop_up {
     } else {
         $::lglobal{errorchecklistbox}->insert( 'end', @errorchecklines );
     }
+    $::lglobal{errorchecklistbox}->insert( 2, "  --> $mark queries" )
+      if $errorchecktype eq 'Jeebies';
+
     $::lglobal{errorchecklistbox}->update;
     $::lglobal{errorchecklistbox}->focus;
     $::lglobal{errorcheckpop}->raise;


### PR DESCRIPTION
The summary of how many queries there were got lost in the code reorganisation.
See #396 for a request to show a similar summary for all checking tools.

Fixes #395