### PR TITLE
Ensure only one plus sign is added to HTML Markup dialog buttons

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -2583,9 +2583,9 @@ sub markupconfiglabel {
 
     my $label = $w->cget( -text );
     if ( $::htmlentryattribhash{$typ} ) {
-        $label =~ s/$/+/;
+        $label =~ s/\+*$/+/;    # Ensure button ends in just one plus sign
     } else {
-        $label =~ s/\+$//;
+        $label =~ s/\+*$//;     # Remove any plus signs
     }
     $w->configure( -text => $label );
 }


### PR DESCRIPTION
When adding class/attributes to an HTML Markup dialog button a plus sign is
appended. It was possible to add 2 or more plus signs, by editing the configuration
further.

Now only one plus sign is ever added, and all plus signs are removed if the
class/attributes field is cleared

Fixes #398