### PR TITLE
Spellcheck old layout and busy handling

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -152,7 +152,6 @@ our $donotcenterpagemarkers = 0;
 our $nohighlights           = 0;
 our $notoolbar              = 0;
 our $intelligentWF          = 0;
-our $oldspellchecklayout    = 0;
 our $defaultpngspath        = ::os_normal('pngs/');
 our $pngspath               = q{};
 our $projectid              = q{};

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -870,7 +870,7 @@ EOM
             font_char fontname fontsize fontweight geometry
             gesperrt_char globalaspellmode highlightcolor history_size ignoreversionnumber
             intelligentWF ignoreversions italic_char jeebiesmode lastversioncheck lastversionrun lmargin markupthreshold
-            multisearchsize multiterm nobell nohighlights projectfileslocation notoolbar oldspellchecklayout poetrylmargin projectfileslocation
+            multisearchsize multiterm nobell nohighlights projectfileslocation notoolbar poetrylmargin projectfileslocation
             recentfile_size rmargin rmargindiff rwhyphenspace sc_char scannos_highlighted spellcheckwithenchant stayontop toolside
             trackoperations txt_conv_bold txt_conv_font txt_conv_gesperrt txt_conv_italic txt_conv_sc txt_conv_tb
             txtfontname txtfontsize txtfontweight txtfontsystemuse

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -850,13 +850,6 @@ sub menu_preferences_appearance {
             -onvalue    => 1,
             -offvalue   => 0
         ],
-        [
-            Checkbutton => 'Use Old Spell Check Layout',
-            -variable   => \$::oldspellchecklayout,
-            -onvalue    => 1,
-            -offvalue   => 0,
-            -command    => \&::savesettings,
-        ],
     ];
 }
 

--- a/src/lib/Guiguts/SpellCheck.pm
+++ b/src/lib/Guiguts/SpellCheck.pm
@@ -560,299 +560,152 @@ sub spellchecker {    # Set up spell check window
         my $spf5 =
           $::lglobal{spellpopup}->Frame->pack( -side => 'top', -anchor => 'n', -padx => 5 );
 
-        if ($::oldspellchecklayout) {
-            my $changebutton = $spf2->Button(
-                -activebackground => $::activecolor,
-                -command          => sub { spellreplace() },
-                -text             => 'Change',
-                -width            => 14
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            my $ignorebutton = $spf2->Button(
-                -activebackground => $::activecolor,
-                -command          => sub {
-                    shift @{ $::lglobal{misspelledlist} };
-                    spellchecknext();
-                },
-                -text  => 'Skip <Ctrl+s>',
-                -width => 14
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            my $spelloptionsbutton = $spf2->Button(
-                -activebackground => $::activecolor,
-                -command          => sub { spelloptions() },
-                -text             => 'Options',
-                -width            => 14
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            $spf2->Button(
-                -activebackground => $::activecolor,
-                -command          => sub {
-                    $::spellindexbkmrk = $textwindow->index( $::lglobal{lastmatchindex} . '-1c' )
-                      || '1.0';
-                    $textwindow->markSet( 'spellbkmk', $::spellindexbkmrk );
-                    ::savesettings();
-                },
-                -text  => 'Set Bookmark',
-                -width => 14,
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            my $replaceallbutton = $spf3->Button(
-                -activebackground => $::activecolor,
-                -command          => sub { spellreplaceall(); spellchecknext() },
-                -text             => 'Change All',
-                -width            => 14,
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            my $ignoreallbutton = $spf3->Button(
-                -activebackground => $::activecolor,
-                -command          => sub { spellignoreall(); spellchecknext() },
-                -text             => 'Skip All <Ctrl+i>',
-                -width            => 14
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            my $closebutton = $spf3->Button(
-                -activebackground => $::activecolor,
-                -command          => \&endaspell,
-                -text             => 'Close',
-                -width            => 14
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            $spf3->Button(
-                -activebackground => $::activecolor,
-                -command          => sub {
-                    return unless $::spellindexbkmrk;
-                    $textwindow->tagRemove( 'sel',       '1.0', 'end' );
-                    $textwindow->tagRemove( 'highlight', '1.0', 'end' );
-                    $textwindow->tagAdd( 'sel', 'spellbkmk', 'end' );
-                    spellcheckfirst();
-                },
-                -text  => 'Resume @ Bkmrk',
-                -width => 14
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            my $dictmybutton = $spf4->Button(
-                -activebackground => $::activecolor,
-                -command          => sub {
-                    spelladdgoodwords();
-                },
-                -text  => 'Add Goodwords To Proj. Dic.',
-                -width => 24,
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            my $dictaddbutton = $spf5->Button(
-                -activebackground => $::activecolor,
-                -command          => sub {
-                    spelladdword();
-                    spellignoreall();
-                    spellchecknext();
-                },
-                -text  => 'Add To Aspell Dic. <Ctrl+a>',
-                -width => 22,
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            my $dictmyaddbutton = $spf5->Button(
-                -activebackground => $::activecolor,
-                -command          => sub {
-                    spellmyaddword( $::lglobal{misspelledentry}->get );
-                    spellignoreall();
-                    spellchecknext();
-                },
-                -text  => 'Add To Project Dic. <Ctrl+p>',
-                -width => 22,
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-        } else {
-            my $changebutton = $spf2->Button(
-                -activebackground => $::activecolor,
-                -command          => sub { spellreplace() },
-                -text             => 'Change',
-                -width            => 14,
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            my $ignorebutton = $spf2->Button(
-                -activebackground => $::activecolor,
-                -command          => sub {
-                    shift @{ $::lglobal{misspelledlist} };
-                    spellchecknext();
-                },
-                -text  => 'Skip <Ctrl+s>',
-                -width => 14,
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            my $dictmyaddbutton = $spf2->Button(
-                -activebackground => $::activecolor,
-                -command          => sub {
-                    spellmyaddword( $::lglobal{misspelledentry}->get );
-                    spellignoreall();
-                    spellchecknext();
-                },
-                -text  => 'Add To Project Dic. <Ctrl+p>',
-                -width => 22,
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            my $replaceallbutton = $spf3->Button(
-                -activebackground => $::activecolor,
-                -command          => sub { spellreplaceall(); spellchecknext() },
-                -text             => 'Change All',
-                -width            => 14,
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            my $ignoreallbutton = $spf3->Button(
-                -activebackground => $::activecolor,
-                -command          => sub { spellignoreall(); spellchecknext() },
-                -text             => 'Skip All <Ctrl+i>',
-                -width            => 14,
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            my $dictaddbutton = $spf3->Button(
-                -activebackground => $::activecolor,
-                -command          => sub {
-                    spelladdword();
-                    spellignoreall();
-                    spellchecknext();
-                },
-                -text  => 'Add To Aspell Dic. <Ctrl+a>',
-                -width => 22,
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            $spf4->Button(
-                -activebackground => $::activecolor,
-                -command          => sub {
-                    $::spellindexbkmrk = $textwindow->index( $::lglobal{lastmatchindex} . '-1c' )
-                      || '1.0';
-                    $textwindow->markSet( 'spellbkmk', $::spellindexbkmrk );
-                    ::savesettings();
-                },
-                -text  => 'Set Bookmark',
-                -width => 14,
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            $spf4->Button(
-                -activebackground => $::activecolor,
-                -command          => sub {
-                    return unless $::spellindexbkmrk;
-                    $textwindow->tagRemove( 'sel',       '1.0', 'end' );
-                    $textwindow->tagRemove( 'highlight', '1.0', 'end' );
-                    $textwindow->tagAdd( 'sel', 'spellbkmk', 'end' );
-                    spellcheckfirst();
-                },
-                -text  => 'Resume @ Bkmrk',
-                -width => 14,
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            my $dictmybutton = $spf5->Button(
-                -activebackground => $::activecolor,
-                -command          => sub {
-                    spelladdgoodwords();
-                },
-                -text  => 'Add Goodwords To Proj. Dic.',
-                -width => 24,
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            my $spelloptionsbutton = $spf5->Button(
-                -activebackground => $::activecolor,
-                -command          => sub { spelloptions() },
-                -text             => 'Options',
-                -width            => 12,
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-            my $closebutton = $spf5->Button(
-                -activebackground => $::activecolor,
-                -command          => \&endaspell,
-                -text             => 'Close',
-                -width            => 12,
-            )->pack(
-                -side   => 'left',
-                -pady   => 2,
-                -padx   => 3,
-                -anchor => 'nw'
-            );
-        }
+        my $changebutton = $spf2->Button(
+            -activebackground => $::activecolor,
+            -command          => sub { spellreplace() },
+            -text             => 'Change',
+            -width            => 14,
+        )->pack(
+            -side   => 'left',
+            -pady   => 2,
+            -padx   => 3,
+            -anchor => 'nw'
+        );
+        my $ignorebutton = $spf2->Button(
+            -activebackground => $::activecolor,
+            -command          => sub {
+                shift @{ $::lglobal{misspelledlist} };
+                spellchecknext();
+            },
+            -text  => 'Skip <Ctrl+s>',
+            -width => 14,
+        )->pack(
+            -side   => 'left',
+            -pady   => 2,
+            -padx   => 3,
+            -anchor => 'nw'
+        );
+        my $dictmyaddbutton = $spf2->Button(
+            -activebackground => $::activecolor,
+            -command          => sub {
+                spellmyaddword( $::lglobal{misspelledentry}->get );
+                spellignoreall();
+                spellchecknext();
+            },
+            -text  => 'Add To Project Dic. <Ctrl+p>',
+            -width => 22,
+        )->pack(
+            -side   => 'left',
+            -pady   => 2,
+            -padx   => 3,
+            -anchor => 'nw'
+        );
+        my $replaceallbutton = $spf3->Button(
+            -activebackground => $::activecolor,
+            -command          => sub { spellreplaceall(); spellchecknext() },
+            -text             => 'Change All',
+            -width            => 14,
+        )->pack(
+            -side   => 'left',
+            -pady   => 2,
+            -padx   => 3,
+            -anchor => 'nw'
+        );
+        my $ignoreallbutton = $spf3->Button(
+            -activebackground => $::activecolor,
+            -command          => sub { spellignoreall(); spellchecknext() },
+            -text             => 'Skip All <Ctrl+i>',
+            -width            => 14,
+        )->pack(
+            -side   => 'left',
+            -pady   => 2,
+            -padx   => 3,
+            -anchor => 'nw'
+        );
+        my $dictaddbutton = $spf3->Button(
+            -activebackground => $::activecolor,
+            -command          => sub {
+                spelladdword();
+                spellignoreall();
+                spellchecknext();
+            },
+            -text  => 'Add To Aspell Dic. <Ctrl+a>',
+            -width => 22,
+        )->pack(
+            -side   => 'left',
+            -pady   => 2,
+            -padx   => 3,
+            -anchor => 'nw'
+        );
+        $spf4->Button(
+            -activebackground => $::activecolor,
+            -command          => sub {
+                $::spellindexbkmrk = $textwindow->index( $::lglobal{lastmatchindex} . '-1c' )
+                  || '1.0';
+                $textwindow->markSet( 'spellbkmk', $::spellindexbkmrk );
+                ::savesettings();
+            },
+            -text  => 'Set Bookmark',
+            -width => 14,
+        )->pack(
+            -side   => 'left',
+            -pady   => 2,
+            -padx   => 3,
+            -anchor => 'nw'
+        );
+        $spf4->Button(
+            -activebackground => $::activecolor,
+            -command          => sub {
+                return unless $::spellindexbkmrk;
+                $textwindow->tagRemove( 'sel',       '1.0', 'end' );
+                $textwindow->tagRemove( 'highlight', '1.0', 'end' );
+                $textwindow->tagAdd( 'sel', 'spellbkmk', 'end' );
+                spellcheckfirst();
+            },
+            -text  => 'Resume @ Bkmrk',
+            -width => 14,
+        )->pack(
+            -side   => 'left',
+            -pady   => 2,
+            -padx   => 3,
+            -anchor => 'nw'
+        );
+        my $dictmybutton = $spf5->Button(
+            -activebackground => $::activecolor,
+            -command          => sub {
+                spelladdgoodwords();
+            },
+            -text  => 'Add Goodwords To Proj. Dic.',
+            -width => 24,
+        )->pack(
+            -side   => 'left',
+            -pady   => 2,
+            -padx   => 3,
+            -anchor => 'nw'
+        );
+        my $spelloptionsbutton = $spf5->Button(
+            -activebackground => $::activecolor,
+            -command          => sub { spelloptions() },
+            -text             => 'Options',
+            -width            => 12,
+        )->pack(
+            -side   => 'left',
+            -pady   => 2,
+            -padx   => 3,
+            -anchor => 'nw'
+        );
+        my $closebutton = $spf5->Button(
+            -activebackground => $::activecolor,
+            -command          => \&endaspell,
+            -text             => 'Close',
+            -width            => 12,
+        )->pack(
+            -side   => 'left',
+            -pady   => 2,
+            -padx   => 3,
+            -anchor => 'nw'
+        );
+
         ::initialize_popup_without_deletebinding('spellpopup');
         $::lglobal{spellpopup}->protocol( 'WM_DELETE_WINDOW' => \&endaspell );
         $::lglobal{spellpopup}->bind(

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -17,7 +17,7 @@ BEGIN {
       &xtops &toolbar_toggle &killpopup &expandselection &currentfileisunicode &currentfileislatin1
       &getprojectid &setprojectid &viewprojectcomments &viewprojectdiscussion &viewprojectpage
       &scrolldismiss &updatedrecently &hidelinenumbers &restorelinenumbers &displaylinenumbers
-      &enable_interrupt &disable_interrupt &set_interrupt &query_interrupt &soundbell);
+      &enable_interrupt &disable_interrupt &set_interrupt &query_interrupt &soundbell &busy &unbusy);
 
 }
 
@@ -2654,6 +2654,19 @@ sub dialogboxcommonsetup {
     $::lglobal{$dlg}->Subwidget('entry')->selectionRange( $len, 'end' );
     $::lglobal{$dlg}->Subwidget('entry')->icursor($len);    # place cursor at end of default text
     $::lglobal{$dlg}->Wait;
+}
+
+#
+# Set cursor to "busy" so user knows something is happening
+# Also ignore key and button presses
+sub busy {
+    $::top->Busy( -recurse => 1 );    # Top level widget and all descendants are "busy"
+}
+
+#
+# Restore cursor and make key/button press bindings active again
+sub unbusy {
+    $::top->Unbusy;
 }
 
 1;


### PR DESCRIPTION
2 commits.

1. Remove the (unused) "old spellcheck layout" to simplify the code.
2. Improve busy handling

Use of the Busy method was a bit haphazard. As well as changing the cursor so the
user knows something is happening, Busy causes button and key input to be ignored.

Extract into Utilities routines the calls to Busy and Unbusy from the top widget with
recurse option to include all lower widgets. Use these routines at the start and end
of each user action where these have keyboard shortcuts. This greatly reduces the
possibility of the user holding down a key and the repeated keystrokes causing a
"deep recursion" error or crash.

Fixes #181 (or at least makes it hard to get the error and I haven't been able to crash
the program).
