### PR TITLE
Improve display of warnings and errors

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -426,7 +426,7 @@ sub errorcheckrun {    # Runs error checks
     $top->Busy( -recurse => 1 );
 
     my $unicode = ::currentfileisunicode();
-    return 1 unless savetoerrortmpfile($tmpfname);
+    savetoerrortmpfile($tmpfname);
     if ( $errorchecktype eq 'HTML Tidy' ) {
         if ($unicode) {
             ::run( $::tidycommand, "-f", $errname, "-e", "-utf8", $tmpfname );
@@ -519,45 +519,31 @@ sub errorcheckrun {    # Runs error checks
 }
 
 # Save current file to a temporary file in order to run a check on it
-# Return true if saved successfully
 sub savetoerrortmpfile {
     my $tmpfname   = shift;
     my $textwindow = $::textwindow;
     my $top        = $::top;
 
     my $unicode = ::currentfileisunicode();
-    if ( open my $td, '>', $tmpfname ) {
-        my $count   = 0;
-        my $index   = '1.0';
-        my ($lines) = $textwindow->index('end - 1c') =~ /^(\d+)\./;
-        while ( $textwindow->compare( $index, '<', 'end' ) ) {
-            my $end     = $textwindow->index("$index  lineend +1c");
-            my $gettext = $textwindow->get( $index, $end );
-            utf8::encode($gettext) if ($unicode);
-            print $td $gettext;
-            $index = $end;
-        }
-        close $td;
-    } else {
-        warn "Could not open temp file for writing. $!";
-        my $dialog = $top->Dialog(
-            -text =>
-              "Could not write file $tmpfname. Check for write permission or space problems.",
-            -bitmap  => 'question',
-            -title   => "Temporary File Error",
-            -buttons => [qw/OK/],
-        );
-        $dialog->Show;
-        return 0;
+    open my $td, '>', $tmpfname or die "Could not open $tmpfname for writing. $!";
+    my $count   = 0;
+    my $index   = '1.0';
+    my ($lines) = $textwindow->index('end - 1c') =~ /^(\d+)\./;
+    while ( $textwindow->compare( $index, '<', 'end' ) ) {
+        my $end     = $textwindow->index("$index  lineend +1c");
+        my $gettext = $textwindow->get( $index, $end );
+        utf8::encode($gettext) if ($unicode);
+        print $td $gettext;
+        $index = $end;
     }
-    return 1;
+    close $td;
 }
 
 sub linkcheckrun {
     my ( $tempfname, $errname ) = @_;
     my $textwindow = $::textwindow;
     my $top        = $::top;
-    open my $logfile, ">", $errname || die "output file error\n";
+    open my $logfile, ">", $errname or die "Error opening link check output file: $errname";
     my ( %anchor, %id, %link, %image, %badlink, $length, $upper );
     my ( $anchors, $ids, $ilinks, $elinks, $images, $count, $css ) = ( 0, 0, 0, 0, 0, 0, 0 );
     my @warning = ();

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -999,7 +999,7 @@ sub file_export_pagemarkup {
     if ( defined($name) and length($name) ) {
         $name .= '.gut';
         my $bincontents = '';
-        open my $fh, '<', getbinname() or die "Could not read $name";
+        open my $fh, '<', getbinname() or die "Could not read " . getbinname();
         my $inpagenumbers   = 0;
         my $pastpagenumbers = 0;
         while ( my $line = <$fh> ) {
@@ -1008,7 +1008,7 @@ sub file_export_pagemarkup {
         close $fh;
 
         # write the file with page markup
-        open my $fh2, '>', "$name" or die "Could not read $name";
+        open my $fh2, '>', "$name" or die "Could not write $name";
         my $unicode      = ::currentfileisunicode();
         my $filecontents = $textwindow->get( '1.0', 'end -1c' );
         utf8::encode($filecontents) if $unicode;

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -1021,6 +1021,7 @@ sub menu_help {
         [ 'command',   '~Keyboard Shortcuts',    -command => \&::hotkeyshelp ],
         [ 'command',   '~Regex Quick Reference', -command => \&::regexref ],
         [ 'command',   '~Compose Sequences',     -command => \&::composeref ],
+        [ 'command',   'Message ~Log',           -command => \&::poperror ],
         [ 'separator', '' ],
         [
             'command',

--- a/src/lib/Guiguts/SpellCheck.pm
+++ b/src/lib/Guiguts/SpellCheck.pm
@@ -472,7 +472,7 @@ sub spelladdgoodwords {
     }
     my $pwd = ::getcwd();
     chdir $::globallastpath;
-    open( DAT, "good_words.txt" ) || die("Could not open good_words.txt!");
+    open( DAT, "good_words.txt" ) or die "Could not open good_words.txt!";
 
     # Remove all newlines and/or carriage returns whatever the current OS
     my @raw_data = map { s/[\n\r]+$//g; $_ } <DAT>;


### PR DESCRIPTION
Warnings and errors whether issued by Tk or via warn/die in the application code
were only output to stderr, which might not be noticed by the user until it was too
later, or which on some platforms would vanish when they exited the program.

1. Override the handling of warn and die to output to a message log dialog as
well as to stderr.
2. Sound the bell (or flash the warning icon) if a warning or error is output and pop
the message log to the front.
3. Allow the user to pop the message log via the Help menu.
4. In the case of die actually going to terminate the program, give the user a chance
to copy/paste messages first.
5. Tidy up a few places that used warn/die in the code.

Fixes #163