### PR TITLE
Correct jeebiesbaseline.txt after number of queries was restored

### DIFF
--- a/src/tests/jeebiesbaseline.txt
+++ b/src/tests/jeebiesbaseline.txt
@@ -1,5 +1,6 @@
 Beginning check: Jeebies
   --> There are 214 "be"s and 142 "he"s. Calibrating...
+  --> 46 queries
 288:59 - Query phrase "trench he shot" 
 328:33 - Query phrase "when he narrowly" 
 426:0 - Query phrase "There he summoned" 


### PR DESCRIPTION
#397 restored the number of queries when running jeebies. This necessitates a new
baseline test file.

Fixes #403