### PR TITLE
Make all the perl modules used mandatory

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -28,6 +28,7 @@ use FindBin;
 use lib $FindBin::Bin . "/lib";
 
 #use Data::Dumper;
+use charnames();
 use Cwd;
 use Encode;
 use FileHandle;
@@ -37,10 +38,12 @@ use File::Spec::Functions qw(catfile);
 use File::Spec::Functions qw(catdir);
 use File::Copy;
 use File::Compare;
+use File::Which;
 use HTML::TokeParser;
+use Image::Size;
 use IPC::Open2;
 use LWP::UserAgent;
-use charnames();
+use Text::LevenshteinXS;
 use Tk;
 use Tk::widgets qw{Balloon
   BrowseEntry
@@ -60,6 +63,8 @@ use Tk::widgets qw{Balloon
   TextEdit
   ToolBar
 };
+use WebService::Validator::HTML::W3C;
+
 our $APP_NAME     = 'Guiguts';
 our $window_title = $APP_NAME . '-' . $VERSION;
 our $icondata;
@@ -273,11 +278,6 @@ our @extops = (
 
 # All local global variables contained in one global hash.
 our %lglobal;    # need to document each variable
-
-# Determine what optional modules are installed
-$lglobal{LevenshteinXS} = eval { require Text::LevenshteinXS; 1; } || 0;
-$lglobal{ImageSize}     = eval { require Image::Size;         1; } || 0;
-$lglobal{Which}         = eval { require File::Which;         1; } || 0;
 
 our $top;
 our $icon;

--- a/src/install_cpan_modules.pl
+++ b/src/install_cpan_modules.pl
@@ -2,18 +2,21 @@
 
 my @modules = (
 
-    # Required modules
-    "LWP::UserAgent",
+    # Needed for user interface
     "Tk",
     "Tk::ToolBar",
 
-    # Optional but recommended modules
+    # Needed for word frequency harmonics
     "Text::LevenshteinXS",
+
+    # Needed to check if a tool is on the path
     "File::Which",
+
+    # Needed to determine the dimensions of images for HTML
     "Image::Size",
 
     # Needed for update checking
-    "LWP::Protocol::https",
+    "LWP::UserAgent",
 
     # Needed for remote HTML validation
     "WebService::Validator::HTML::W3C",
@@ -21,6 +24,6 @@ my @modules = (
 );
 
 foreach my $module (@modules) {
-    system("cpanm --notest --install $module") == 0
+    system("cpanm --notest $module") == 0
       or die("Failed trying to install $module\n");
 }

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -387,13 +387,6 @@ sub errorcheckrun {    # Runs error checks
     my ( $errorchecktype, $tmpfname, $errname ) = @_;
     my $textwindow = $::textwindow;
     my $top        = $::top;
-    if ( $errorchecktype eq 'W3C Validate Remote' ) {
-        unless ( eval { require WebService::Validator::HTML::W3C } ) {
-            print
-              "Install the module WebService::Validator::HTML::W3C to do W3C Validation remotely. Defaulting to local validation.\n";
-            $errorchecktype = 'W3C Validate';
-        }
-    }
     ::operationadd("$errorchecktype");
     ::hidepagenums();
     if ( $::lglobal{errorcheckpop} ) {

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1941,19 +1941,11 @@ sub thumbnailbrowse {
         -initialdir => $::globalimagepath
     );
     return unless ($name);
-    my $xythumb = 200;
-    if ( $::lglobal{ImageSize} ) {
-        ( $::lglobal{htmlimagesizex}, $::lglobal{htmlimagesizey} ) = Image::Size::imgsize($name);
-        $::lglobal{htmlimggeom}->configure( -text => "File size: "
-              . $::lglobal{htmlimagesizex} / $EMPX . " x "
-              . $::lglobal{htmlimagesizey} / $EMPX . " em "
-              . "($::lglobal{htmlimagesizex} x $::lglobal{htmlimagesizey} px)" );
-    } else {
-        $::lglobal{htmlimagesizex} = $xythumb;
-        $::lglobal{htmlimagesizey} = $xythumb;
-        $::lglobal{htmlimggeom}->configure( -text => "File size: unknown" );
-        $::lglobal{htmlimgmaxwidth}->configure( -text => "" );
-    }
+    ( $::lglobal{htmlimagesizex}, $::lglobal{htmlimagesizey} ) = Image::Size::imgsize($name);
+    $::lglobal{htmlimggeom}->configure( -text => "File size: "
+          . $::lglobal{htmlimagesizex} / $EMPX . " x "
+          . $::lglobal{htmlimagesizey} / $EMPX . " em "
+          . "($::lglobal{htmlimagesizex} x $::lglobal{htmlimagesizey} px)" );
     htmlimagewidthsetdefault();
 
     $::lglobal{htmlorig}->blank;
@@ -1970,8 +1962,9 @@ sub thumbnailbrowse {
         $ext =~ s/jpg/jpeg/;
         $::lglobal{htmlorig}->read( $name, -format => $ext, -shrink );
     }
-    my $sw = int( ( $::lglobal{htmlorig}->width ) / $xythumb );
-    my $sh = int( ( $::lglobal{htmlorig}->height ) / $xythumb );
+    my $xythumb = 200;
+    my $sw      = int( ( $::lglobal{htmlorig}->width ) / $xythumb );
+    my $sh      = int( ( $::lglobal{htmlorig}->height ) / $xythumb );
     if ( $sh > $sw ) {
         $sw = $sh;
     }

--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -23,19 +23,8 @@ sub setdefaultpath {
     # Does the file exist in the same location without the extension (ala *nix)?
     if ( -e ::catfile( $filepath, $basename ) ) {
         $pathname = ::catfile( $filepath, $basename );
-    } else {
-
-        # Is it on the path somewhere?
-        if ( $::lglobal{Which} ) {
-
-            # Check both with and without extension
-            $pathname = File::Which::which($filename)
-              || File::Which::which($basename);
-        } elsif ( !$::OS_WIN ) {
-
-            # Only check without extension since we're on *nix
-            $pathname = substr( qx/which $basename/, 0, -1 );    # strip trailing \n
-        }
+    } else {    # Is it on the path somewhere - check both with and without extension
+        $pathname = File::Which::which($filename) or File::Which::which($basename);
     }
 
     if ( $pathname && -x $pathname ) {

--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -1190,39 +1190,11 @@ sub harmonics2 {
         $::lglobal{harmonic}{$test} = 1 if ( distance( $word, $test ) <= 2 );
     }
 }
-#### Levenshtein edit distance calculations #################
-#### taken from the Text::Levenshtein Module ################
-#### If available, uses Text::LevenshteinXS #################
-#### which is orders of magnitude faster. ###################
-sub distance {
-    if ( $::lglobal{LevenshteinXS} ) {
-        return Text::LevenshteinXS::distance(@_);
-    }
-    my $word1 = shift;
-    my $word2 = shift;
-    return 0 if $word1 eq $word2;
-    my @d;
-    my $len1 = length $word1;
-    my $len2 = length $word2;
-    $d[0][0] = 0;
 
-    for ( 1 .. $len1 ) {
-        $d[$_][0] = $_;
-    }
-    for ( 1 .. $len2 ) {
-        $d[0][$_] = $_;
-    }
-    for my $i ( 1 .. $len1 ) {
-        my $w1 = substr( $word1, $i - 1, 1 );
-        for ( 1 .. $len2 ) {
-            $d[$i][$_] = _min(
-                $d[ $i - 1 ][$_] + 1,
-                $d[$i][ $_ - 1 ] + 1,
-                $d[ $i - 1 ][ $_ - 1 ] + ( $w1 eq substr( $word2, $_ - 1, 1 ) ? 0 : 1 )
-            );
-        }
-    }
-    return $d[$len1][$len2];
+#
+# Levenshtein edit distance calculation
+sub distance {
+    return Text::LevenshteinXS::distance(@_);
 }
 
 sub _min {


### PR DESCRIPTION
Some modules were mandatory and some were "optional" but removed or degraded
some functionality. Since all the modules are easily installed using cpanm via the
provided script, it's simpler to just require all of them.

Fixes #243.

See also #409