### PR TITLE
Use ebookmaker classes to tailor output for handheld devices 

### DIFF
--- a/src/headerdefault.txt
+++ b/src/headerdefault.txt
@@ -170,6 +170,9 @@ img.w100 {width: 100%;}
     page-break-inside: avoid;
     max-width: 100%;
 }
+/* comment out next line and uncomment the following one for floating figleft on ebookmaker output */
+.x-ebookmaker .figleft {float: none; text-align: center; margin-right: 0;}
+/* .x-ebookmaker .figleft {float: left;} */
 
 .figright {
     float: right;
@@ -183,6 +186,9 @@ img.w100 {width: 100%;}
     page-break-inside: avoid;
     max-width: 100%;
 }
+/* comment out next line and uncomment the following one for floating figright on ebookmaker output */
+.x-ebookmaker .figright {float: none; text-align: center; margin-left: 0;}
+/* .x-ebookmaker .figright {float: right;} */
 
 /* Footnotes */
 .footnotes        {border: 1px dashed;}

--- a/src/headerdefault.txt
+++ b/src/headerdefault.txt
@@ -206,7 +206,8 @@ img.w100 {width: 100%;}
 .poetry .stanza   {margin: 1em auto;}
 .poetry .verse    {text-indent: -3em; padding-left: 3em;}
 /* large inline blocks don't split well on paged devices */
-@media handheld, print { .poetry {display: block;} }
+@media print { .poetry {display: block;} }
+.x-ebookmaker .poetry {display: block;}
 
 /* Transcriber's notes */
 .transnote {background-color: #E6E6FA;

--- a/src/headerdefault.txt
+++ b/src/headerdefault.txt
@@ -41,6 +41,7 @@ hr {
 
 hr.tb   {width: 45%; margin-left: 27.5%; margin-right: 27.5%;}
 hr.chap {width: 65%; margin-left: 17.5%; margin-right: 17.5%;}
+@media print { hr.chap {display: none; visibility: hidden;} }
 hr.full {width: 95%; margin-left: 2.5%; margin-right: 2.5%;}
 
 hr.r5  {width: 5%; margin-top: 1em; margin-bottom: 1em; margin-left: 47.5%; margin-right: 47.5%;}

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1756,7 +1756,7 @@ sub htmlimageok {
         # If % width and override flag set, then also add CSS to override width to 100% for epub
         my $cssovr =
           ( $::lglobal{htmlimgwidthtype} eq '%' and $::epubpercentoverride )
-          ? "    \@media handheld { .$classname {width: 100%;} }"
+          ? "\n.x-ebookmaker .$classname {width: 100%;}"
           : "";
 
         # If this class has been added already, write it again (override may have changed)

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1063,7 +1063,7 @@ sub html_convert_chapterdivs {
             # insert the end and start of the chapter div, with a chapter break <hr> before it
             $textwindow->ntinsert( $h2blockend . '+5c', "\n</div>" );
             $textwindow->ntinsert( $h2blockstart,
-                "\n<hr class=\"chap\" />\n\n<div class=\"chapter\">\n" );
+                "\n<hr class=\"chap x-ebookmaker-drop\" />\n\n<div class=\"chapter\">\n" );
         }
         $searchstart = $h2blockend . '+5l';    # ensure we don't find the same </h2 again
     }


### PR DESCRIPTION
1. Change from `@media` to `.x-ebookmaker`
2. Add code for figleft and figright using new mechanism
3. Suppress unwanted horizontal rules using new mechanism

Fixes #289, #342 and #400 