### PR TITLE
Fix HTML generation footnote error

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1118,17 +1118,19 @@ sub html_convert_footnoteblocks {
         # the next footnote block
         my $nextfootnoteblock =
           $textwindow->search( '-exact', '--', 'FOOTNOTES:', $thisblockstart . '+1l', 'end' );
-        unless ($nextfootnoteblock) {
-            $nextfootnoteblock = 'end';
-        }
-        unless ($nextfootnoteblock) {
-            $nextfootnoteblock = 'end';
-        }
+        $nextfootnoteblock = 'end' unless $nextfootnoteblock;
 
-        # find the start of last footnote
+        # find the start of last footnote in this block
         my $lastfootnoteinblock =
           $textwindow->search( '-exact', '-backwards', '--', '<div class="footnote">',
             $nextfootnoteblock );
+
+        # if no footnotes in block just insert closing /div immediately after heading
+        if ( not $lastfootnoteinblock ) {
+            $textwindow->insert( $thisblockstart . '+42c', '</div>' );
+            $thisblockstart .= '+1l';
+            next;
+        }
 
         # find the end of the last footnote
         my $endoflastfootnoteinblock =


### PR DESCRIPTION
In the unusual circumstance where a FOOTNOTES title did not have any footnotes
below it, the code continued to try to use indexes that were undefined.

Just safely close the div that has been opened and carry on instead.

FIxes #416 