### PR TITLE
Stop user removing errorcheck entry while already removing one

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -127,6 +127,7 @@ sub errorcheckpop_up {
     $::lglobal{errorchecklistbox}->bind(
         '<<remove>>',
         sub {
+            ::busy();
             my $xx = $::lglobal{errorchecklistbox}->pointerx - $::lglobal{errorchecklistbox}->rootx;
             my $yy = $::lglobal{errorchecklistbox}->pointery - $::lglobal{errorchecklistbox}->rooty;
             my $idx = $::lglobal{errorchecklistbox}->index("\@$xx,$yy");
@@ -137,7 +138,7 @@ sub errorcheckpop_up {
             $::lglobal{errorchecklistbox}->delete('active');
             $::lglobal{errorchecklistbox}->selectionSet('active');
             errorcheckview();
-            $::lglobal{errorchecklistbox}->after( $::lglobal{delay} );
+            ::unbusy();
         }
     );
     $::lglobal{errorcheckpop}->update;


### PR DESCRIPTION
If the user right-clicked twice in the errorcheck box in rapid succession, then the
system might be refreshing the window when the second click was processed,
leading to an error message.

To avoid this, use busy() to ignore further clicks while first click is being processed.

There was a call to the `after` method in the code, which sleeps for a short period
ignoring clicks - this was perhaps a previous attempt to avoid the same issue, but
has proved insufficient since recent alterations to dialog updating.

Fixes #425 