### PR TITLE
Speed up error message output

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2567,14 +2567,10 @@ sub soundbell {
     $::textwindow->bell if $::textwindow and not $::nobell;
     return              if $noflash;
     return unless $::lglobal{current_line_label};
-    for ( 1 .. 5 ) {
-        $::lglobal{current_line_label}->after( $::lglobal{delay} );
-        $::lglobal{current_line_label}->configure( -background => $::activecolor );
-        $::lglobal{current_line_label}->update;
-        $::lglobal{current_line_label}->after( $::lglobal{delay} );
-        $::lglobal{current_line_label}->configure( -background => 'gray' );
-        $::lglobal{current_line_label}->update;
-    }
+    $::lglobal{current_line_label}->configure( -background => $::activecolor );
+    $::lglobal{current_line_label}->update;
+    $::lglobal{current_line_label}->after( $::lglobal{delay} );
+    $::lglobal{current_line_label}->configure( -background => 'gray' );
 }
 
 #


### PR DESCRIPTION
Flashing the corner label 5 times was taking too long (almost a second) which meant
that multiple errors were mistaken for an infinite loop.

Just flashing once means a 10x speed-up since only one delay is required rather than
2 per flash.

Fixes #428 