### PR TITLE
Stop uninitialized error when Aspell version is unobtainable

### DIFF
--- a/src/lib/Guiguts/SpellCheck.pm
+++ b/src/lib/Guiguts/SpellCheck.pm
@@ -293,7 +293,9 @@ sub get_spellchecker_version {
     }
     close $aspell;
     unlink 'aspell.tmp';
-    return $::lglobal{spellversion} = $aspell_version;
+    $::lglobal{spellversion} = $aspell_version;
+    $aspell_version = "Unknown" unless $aspell_version;
+    return $aspell_version;
 }
 
 sub aspellstop {


### PR DESCRIPTION
When Help-->Software Versions runs but Aspell cannot report its version (due to
bad path or Aspell not installed) it returned an uninitialized value causing an error.

Instead, return "Unknown", but keep the global variable uninitialized so that the
user can correct it by using Prefs-->File Paths, then recheck Software Versions.

Fixes #429 