### PR TITLE
Fix crash during pasting

### DIFF
--- a/src/hotkeys.txt
+++ b/src/hotkeys.txt
@@ -9,6 +9,7 @@ MAIN WINDOW
 <ctrl>+<shift>+s -- save as
 <ctrl>+<alt>+r -- open regex quick reference
 <ctrl>+<alt>+s -- open scratchpad.txt
+<ctrl>+<alt>+v -- alternative paste method to avoid bug with Unicode characters
 
 <shift>+mouse drag -- column select
 F1 -- column copy

--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -25,13 +25,14 @@ sub keybindings {
     keybind( '<Control-Shift-s>', sub { ::file_saveas($textwindow); } );
 
     # Select, copy, paste
-    keybind( '<Control-a>', sub { $textwindow->selectAll; } );
-    keybind( '<Control-c>', sub { ::textcopy(); }, '<<Copy>>' );
-    keybind( '<Control-x>', sub { ::cut(); }, '<<Cut>>' );
-    keybind( '<Control-v>', sub { ::paste(); } );
-    keybind( '<F1>',        sub { ::colcopy($textwindow); } );
-    keybind( '<F2>',        sub { ::colcut($textwindow); } );
-    keybind( '<F3>',        sub { ::colpaste($textwindow); } );
+    keybind( '<Control-a>',     sub { $textwindow->selectAll; } );
+    keybind( '<Control-c>',     sub { ::textcopy(); }, '<<Copy>>' );
+    keybind( '<Control-x>',     sub { ::cut(); }, '<<Cut>>' );
+    keybind( '<Control-v>',     sub { ::paste(); } );
+    keybind( '<Control-Alt-v>', sub { ::paste('alternative'); } );     # to avoid Perl/Tk paste bug
+    keybind( '<F1>',            sub { ::colcopy($textwindow); } );
+    keybind( '<F2>',            sub { ::colcut($textwindow); } );
+    keybind( '<F3>',            sub { ::colpaste($textwindow); } );
 
     # Tools
     keybind( '<F5>', sub { ::wordfrequency(); } );

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -153,6 +153,11 @@ sub menu_edit {
             -accelerator => 'Ctrl+v',
             -command     => sub { ::paste(); },
         ],
+        [
+            'command', 'Alternative Paste',
+            -accelerator => 'Ctrl+Alt+v',
+            -command     => sub { ::paste('alternative'); },
+        ],
         [ 'separator', '' ],
         [
             'command', 'Column Cut',


### PR DESCRIPTION
MR #388 to fix #179 changed the routines used for pasting into the main window.
The new method caused crashes with some moderate/large amounts of text.

Revert to the old method for default pasting, but allow user to choose the
alternative method, either from the Edit menu or with Ctrl+Alt+v

Fixes #439 