### PR TITLE
Output error messages using warn, not print to STDERR

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -310,8 +310,7 @@ sub win32_create_process {
     if ( Win32::Process::Create( $proc, $exe, $cmdline, 1, 0, '.' ) ) {
         return $proc;
     } else {
-        print STDERR "Failed to run $args[0]: ";
-        print STDERR Win32::FormatMessage( Win32::GetLastError() );
+        warn "Failed to run $args[0]: " . Win32::FormatMessage( Win32::GetLastError() );
         return undef;
     }
     return;


### PR DESCRIPTION
To make the error appear in the new message log, `warn` should be used, not a
print to STDERR.
The only place this happened was when spawning a win32 process, e.g. to run
Aspell.
Replaced print to STDERR with a call to warn.

Fixes #433