### PR TITLE
Output bin files in utf8 mode

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -294,6 +294,7 @@ sub _bin_save {
     }
     my $fh = FileHandle->new("> $binname");
     if ( defined $fh ) {
+        binmode $fh, ":encoding(utf-8)";
         print $fh "\%::pagenumbers = (\n";
         for my $page ( sort { $a cmp $b } keys %::pagenumbers ) {
             if ( $page eq "Pg" ) {


### PR DESCRIPTION
If the bin file has a non-ascii character, e.g. curly quotes when trying to log the
operation to check for orphaned curly quotes, it would output an error about
wide character in print.

Fixed by setting mode of bin file to utf-8

Fixes #447 