### PR TITLE
Restore ability to specify image sizes in pixels

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -144,6 +144,7 @@ our $globalprojectdirectory = q{};
 our @gsopt;
 our $highlightcolor         = '#a08dfc';
 our $history_size           = 20;
+our $htmlimageallowpixels   = 0;                           # Don't allow user to specify image size in pixels by default
 our $ignoreversions         = "none";                      # Don't ignore any updates by default
 our $ignoreversionnumber    = "";                          # Ignore a specific version
 our $jeebiesmode            = 'p';

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -884,7 +884,7 @@ EOM
             blocklmargin blockrmargin bold_char composepopbinding cssvalidationlevel
             defaultindent donotcenterpagemarkers epubpercentoverride failedsearch
             font_char fontname fontsize fontweight geometry
-            gesperrt_char globalaspellmode highlightcolor history_size ignoreversionnumber
+            gesperrt_char globalaspellmode highlightcolor history_size htmlimageallowpixels ignoreversionnumber
             intelligentWF ignoreversions italic_char jeebiesmode lastversioncheck lastversionrun lmargin markupthreshold
             multisearchsize multiterm nobell nohighlights projectfileslocation notoolbar poetrylmargin projectfileslocation
             recentfile_size rmargin rmargindiff rwhyphenspace sc_char scannos_highlighted spellcheckwithenchant stayontop toolside

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -1006,6 +1006,12 @@ sub menu_preferences_processing {
             -offvalue   => 'css3',
         ],
         [ 'command', 'Set Compose Key...', -command => sub { ::composekeypopup() } ],
+        [
+            Checkbutton => 'Allow px Sizes for HTML Images',
+            -variable   => \$::htmlimageallowpixels,
+            -onvalue    => 1,
+            -offvalue   => 0
+        ],
     ];
 }
 


### PR DESCRIPTION
Several users want to specify the HTML image size in pixels.
Allow this (reversion to 1.0.25 output) if toggle is enabled in Prefs menu.
Note that this will also use `style` rather than class to set the div width.

By setting the toggle 'off' by default, it steers new users away from using this method
while allowing users familiar with older versions to get the code they are familiar
with.

Resolves #441, resolves #444 