### PR TITLE
Preserve underscores when creating ids and anchors

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -2980,12 +2980,14 @@ sub hyperlinkpagenums {
 sub makeanchor {
     my $linkname = shift;
     return unless $linkname;
-    $linkname =~ s/-/\x00/g;
+    $linkname =~ s/-/\x00/g;              # preserve hyphens
+    $linkname =~ s/_/\x01/g;              # preserve underscores
     $linkname =~ s/&amp;|&mdash;/\xFF/;
     $linkname =~ s/<sup>.*?<\/sup>//g;
     $linkname =~ s/<\/?[^>]+>//g;
     $linkname =~ s/\p{Punct}//g;
-    $linkname =~ s/\x00/-/g;
+    $linkname =~ s/\x00/-/g;              # restore hyphens
+    $linkname =~ s/\x01/_/g;              # restore underscores
     $linkname =~ s/\s+/_/g;
 
     while ( $linkname =~ m/([\x{100}-\x{ffef}])/ ) {


### PR DESCRIPTION
This is because they are particularly useful to preserve when a filename is being
converted to an id for an HTML image. It's harmless and probably won't happen
apart from that, e.g. for the anchor used in the automatically generated ToC,
because books don't generally have underscores (they are used in the text version
for italics, but not in the HTML version).

Fixes #457