### PR TITLE
Save page labels in bin file more safely

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -306,12 +306,10 @@ sub _bin_save {
             print $fh "'offset' => '$::pagenumbers{$page}{offset}', ";
 
             # if labels have been set up, output label information too
-            if ( $::pagenumbers{$page}{label} ) {
-                print $fh "'label' => '$::pagenumbers{$page}{label}', ";
-                print $fh "'style' => '$::pagenumbers{$page}{style}', ";
-                print $fh "'action' => '$::pagenumbers{$page}{action}', ";
-                print $fh "'base' => '$::pagenumbers{$page}{base}'";
-            }
+            print $fh "'label' => '" .  ( $::pagenumbers{$page}{label}  || "" ) . "', ";
+            print $fh "'style' => '" .  ( $::pagenumbers{$page}{style}  || "" ) . "', ";
+            print $fh "'action' => '" . ( $::pagenumbers{$page}{action} || "" ) . "', ";
+            print $fh "'base' => '" .   ( $::pagenumbers{$page}{base}   || "" ) . "'";
             print $fh "},\n";
         }
         print $fh ");\n\n";


### PR DESCRIPTION
Bug introduced by #432 - trying to avoid outputting label info if undefined.
Fix was too aggressive, meaning required information was not output.
Changed to mimic what used to be output, but without accessing undefined
variables

Fixes #463 