### PR TITLE
Reduce default width of SR dialog fields

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -982,7 +982,7 @@ sub searchpopup {
         $::lglobal{searchentry} = $sf11->Entry(
             -background => $::bkgcolor,
             -foreground => 'black',
-            -width      => 60,
+            -width      => 40,
             -validate   => 'all',
             -vcmd       => sub { reg_check(shift); }
         )->pack(
@@ -1164,7 +1164,7 @@ sub searchpopup {
         );
         $::lglobal{replaceentry} = $sf12->Entry(
             -background => $::bkgcolor,
-            -width      => 60,
+            -width      => 40,
         )->pack(
             -side   => 'right',
             -anchor => 'w',
@@ -1519,7 +1519,7 @@ sub searchaddterms {
         );
         $::lglobal{$replaceentry} = $msref->[$_]->Entry(
             -background => $::bkgcolor,
-            -width      => 60,
+            -width      => 40,
         )->pack(
             -side   => 'right',
             -anchor => 'w',


### PR DESCRIPTION
Since recent font changes, SR dialog can be wide. It has never had the capability to
store its width, so when user resizes, it returns to its default size.

A quick fix to store the width using the geometryhash will not suffice, since resizing
is complex for this dialog as the number of replace rows can grow and shrink via
the code, and the width needs to be adjustable by the user.

#460 remains as a long-standing issue to be addressed, but not in a bug fix release,
so reducing the default width from 60 characters to 40 is the best option for now.