### PR TITLE
Implement alternative paste method for Entry widgets

### DIFF
--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -291,17 +291,11 @@ sub keybindings {
     # Note that for this to work, a dummy Entry is created in initialize() routine previously,
     # because default class bindings don't get set up until first Entry is created. So without
     # the dummy widget, the binding below would be overwritten by the default at a later point.
-    $textwindow->MainWindow->bind(
-        'Tk::Entry',
-        '<<Paste>>' => sub {    # Taken from Tk::clipboardPaste (where delete is commented out)
-            my $w = shift;
-            $w->deleteSelected;
+    $textwindow->MainWindow->bind( 'Tk::Entry', '<<Paste>>' => sub { ::entrypaste(shift); }, );
 
-            # Basic eval exception handling to avoid error if nothing in clipboard
-            eval { $w->insert( "insert", $::textwindow->clipboardGet ); };
-            $w->SeeInsert if $w->can('SeeInsert');
-        }
-    );
+    # Alternative paste to give user a second option if Perl/Tk utf8 bug strikes
+    $textwindow->MainWindow->bind( 'Tk::Entry',
+        '<Control-Alt-v>' => sub { ::entrypaste( shift, 'alternative' ); }, );
 }
 
 # Bind a key-combination to a sub allowing for capslock on/off.

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -12,7 +12,7 @@ BEGIN {
       &win32_is_exe &win32_create_process &dos_path &runner &debug_dump &run &launchurl &escape_regexmetacharacters
       &deaccentsort &deaccentdisplay &readlabels &working &initialize &initialize_popup_with_deletebinding
       &initialize_popup_without_deletebinding &titlecase &os_normal &escape_problems &natural_sort_alpha
-      &natural_sort_length &natural_sort_freq &drag &cut &paste &textcopy &colcut &colcopy &colpaste &showversion
+      &natural_sort_length &natural_sort_freq &drag &cut &paste &entrypaste &textcopy &colcut &colcopy &colpaste &showversion
       &checkforupdates &checkforupdatesmonthly &gotobookmark &setbookmark &seeindex &ebookmaker
       &sidenotes &poetrynumbers &get_page_number &externalpopup &add_entry_history &entry_history
       &xtops &toolbar_toggle &killpopup &expandselection &currentfileisunicode &currentfileislatin1
@@ -1689,6 +1689,23 @@ sub paste {
         } else {
             $textwindow->clipboardPaste;
         }
+    }
+}
+
+#
+# Special paste routine to insert into Entry widgets
+# Try to cope with Perl/Tk failing to handle utf8 correctly on some platforms
+# Similarly to paste routine above, alternative paste uses slightly different method
+sub entrypaste {
+    my $w = shift;
+    $w->deleteSelected;    #
+
+    my $alternative_paste = shift;
+    if ($alternative_paste) {
+        eval { $w->insert( "insert", $::textwindow->clipboardGet ); };
+        $w->SeeInsert if $w->can('SeeInsert');
+    } else {
+        $w->clipboardPaste;
     }
 }
 


### PR DESCRIPTION
To cope with Perl/Tk bug when pasting unicode characters, use alternative paste
method similarly to #442 for the main text window.

User can still use previous method my using Ctrl-Alt-V instead of Ctrl-V, just like in
the main window.

Fixes #478