### PR TITLE
Fix error message and ignored orphaned brackets

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1952,20 +1952,6 @@ sub orphanedbrackets {
             $::lglobal{brbrackets}[1] = $::lglobal{brbrackets}[1] || '';
             last unless @{ $::lglobal{brbrackets} };
         }
-        if ( ( $::lglobal{brbrackets}[2] ) && ( $::lglobal{brbrackets}[3] ) ) {
-            if (   ( $::lglobal{brbrackets}[0] eq $::lglobal{brbrackets}[1] )
-                && ( $::lglobal{brbrackets}[2] eq $::lglobal{brbrackets}[3] ) ) {
-                shift @{ $::lglobal{brbrackets} };
-                shift @{ $::lglobal{brbrackets} };
-                shift @{ $::lglobal{brindices} };
-                shift @{ $::lglobal{brindices} };
-                shift @{ $::lglobal{brbrackets} };
-                shift @{ $::lglobal{brbrackets} };
-                shift @{ $::lglobal{brindices} };
-                shift @{ $::lglobal{brindices} };
-                brnext( $brkresult, $brnextbt );
-            }
-        }
         if ( @{ $::lglobal{brbrackets} } && $::lglobal{brindices}[0] ) {
             $textwindow->markSet( 'insert', $::lglobal{brindices}[0] )
               if $::lglobal{brindices}[0];


### PR DESCRIPTION
A piece of code checked if there were four identical brackets and skipped the check
on them. This meant that the user would be warned about 3 consecutive orphaned
brackets (or indeed the 5th one of 5)
```
(a)
b)
c)
d)
(e)
```
but not about four such brackets
```
(a)
b)
c)
d)
e)
(f)
```
If the final (f) is omitted, so that the four orphaned brackets are the final ones in the
file, then an "uninitialized value" error was output.

I can't see any reason why that behaviour would be desired and have removed the
code that did it. Now all the orphaned brackets in the above examples are warned
about correctly, and no error is output if the orphaned ones are the last ones in
the file.

Fixes #479