### PR TITLE
Fix uninitialized value error when saving file with path containing quote

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -315,7 +315,7 @@ sub _bin_save {
         print $fh ");\n\n";
         foreach ( keys %::operationshash ) {
             my $mark = ::escape_problems($_);
-            print $fh "\$::operationshash{'$mark'}='" . $::operationshash{$mark} . "';\n";
+            print $fh "\$::operationshash{'$mark'}='" . $::operationshash{$_} . "';\n";
         }
         print $fh "\n";
         print $fh '$::bookmarks[0] = \'' . $textwindow->index('insert') . "';\n";
@@ -634,7 +634,6 @@ sub operationadd {
     $mon  += 1;
     my $timestamp = sprintf( '%4d-%02d-%02d %02d:%02d', $year, $mon, $mday, $hour, $min );
     $::operationshash{$operation} = $timestamp;
-    $operation = ::escape_problems($operation);
     ::oppopupdate() if $::lglobal{oppop};
     ::setedited(1);
 }


### PR DESCRIPTION
If the path to a file contained a quote, the quote is escaped when the "file opened"
operation is being written to the list of operations stored in the bin file. However,
the escaped version of the hash key was also used for looking up the timestamp,
which was then undefined because the non-escaped hash key was used when storing
the timestamp originally. Error only occurred when operations history was enabled.

Also, removed a redundant escaping of the operation name in operationadd()
which was done after the operation variable had been used.

Fixes #476