### PR TITLE
Search correctly for 0 from Word Frequency dialog

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -88,8 +88,8 @@ sub searchtext {
         $::searchendindex = $start . $stepforward;
     }
 
-    # use the string in the dialog search field unless one was passed in as an argument
-    $searchterm = $::lglobal{searchentry}->get unless ($searchterm);
+    # use the string in the dialog search field if none passed in as an argument
+    $searchterm = $::lglobal{searchentry}->get if $searchterm eq '';
     return ('') unless length($searchterm);
     if ( $::sopt[3] ) {
         unless ( ::isvalid($searchterm) ) {


### PR DESCRIPTION
Searching for the character "0" from the Character Counts list in Word Frequency
caused an error message because "0" was interpreted as "false" due to incorrect
test. Bug introduced during implementation of S&R Count button in release 1.1.
Changed to explicitly check search term was empty.