### PR TITLE
Fix rewrap indentation issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - closing footnote divs were badly placed
 - file paths with quotes caused errors when saving
 - error when searching for "0" from Word Frequency dialog
+- spaces at the start of a paragraph were wrongly preserved, leading to an
+  indented first line after rewrap
 
 ## Version 1.2.3
 

--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -89,8 +89,8 @@ sub selectrewrap {
     }
 
     # If the selection starts on a blank(ish) line, advance the selection start until it isn't.
-    while ( $textwindow->get($start) =~ /[\s\n$TEMPPAGEMARK]/ ) {
-        $start = $textwindow->index("$start+1c");
+    while ( $textwindow->get( $start, "$start lineend" ) =~ /^[\s\n$TEMPPAGEMARK]*$/ ) {
+        $start = $textwindow->index("$start+1l linestart");
     }
 
     # If the selection ends at the end of a line but not over it advance the selection end until it does.


### PR DESCRIPTION
If the region to be rewrapped has spaces at the start of the first line, these were
preserved, leading to an apparent first-line indentation.

Start of selection was being advanced to a non-space character. It should be to
the start of a non-blank line (page markers count as blanks).

Caused by fix for #461 
Fixes #492 