### PR TITLE
Stop loop in Fixup Page Separator 80% mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - error when searching for "0" from Word Frequency dialog
 - spaces at the start of a paragraph were wrongly preserved, leading to an
   indented first line after rewrap
+- 80% auto mode in Fixup Page Separators could get stuck in a loop
 
 ## Version 1.2.3
 

--- a/src/lib/Guiguts/PageSeparators.pm
+++ b/src/lib/Guiguts/PageSeparators.pm
@@ -110,6 +110,7 @@ sub handleautomaticonrefresh {
         $textwindow->insert( $index, "\n" );
 
         if ( $::lglobal{pagesepauto} == 2 ) {
+            my $nothingdone = 1;
 
             # If the last character is a word, ";" or ","
             # and the next character is \n or *, then delete the character
@@ -119,10 +120,8 @@ sub handleautomaticonrefresh {
                     $index     = $textwindow->index('page1');
                     $character = $textwindow->get($index);
                     if ( $character =~ /[\*]/ ) {    # dropped \n
-                        print "deleting:character page1\n";
                         $textwindow->delete($index);
-                        last
-                          if $textwindow->compare( 'page1 +1l', '>=', 'end' );
+                        last if $textwindow->compare( 'page1 +1l', '>=', 'end' );
                     } else {
                         last;
                     }
@@ -133,6 +132,7 @@ sub handleautomaticonrefresh {
             #print $character.":page?\n";
             if ( ( $character =~ /\p{IsLower}/ ) || ( $character =~ /^I / ) ) {
                 processpageseparator('j');
+                $nothingdone = 0;
             }
             my ( $r, $c ) = split /\./, $textwindow->index('page-1c');
             my ($size) =
@@ -141,7 +141,10 @@ sub handleautomaticonrefresh {
             # Insert blank line if the character is ."'?
             if ( ( $character =~ /[\.\"\'\?]/ ) && ( $c < ( $size * 0.5 ) ) ) {
                 processpageseparator('l');
+                $nothingdone = 0;
             }
+            last if $nothingdone;
+
         } elsif ( $::lglobal{pagesepauto} == 3 ) {
             my $linebefore = $textwindow->get( "$index -10c",    $index );
             my $lineafter  = $textwindow->get( "$index +1c +1l", "$index +1c +1l +5c" );


### PR DESCRIPTION
In 80% auto mode, the code was looping indefinitely. Previous work to make it
non-recursive had left this mode unable to break out of the loop which replaced
the recursion, until it reached the end of the file.