### PR TITLE
Make 99% Auto Page Sep Fixup work with blockquote markup

### DIFF
--- a/src/lib/Guiguts/PageSeparators.pm
+++ b/src/lib/Guiguts/PageSeparators.pm
@@ -146,8 +146,8 @@ sub handleautomaticonrefresh {
             last if $nothingdone;
 
         } elsif ( $::lglobal{pagesepauto} == 3 ) {
-            my $linebefore = $textwindow->get( "$index -10c",    $index );
-            my $lineafter  = $textwindow->get( "$index +1c +1l", "$index +1c +1l +5c" );
+            my $linebefore = $textwindow->get( "page -10c",       "page -1c" );
+            my $lineafter  = $textwindow->get( "page1 linestart", "page1 linestart +5c" );
             if ( $lineafter =~ /^\n\n\n\n/ ) {
                 processpageseparator('h');
             } elsif ( $lineafter =~ /^\n\n/ ) {
@@ -158,8 +158,8 @@ sub handleautomaticonrefresh {
                 processpageseparator('l');
             } elsif ( $lineafter =~ /^\S/ ) {
                 if ( closeupmarkup() ) {
-                    $linebefore = $textwindow->get( "$index -10c",    $index );
-                    $lineafter  = $textwindow->get( "$index +1c +1l", "$index +1c +1l +5c" );
+                    $linebefore = $textwindow->get( "page -10c",       "page -1c" );
+                    $lineafter  = $textwindow->get( "page1 linestart", "page1 linestart +5c" );
                 }
                 if ( $lineafter =~ /^\n/ ) {    # can be reached if closeupmarkup did something
                     processpageseparator('l');
@@ -231,6 +231,10 @@ sub closeupmarkup {
             $textwindow->delete('page+1l linestart');
             $textwindow->delete( 'page-1l linestart', 'page-1l lineend' );
             $textwindow->delete('page-1l linestart');
+
+            # close/reopen markup has been deleted, so re-fetch the lines surrounding the page break
+            $linebefore = $textwindow->get( 'page-1l linestart', 'page-1l lineend' );
+            $lineafter  = $textwindow->get( 'page+1l linestart', 'page+1l lineend' );
             $changemade = 1;
         }
     }


### PR DESCRIPTION
If a page break fell mid-blockquote, the markup was closed and re-opened by the
formatters. If, in addition, there was an end-of-page hyphen, then 99% Auto
Page Separator Fixup would join the work, leaving the hyphen, rather than letting
the user decide on the hyphen. This was caused by a stale index value being used
after the close/reopen markup was removed. Also, the lines before/after the
pagebreak needed to be refetched after the markup had been removed so the
routine could remove superfluous second asterisk.

Solved by using the page break marks already set up instead of indexes, since
marks retain their positions correctly when text around them is edited.

Fixes #501 