### PR TITLE
Fix 2 ways in which Tk fails to handle wordstart/end with utf-8 chars

### DIFF
--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -286,6 +286,20 @@ sub keybindings {
     # Compose - define last since user could set the compose key to one of the above that they never use
     keybind( "<$::composepopbinding>", sub { ::composepopup(); } );
 
+    # Override wordstart/end moves because Tk fails to safely find wordstart/end with utf-8 characters.
+    # Bindings are same as in Text.pm, except there the position argument is Ev'd with the index function.
+    # That is unnecessary because SetCursor and KeySelect can accept a non-numeric position index, and
+    # we need the words 'wordstart' or 'wordend' so that the overridden versions of those routines in
+    # TextUnicode can handle wordstart/end safely.
+    $textwindow->MainWindow->bind( 'TextUnicode', '<Control-Left>',
+        [ 'SetCursor', 'insert-1c wordstart' ] );
+    $textwindow->MainWindow->bind( 'TextUnicode', '<Shift-Control-Left>',
+        [ 'KeySelect', 'insert-1c wordstart' ] );
+    $textwindow->MainWindow->bind( 'TextUnicode', '<Control-Right>',
+        [ 'SetCursor', 'insert+1c wordend' ] );
+    $textwindow->MainWindow->bind( 'TextUnicode', '<Shift-Control-Right>',
+        [ 'KeySelect', 'insert wordend' ] );
+
     # Override Paste binding, so that Entry widgets delete any selected text
     # in the field, just like happens in the main textwindow
     # Note that for this to work, a dummy Entry is created in initialize() routine previously,

--- a/src/lib/Guiguts/TextUnicode.pm
+++ b/src/lib/Guiguts/TextUnicode.pm
@@ -428,8 +428,8 @@ sub SelectTo {
 # pos - The desired new position for the cursor in the window.
 sub SetCursor {
     my ( $w, $pos ) = @_;
-    $pos = 'end - 1 chars' if $w->compare( $pos, '==', 'end' );
     $pos = $w->safeword($pos);
+    $pos = 'end - 1 chars' if $w->compare( $pos, '==', 'end' );
     $w->markSet( 'insert', $pos );
     $w->unselectAll;
     $w->see('insert');
@@ -499,12 +499,14 @@ sub safeword {
         $start = $w->index("$pos linestart") unless $start;    # word was at start of line
         return $start;
     } elsif ( $pos =~ s/ wordend// ) {
+        return 'end-1c' if $w->compare( $pos, '>=', 'end-1c' );    # don't try to go beyond the end
+
         my $endch = $w->get($pos);
-        return $w->index("$pos + 1c") if ( $endch =~ '\W' );    # already at a non-word character
+        return $w->index("$pos + 1c") if ( $endch =~ '\W' );       # already at a non-word character
 
         # Find first non-word character forwards on the current line
         my $end = $w->search( '-regexp', '--', '\W', "$pos", "$pos lineend" );
-        $end = $w->index("$pos lineend") unless $end;           # word was at end of line
+        $end = $w->index("$pos lineend") unless $end;              # word was at end of line
         return $end;
     }
 


### PR DESCRIPTION
1. Bindings for Ctrl left/right arrows used to call index function with wordstart/end
arguments. Now defined in KeyBindings so that index is not called before giving
safeword a chance to fix the wordstart/end error in SetCursor and KeySelect.
2. Original version of SetCursor has a check for being at end of file. Previous work
on this issue called safeword after this check instead of before it.
3. Also needed a check in safeword to avoid searching past end of file.

Fixes #502 