### PR TITLE
Permit `&` in spawned commands on Windows

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -233,6 +233,7 @@ sub win32_cmdline {
     foreach (@args) {
         s/(\\*)\"/$!$!\\\"/g;
         s/^(.*)(\\*)$/\"$1$2$2\"/ if m/[ "]/;
+        s/&/^&/g;    # Windows command line escapes & with ^
     }
     return join " ", @args;
 }
@@ -250,8 +251,8 @@ sub win32_start {
     # which doesn't have this limitation.
     #
     foreach (@args) {
-        if (m/["<>|&()!%^]/) {    # would be very nice to have & for urls...""
-            warn 'Refusing to run "start" command with unsafe characters ("<>|&()!%^): '
+        if (m/["<>|()!%^]/) {
+            warn 'Refusing to run "start" command with unsafe characters ("<>|()!%^): '
               . join( " ", @args );
             return -1;
         }


### PR DESCRIPTION
It is useful to be able to include ampersand in a command, e.g. when trying to open
a URL such as a forum topic/post

Ampersand was previously refused - now escaped with caret as needed for Windows
command line.

Fixes #81 