### PR TITLE
Grab focus back after Image Viewer is spawned

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -59,7 +59,14 @@ sub openpng {
     }
     my $imagefile = ::get_image_file($pagenum);
     if ( $imagefile && $::globalviewerpath ) {
+        my $focuswidget = $textwindow->focusCurrent;    # remember which widget had focus before spawning viewer
         ::runner( $::globalviewerpath, $imagefile );
+        my $grabperiod   = 200;                         # try to get focus back for 200 milliseconds
+        my $grabinterval = 10;                          # try to get focus back every 10 milliseconds
+        for ( 1 .. ( $grabperiod / $grabinterval ) ) {
+            $focuswidget->after($grabinterval);
+            $focuswidget->focusForce;
+        }
     } else {
         ::setpngspath();
     }


### PR DESCRIPTION
It isn't possible to avoid the Image Viewer getting focus, so the only solution is to
grab it back. Rather than wait 1/5 second which means the Image Viewer has focus
for a noticeable length of time, try every 1/100 second for 1/5 second. This makes
the Viewer only flash briefly with focus. If the user's computer is too slow and the
Image Viewer has not been given focus within the grab period, then GG will lose
focus (once the viewer is running) as happened prior to this fix.

I considered a configurable grab period, but it's not worth the code and user
interface complexity.

Fixes #98