### PR TITLE
Remove buggy Alt-Up/Down function

### DIFF
--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -219,8 +219,6 @@ sub keybindings {
     );
     keybind( '<Alt-Left>',  sub { ::indent( $textwindow, 'out' ); } );
     keybind( '<Alt-Right>', sub { ::indent( $textwindow, 'in' ); } );
-    keybind( '<Alt-Up>',    sub { ::indent( $textwindow, 'up' ); } );
-    keybind( '<Alt-Down>',  sub { ::indent( $textwindow, 'dn' ); } );
 
     # Scratchpad
     keybind(

--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -632,7 +632,6 @@ sub indent {
         return;
     } else {
         my @selarray;
-        if ( $indent eq 'up' ) { @ranges = reverse @ranges }
         $textwindow->addGlobStart;
         while (@ranges) {
             my $end            = pop(@ranges);
@@ -679,53 +678,6 @@ sub indent {
                     $index .= '.0';
                 }
                 push @selarray, ( $thisblockstart, "$thisblockend lineend" );
-            }
-            if ( $indent eq 'up' ) {
-                my $temp = $end, $end = $start;
-                $start = $temp;
-                if ( $textwindow->compare( "$start linestart", '==', '1.0' ) ) {
-                    push @selarray, ( $start, $end );
-                    push @selarray, @ranges;
-                    last;
-                } else {
-                    while ( $textwindow->compare( "$end-1l", '>=', "$end-1l lineend" ) ) {
-                        $textwindow->insert( "$end-1l lineend", ' ' );
-                    }
-                    my $templine = $textwindow->get( "$start-1l", "$end-1l" );
-                    $textwindow->replacewith( "$start-1l", "$end-1l",
-                        ( $textwindow->get( $start, $end ) ) );
-                    push @selarray, ( "$start-1l", "$end-1l" );
-                    while (@ranges) {
-                        $start = pop(@ranges);
-                        $end   = pop(@ranges);
-                        $textwindow->replacewith( "$start-1l", "$end-1l",
-                            ( $textwindow->get( $start, $end ) ) );
-                        push @selarray, ( "$start-1l", "$end-1l" );
-                    }
-                    $textwindow->replacewith( $start, $end, $templine );
-                }
-            } elsif ( $indent eq 'dn' ) {
-                if ( $textwindow->compare( "$end+1l", '>=', $textwindow->index('end') ) ) {
-                    push @selarray, ( $start, $end );
-                    push @selarray, @ranges;
-                    last;
-                } else {
-                    while ( $textwindow->compare( "$end+1l", '>=', "$end+1l lineend" ) ) {
-                        $textwindow->insert( "$end+1l lineend", ' ' );
-                    }
-                    my $templine = $textwindow->get( "$start+1l", "$end+1l" );
-                    $textwindow->replacewith( "$start+1l", "$end+1l",
-                        ( $textwindow->get( $start, $end ) ) );
-                    push @selarray, ( "$start+1l", "$end+1l" );
-                    while (@ranges) {
-                        $end   = pop(@ranges);
-                        $start = pop(@ranges);
-                        $textwindow->replacewith( "$start+1l", "$end+1l",
-                            ( $textwindow->get( $start, $end ) ) );
-                        push @selarray, ( "$start+1l", "$end+1l" );
-                    }
-                    $textwindow->replacewith( $start, $end, $templine );
-                }
             }
             $textwindow->focus;
             $textwindow->tagRemove( 'sel', '1.0', 'end' );


### PR DESCRIPTION
Never documented and buggy, Alt-Up/Down arrow moved the selected text up/down.
No-one claims to use the feature, unsurprisingly, since inspecting the code would be
the only way to know of its existence. Perhaps an experiment by a previous coder.
Rather than fix the bug, it's tidier to just remove the feature.

Fixes #91