### PR TITLE
Make regex replace work for zero-length match

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -654,7 +654,11 @@ sub replace {
     return unless $::searchstartindex;
     my $searchterm = $::lglobal{searchentry}->get;
     $replaceterm = replaceeval( $searchterm, $replaceterm ) if ( $::sopt[3] );
-    if ($::searchstartindex) {
+
+    # If matching string is zero-length, just insert replacement text because Perl/Tk won't replace a zero-length string
+    if ( $::textwindow->compare( $::searchstartindex, '==', $::searchendindex ) ) {
+        $::textwindow->insert( $::searchstartindex, $replaceterm );
+    } elsif ($::searchstartindex) {
         $::textwindow->replacewith( $::searchstartindex, $::searchendindex, $replaceterm );
     }
     return 1;


### PR DESCRIPTION
With a search regex of `$` or `^` or a lookahead expression, there can be a
zero-length match. Perl/Tk does not replace these with the replacement string,
so if zero-length, just insert the replacement.

Fixes #223 plus other similar situations.
