### PR TITLE
Make all footnotes move to inline position correctly

### DIFF
--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -1265,7 +1265,7 @@ sub footnotefind {
         }
         last;
     }
-    $::lglobal{ftnoteindexstart} = "$bracketstartndx+10c";
+    $::lglobal{ftnoteindexstart} = "$bracketstartndx+1c";
     $textwindow->markSet( 'fnindex', $::lglobal{ftnoteindexstart} );
     my $lastfnindex = $textwindow->index('lastfnindex');
     if ( $textwindow->compare( $lastfnindex, '<', $bracketendndx ) ) {


### PR DESCRIPTION
If two footnotes were out-of-line and followed directly after one another (actually
with fewer that 10 characters between them), then when both were moved inline
the second would be left behind because the footnote finding function moved on
10 characters from the last one in order to avoid finding the same one twice.

Now adjusted to move on just 1 character, which is sufficient to avoid finding the
same footnote again, but not so much that it skips over the start of another footnote.

Fixes #521 