### PR TITLE
Make `$t` substitute correctly for utf8 characters in Custom menu

### DIFF
--- a/src/install_cpan_modules.pl
+++ b/src/install_cpan_modules.pl
@@ -23,6 +23,11 @@ my @modules = (
     "XML::XPath",
 );
 
+# Windows-specific modules
+if ( $^O eq 'MSWin32' ) {
+    push @modules, "Win32::Unicode::Process";
+}
+
 foreach my $module (@modules) {
     system("cpanm --notest $module") == 0
       or die("Failed trying to install $module\n");

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -185,7 +185,9 @@ sub cmdinterp {
                 $selection = '';
             }
             $arg =~ s/\$t/$selection/g;
-            $arg = ::encode( "utf-8", $arg );
+
+            # Windows uses systemW in place of system later, so don't encode here
+            $arg = ::encode( "utf-8", $arg ) unless $::OS_WIN;
         }
 
         # Pass file to default file handler, $f $d $e give the fully specified path/filename
@@ -278,7 +280,8 @@ sub win32_start {
     # because if it isn't quoted it will be interpreted as the command. Windows!
     @args = ( 'start', 'Guiguts Command Window', @args );
     my $cmdline = win32_cmdline(@args);
-    system $cmdline;
+    require Win32::Unicode::Process;
+    Win32::Unicode::Process::systemW $cmdline;    # systemW is like system, but copes with utf8 encoding correctly.
 }
 
 sub win32_is_exe {
@@ -2619,7 +2622,7 @@ sub add_entry_history {
 
     # add the other terms from the list in order
     for (@temparray) {
-        next if $_ eq $term;    # omit current term if previously in list
+        next if $_ eq $term;                               # omit current term if previously in list
         push @$history_array_ref, $_;
         last if @$history_array_ref >= $::history_size;    # don't exceed maximum history size
     }

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2622,7 +2622,7 @@ sub add_entry_history {
 
     # add the other terms from the list in order
     for (@temparray) {
-        next if $_ eq $term;                               # omit current term if previously in list
+        next if $_ eq $term;    # omit current term if previously in list
         push @$history_array_ref, $_;
         last if @$history_array_ref >= $::history_size;    # don't exceed maximum history size
     }


### PR DESCRIPTION
The system command under Windows wasn't capable of handling utf8 characters
which meant that the Custom menu couldn't look up a word in a dictionary if the
word had accented characters.

Fixed by using the Win32::Unicode module which implements a systemW equivalent
to system. This is only required for Windows, and the cpan installer script now has a
section for Windows-specific modules.

Fixes #252 