### PR TITLE
Move to Github Actions for CI/CD

### DIFF
--- a/.github/workflows/perltidy.yml
+++ b/.github/workflows/perltidy.yml
@@ -1,0 +1,19 @@
+name: perltidy
+on: [push, pull_request]
+jobs:
+  perltidy:
+    runs-on: ubuntu-latest
+    container:
+      image: perl:5.32
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: perl -V
+        run: perl -V
+      - name: Install dependencies
+        run: cpanm --quiet --installdeps --notest --with-develop .
+      - name: perltidy --version
+        run: perltidy --version
+      - name: Run perltidy
+        shell: bash
+        run: ./format_files.sh --check


### PR DESCRIPTION
This moves CI/CD from TravisCI to Github Actions with identical functionality. TravisCI recently moved to a paid model and the DistributedProofreaders project is running out of the free credits. Github Actions is (at least currently) free with comparable functionality.