### PR TITLE
Only convert correctly formatted index page numbers to links

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -3886,12 +3886,18 @@ sub pageadjust {
     }
 }
 
+#
+# Convert numbers to page links in given text only where the numbers are less than 1000
+# (to help avoid dates) and where the formatting guidelines have been followed.
+# Modified text is returned.
+# The rules are as follows:
+# 1. Number must be preceded by a comma then one or more spaces
+# 2. Number must be no more than 3 digits (word boundary \b used to avoid partial matches with 4 digit numbers)
+# 3. Page range may be specified by hyphen between two numbers
 sub addpagelinks {
     my $selection = shift;
-    $selection =~ s/(\d{1,3})-(\d{1,3})/<a href="#$::htmllabels{pglabel}$1">$1-$2<\/a>/g;
-    $selection =~ s/(\d{1,3})([,;\.])/<a href="#$::htmllabels{pglabel}$1">$1<\/a>$2/g;
-    $selection =~ s/\s(\d{1,3})\s/ <a href="#$::htmllabels{pglabel}$1">$1<\/a> /g;
-    $selection =~ s/(\d{1,3})$/<a href="#$::htmllabels{pglabel}$1">$1<\/a>/;
+    $selection =~ s/, +(\d{1,3})-\b(\d{1,3})\b/, <a href="#$::htmllabels{pglabel}$1">$1-$2<\/a>/g;
+    $selection =~ s/, +\b(\d{1,3})\b/, <a href="#$::htmllabels{pglabel}$1">$1<\/a>/g;
     return $selection;
 }
 1;


### PR DESCRIPTION
Page numbers are required to have a comma and space preceding them when an
index comes out of the rounds. This was not enforced by the code, so some numbers
got converted that shouldn't be, e.g. in
`The Taking of Pelham 123, 7, 19, 26.`
the 123 would have been converted.
Also, if a 4 digit number appeared (like a date or a genuine page number at the
end of a list), the first or last 3 digits could sometimes be converted.

Rules now (fairly) strictly enforced. This is preferable, because if the index is badly
formatted, it is better for the PPer to be alerted by the link not being created than
to silently and possibly wrongly attempt a conversion anyway. A formatting error
like that would quite likely need some correction in the text file anyway, so it's
good to be aware of it.

Fixes #394