### PR TITLE
Stop bookloupe saying it won't report things that it will

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -305,6 +305,7 @@ sub errorcheckpop_up {
 
         } elsif ( $errorchecktype eq "Bookloupe" ) {
             next if $line =~ /^File: /;
+            next if $line =~ /^\s*-->.+ Not reporting/;
             if ( $line =~ /^\s*Line (\d+) column (\d+)\s*/ ) {
 
                 # Adjust column number to start from 0 for most bookloupe errors


### PR DESCRIPTION
Bookloupe does an early check and, for example, if it finds a lot of long lines, it says
it won't bother reporting them. However, with the verbose flag on, which it always is
when run through Guiguts, it then reports everything, including the things it said it
wouldn't.

This commit skips over those "Not reporting..." messages, but doesn't change what
is actually reported.

Fixes #487 