### PR TITLE
Preserve blank lines after block markup during Page Sep Fixup

### DIFF
--- a/src/lib/Guiguts/PageSeparators.pm
+++ b/src/lib/Guiguts/PageSeparators.pm
@@ -161,7 +161,11 @@ sub handleautomaticonrefresh {
                     $linebefore = $textwindow->get( "page -10c",       "page -1c" );
                     $lineafter  = $textwindow->get( "page1 linestart", "page1 linestart +5c" );
                 }
-                if ( $lineafter =~ /^\n/ ) {    # can be reached if closeupmarkup did something
+                if ( $lineafter =~ /^\n\n\n\n/ ) {    # can be reached if closeupmarkup did something
+                    processpageseparator('h');
+                } elsif ( $lineafter =~ /^\n\n/ ) {
+                    processpageseparator('t');
+                } elsif ( $lineafter =~ /^\n/ ) {
                     processpageseparator('l');
                 } elsif ( $lineafter =~ /^\// ) {
                     last;


### PR DESCRIPTION
If block markup continued through a page boundary, and was followed by 2 or more
blank lines, these were reduced to 1 blank line, e.g.
```
...
*/
---File: --------page sep
/*


Section head in ToC, for example
...
```

Code was only checking for 1 blank line and assuming it was the start of a
paragraph. Changed to check for 4 or 2 first and treat accordingly.

Fixes #539 