### PR TITLE
Fix occasional failure to display scrollbars in page label adjust dialog

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -3882,7 +3882,9 @@ sub pageadjust {
                 $pagetrack{$num}[5]->insert( 'end', $::pagenumbers{$page}{base} );
             }
         }
+        $frame1->yview( 'scroll', => 1, 'units' );
         $top->update;
+        $frame1->yview( 'scroll', -1, 'units' );
     }
 }
 


### PR DESCRIPTION
Previously removed as thought to be superfluous in MR #319, it appears as though
very rarely (large number of page labels) the scrollbar fails to become active on
some Windows systems.

Hopefully this will not reintroduce the problem referred to in #77. I don't think it
should as it is in a totally separate code area.

Fixes #541 