### PR TITLE
Commonise code in PageNumbers.pm

### DIFF
--- a/src/lib/Guiguts/StatusBar.pm
+++ b/src/lib/Guiguts/StatusBar.pm
@@ -421,10 +421,8 @@ sub update_prev_img_button {
             '<1>',
             sub {
                 $::lglobal{previmagebutton}->configure( -relief => 'sunken' );
-                $::lglobal{showthispageimage} = 1;
                 ::displaypagenums();
-                $textwindow->focus;
-                ::pgprevious();
+                ::pgfocus( -1, 'show' );
             }
         );
         _butbind( $::lglobal{previmagebutton} );
@@ -478,10 +476,8 @@ sub update_next_img_button {
             '<1>',
             sub {
                 $::lglobal{nextimagebutton}->configure( -relief => 'sunken' );
-                $::lglobal{showthispageimage} = 1;
                 ::displaypagenums();
-                $textwindow->focus;
-                ::pgnext();
+                ::pgfocus( +1, 'show' );
             }
         );
         _butbind( $::lglobal{nextimagebutton} );

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -956,7 +956,6 @@ sub initialize {
     $::lglobal{selmaxlength}       = 1;
     $::lglobal{shorthtmlfootnotes} = 1;                           # HTML convert - Footnote_3 rather than Footnote_3_3
     $::lglobal{showblocksize}      = 1;
-    $::lglobal{showthispageimage}  = 0;
     $::lglobal{spellencoding}      = "iso8859-1";
     $::lglobal{stepmaxwidth}       = 70;
     $::lglobal{suspects_only}      = 0;


### PR DESCRIPTION
One set of 2 routines and one set of 4 have each been combined into one routine
that takes an argument to avoid lots of duplicate code, which did not all work
consistently with one another, e.g. some moves would not allow one marker to
"overtake" another, but others would.

PPer now has full freedom to move page markers, which is appropriate, since the
only time this dialog is used is when markers have gone wrong for some reason and
need correcting.

Fixes #548