### PR TITLE
Remove remnant blank lines around moved footnotes

### DIFF
--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -1238,10 +1238,16 @@ sub setanchor {
         $textwindow->insert( $textwindow->index("fna$::lglobal{fnindex}"), $fn )
           if $textwindow->compare( $textwindow->index("fna$::lglobal{fnindex}"),
             '>', $textwindow->index("fns$::lglobal{fnindex}") );
-        $textwindow->delete(
-            $textwindow->index("fns$::lglobal{fnindex}"),
-            $textwindow->index("fne$::lglobal{fnindex}")
-        );
+
+        # Delete blank line before footnote if there is one
+        my $start = $textwindow->index("fns$::lglobal{fnindex}");
+        $start = "$start -1l" if $textwindow->get( "$start -1l", "$start -1l lineend" ) eq "";
+
+        # Delete trailing newline after footnote if there is one
+        my $end = $textwindow->index("fne$::lglobal{fnindex}");
+        $end = "$end +1c" if $textwindow->get($end) eq "\n";
+        $textwindow->delete( $start, $end );
+
         $textwindow->insert( $textwindow->index("fna$::lglobal{fnindex}"), $fn )
           if $textwindow->compare( $textwindow->index("fna$::lglobal{fnindex}"),
             '<=', $textwindow->index("fns$::lglobal{fnindex}") );

--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -1029,8 +1029,11 @@ sub footnotemove {
     while (1) {
         $index = $textwindow->search( '-regex', '--', 'FOOTNOTES:', $index, 'end' );
         last unless ($index);
-        unless ( $textwindow->get("$index +2l") =~ /^\[/ ) {
-            $textwindow->delete( $index, "$index+12c" );
+        unless ( $textwindow->get("$index +2l") =~ /^\[/ ) {    # Remove unused landing zones
+            my $start = $index;                                 # Also remove up to 2 blank lines before landing zone
+            $start = "$start -1l" if $textwindow->get( "$start -1l", "$start -1l lineend" ) eq "";
+            $start = "$start -1l" if $textwindow->get( "$start -1l", "$start -1l lineend" ) eq "";
+            $textwindow->delete( $start, "$index +1l linestart" );
         }
         $index .= '+4l';
     }


### PR DESCRIPTION
Two commits:
1. Remove blank lines around unused footnote landing zones - fixes #551
2. Remove blank lines around footnotes when they are moved inline - fixes #552

