### PR TITLE
Remove global debug flag

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -22,8 +22,6 @@ our $VERSION = '1.2.4';
 
 # DON'T FORGET to update the version number in makefile too
 
-# To debug use Devel::ptkdb perl -d:ptkdb guiguts.pl
-our $debug = 0;    # turn on to report debug messages. Do not commit with $debug on
 use FindBin;
 use lib $FindBin::Bin . "/lib";
 

--- a/src/lib/Guiguts/Highlight.pm
+++ b/src/lib/Guiguts/Highlight.pm
@@ -13,10 +13,7 @@ BEGIN {
 # Routine to find highlight word list
 sub scannosfile {
     my $top = $::top;
-    if ($::debug) { print "sub scannosfile\n"; }
-    if ($::debug) { print "scannoslistpath=$::scannoslistpath\n"; }
     $::scannoslistpath = ::os_normal($::scannoslistpath);
-    if ($::debug) { print "sub scannosfile1\n"; }
     my $types       = [ [ 'Text file', [ '.txt', ] ], [ 'All Files', ['*'] ], ];
     my $scannosfile = $top->getOpenFile(
         -title      => 'List of words to highlight?',
@@ -27,32 +24,18 @@ sub scannosfile {
         $::scannoslist = $scannosfile;
         my ( $name, $path, $extension ) = ::fileparse( $::scannoslist, '\.[^\.]*$' );
         $::scannoslistpath = $path;
-        if ($::debug) {
-            print "sub scannosfile1.5:" . $::scannoslistpath . "\n";
-        }
         ::highlight_scannos() if ($::scannos_highlighted);
         %{ $::lglobal{wordlist} } = ();
         ::highlight_scannos();
         read_word_list();
     }
-    if ($::debug) { print "sub scannosfile2:" . $::scannoslist . "\n"; }
     return;
 }
 ##routine to automatically highlight words in the text
 sub highlightscannos {
     my $textwindow = $::textwindow;
     my $top        = $::top;
-    if ($::debug) { print "sub highlightscannos\n"; }
     return 0 unless $::scannos_highlighted;
-    if ($::debug) {
-        print $::scannoslist . ":wdlist\n";
-        if ( -e $::scannoslist ) {
-            print $::scannoslist . ":exists\n";
-        } else {
-            print $::scannoslist . ":does not exist\n";
-        }
-        print $::lglobal{wordlist} . ":lglob wordlist\n";
-    }
     unless ( $::lglobal{wordlist} ) { read_word_list(); }
     my ( $fileend, undef ) = split /\./, $textwindow->index('end');
     if ( $::lglobal{hl_index} < $fileend ) {
@@ -145,12 +128,9 @@ sub read_word_list {
     my $top = $::top;
     ::scannosfile() unless ( defined $::scannoslist && -e $::scannoslist );
     return 0        unless $::scannoslist;
-    if ($::debug) { print "opening scannos list\n"; }
     if ( open my $fh, '<', $::scannoslist ) {
-        if ($::debug) { print "opened scannos list\n"; }
         while (<$fh>) {
             utf8::decode($_);
-            if ($::debug) { print "$_ :scanno read "; }
             if ( $_ =~ 'scannoslist' ) {
                 my $dialog = $top->Dialog(
                     -text    => 'Warning: File must contain only a list of words.',

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -187,10 +187,6 @@ sub searchtext {
             if   ( $::sopt[0] or $::sopt[3] ) { $mode = '-regexp' }
             else                              { $mode = '-exact' }
 
-            if ($::debug) {
-                print "$mode:$direction:$length:$searchterm:$searchstart:$end\n";
-            }
-
             #finally we actually do some searching
             if ( $::sopt[1] ) {
                 $::searchstartindex = $textwindow->search(

--- a/src/lib/Guiguts/SpellCheck.pm
+++ b/src/lib/Guiguts/SpellCheck.pm
@@ -376,7 +376,6 @@ sub spellget_misspellings {    # get list of misspelled words
 }
 
 sub getmisspelledwords {
-    if ($::debug) { print "sub getmisspelledwords\n"; }
     $::lglobal{misspelledlist} = ();
     my $section = shift;
     my ( $word, @templist );
@@ -390,16 +389,7 @@ sub getmisspelledwords {
     my $runner = ::runner::withfiles( 'checkfil.txt', 'temp.txt' );
     $runner->run( $::globalspellpath, @spellopt );
 
-    if ($::debug) {
-        print "\$::globalspellpath ", $::globalspellpath, "\n";
-        print "\@spellopt\n";
-        for my $element (@spellopt) {
-            print "$element\n";
-        }
-        print "checkfil.txt retained\n";
-    } else {
-        unlink 'checkfil.txt';
-    }
+    unlink 'checkfil.txt';
     open my $infile, '<', 'temp.txt';
     my ( $ln, $tmp );
     while ( $ln = <$infile> ) {
@@ -409,11 +399,7 @@ sub getmisspelledwords {
         push( @templist, $ln );
     }
     close $infile;
-    if ($::debug) {
-        print "temp.txt retained\n";
-    } else {
-        unlink 'temp.txt';
-    }
+    unlink 'temp.txt';
     foreach my $word (@templist) {
         next if ( exists( $::projectdict{$word} ) );
         push @{ $::lglobal{misspelledlist} }, $word;    # filter out project dictionary word list.

--- a/src/lib/Guiguts/Tests.pm
+++ b/src/lib/Guiguts/Tests.pm
@@ -34,8 +34,6 @@ sub runtests {
 
     ok( ( ::entity(255) eq '&yuml;' ), "entity(255) eq '&yuml;'" );
 
-    ok( $::debug == 0, "Do not release with \$debug = 1" );
-
     ok( 1 == do { 1 }, "do block" );
 
     runtesterrorcheck( "Bookloupe",        "textcheck.txt",   "bookloupebaseline.txt" );

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -9,7 +9,7 @@ BEGIN {
     @ISA    = qw(Exporter);
     @EXPORT = qw(&openpng &get_image_file &arabic &roman &popscroll
       &cmdinterp &nofileloadedwarning &win32_cmdline &win32_start &dialogboxcommonsetup &textentrydialogpopup
-      &win32_is_exe &win32_create_process &dos_path &runner &debug_dump &run &launchurl &escape_regexmetacharacters
+      &win32_is_exe &win32_create_process &dos_path &runner &run &launchurl &escape_regexmetacharacters
       &deaccentsort &deaccentdisplay &readlabels &working &initialize &initialize_popup_with_deletebinding
       &initialize_popup_without_deletebinding &titlecase &os_normal &escape_problems &natural_sort_alpha
       &natural_sort_length &natural_sort_freq &drag &cut &paste &entrypaste &textcopy &colcut &colcopy &colpaste &showversion
@@ -480,69 +480,6 @@ sub runner {
         # Return any error from the external program
         return $?;
     }
-}
-
-# just working out how to do things
-# prints everything I can think of to debug.txt
-# prints seenwords to words.txt
-sub debug_dump {
-    open my $save, '>', 'debug.txt';
-    print $save "\%lglobal values:\n";
-    for my $key ( keys %::lglobal ) {
-        if   ( $::lglobal{$key} ) { print $save "$key => $::lglobal{$key}\n"; }
-        else                      { print $save "$key x=>\n"; }
-    }
-    print $save "\n\@ARGV command line arguments:\n";
-    for my $element (@ARGV) {
-        print $save "$element\n";
-    }
-    print $save "\n\%SIG variables:\n";
-    for my $key ( keys %SIG ) {
-        if ( $SIG{$key} ) {
-            print $save "$key => $SIG{$key}\n";
-        } else {
-            print $save "$key x=>\n";
-        }
-    }
-    print $save "\n\%ENV environment variables:\n";
-    for my $key ( keys %ENV ) {
-        print $save "$key => $ENV{$key}\n";
-    }
-    print $save "\n\@INC include path:\n";
-    for my $element (@INC) {
-        print $save "$element\n";
-    }
-    print $save "\n\%INC included filenames:\n";
-    for my $key ( keys %INC ) {
-        print $save "$key => $INC{$key}\n";
-    }
-    close $save;
-    my $section = "\%lglobal{seenwords}\n";
-    open $save, '>:bytes', 'words.txt';
-    for my $key ( keys %{ $::lglobal{seenwords} } ) {
-        $section .= "$key => $::lglobal{seenwords}{$key}\n";
-    }
-    utf8::encode($section);
-    print $save $section;
-    close $save;
-    $section = "\%lglobal{seenwordslang}\n";
-    open $save, '>:bytes', 'words2.txt';
-    for my $key ( keys %{ $::lglobal{seenwords} } ) {
-        if ( $::lglobal{seenwordslang}{$key} ) {
-            $section .= "$key => $::lglobal{seenwordslang}{$key}\n";
-        } else {
-            $section .= "$key x=>\n";
-        }
-    }
-    utf8::encode($section);
-    print $save $section;
-    close $save;
-    open $save, '>', 'project.txt';
-    print $save "\%projectdict\n";
-    for my $key ( keys %::projectdict ) {
-        print $save "$key => $::projectdict{$key}\n";
-    }
-    close $save;
 }
 
 sub escape_regexmetacharacters {


### PR DESCRIPTION
Since only partially implemented in limited sections of the code, the debug flag is no
real use and the debug code just detracts from the main flow. Also the debug_dump
routine for similar reasons.

Fixes #453