### PR TITLE
Fix HTML page numbering errors

### DIFF
--- a/src/tests/bookloupebaseline.txt
+++ b/src/tests/bookloupebaseline.txt
@@ -1,10 +1,5 @@
 Beginning check: Bookloupe
-  --> 1694 lines in this file contain '.,'. Not reporting them.
-  --> 515 lines in this file contain forward slashes. Not reporting them.
-  --> 27 lines in this file contain unpunctuated endquotes. Not reporting them.
-  --> 543 lines in this file contain standalone 0s and 1s. Not reporting them.
   --> 26 lines in this file are VERY long!
-  --> There are a lot of foreign letters here. Not reporting them.
   *** Verbose output is ON -- you asked for it! ***
 
   --> 5585 queries.

--- a/src/tests/testhtml2baseline.html
+++ b/src/tests/testhtml2baseline.html
@@ -267,7 +267,7 @@ INSTRUMENTS</p>
 <hr class="chap x-ebookmaker-drop" />
 
 <div class="chapter">
-<p><span class="pagenum" id="Page_3">[Pg xiv]</span></p>
+<p><span class="pagenum" id="Page_3">[Pg 3]</span></p>
 <h2 class="nobreak" id="The_Tools_of_Science"><i>The Tools of Science</i></h2>
 </div>
 


### PR DESCRIPTION
1. If two page markers were adjacent, in one place the first one encountered might
be used and in the other the highest one numerically might be used, leading to an
id of 'Page_292' on page '293', for example. Now always choose the highest
numbered.

2. If Roman page xiv immediately preceded Arabic page 3, it treated the Roman
number as the "last" since it was a bigger number. Since Roman page numbers
nearly always precede Arabic, it's safer to force that than the reverse.

3. Minor fix to baseline bookloupe test file while tests being edited.

Fixes #555 