### PR TITLE
Pass title and author to locally-run ebookmaker

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -37,6 +37,7 @@ use File::Spec::Functions qw(catdir);
 use File::Copy;
 use File::Compare;
 use File::Which;
+use HTML::Entities;
 use HTML::TokeParser;
 use Image::Size;
 use IPC::Open2;

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2053,7 +2053,7 @@ sub ebookmaker {
         my $tstring = $textwindow->get( $tbeg . '+7c', $tend );    # Get whole title/author string
         $tstring =~ s/\s+/ /g;                                     # Join into one line, single spaced
         if (
-            $tstring =~ s/The Project Gutenberg EBook of//i         # Strip PG part - 2 formats
+            $tstring =~ s/The Project Gutenberg EBook of//i        # Strip PG part - 2 formats
             or $tstring =~ s/&mdash;A Project Gutenberg eBook//i
         ) {
             HTML::Entities::decode_entities($tstring);             # HTML entities need converting to characters

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2026,7 +2026,7 @@ sub seeindex {
 
 # Run EBookMaker tool on current HTML file to create epub and mobi versions
 sub ebookmaker {
-
+    my $textwindow = $::textwindow;
     ::busy();    # Change cursor to show user something is happening
     unless ($::ebookmakercommand) {
         ::locateExecutable( 'EBookMaker', \$::ebookmakercommand );
@@ -2043,6 +2043,34 @@ sub ebookmaker {
         )->Show;
         return;
     }
+
+    # Get title and author information
+    my $ttitle  = $fname;      # Title defaults to base filename
+    my $tauthor = 'Unknown';
+    my $tbeg    = $textwindow->search( '-exact', '--', '<title>',  '1.0', '20.0' );
+    my $tend    = $textwindow->search( '-exact', '--', '</title>', '1.0', '20.0' );
+    if ( $tbeg & $tend ) {
+        my $tstring = $textwindow->get( $tbeg . '+7c', $tend );    # Get whole title/author string
+        $tstring =~ s/\s+/ /g;                                     # Join into one line, single spaced
+        if (
+            $tstring =~ s/The Project Gutenberg EBook of//         # Strip PG part - 2 formats
+            or $tstring =~ s/&mdash;A Project Gutenberg eBook//
+        ) {
+            HTML::Entities::decode_entities($tstring);             # HTML entities need converting to characters
+            $tstring = deaccentdisplay($tstring);                  # Remove accents since passing as argument in shell
+            $tstring =~ s/[^[:ascii:]]/_/g;                        # Substitute "_" for any remaining non-ASCII characters
+
+            # Split into title/author - use last "by" in case "by" is in the book title
+            my $byidx = rindex( $tstring, ", by " );
+            if ( $byidx > -1 ) {
+                $ttitle = substr( $tstring, 0, $byidx );
+                $ttitle =~ s/^\s+|\s+$//g;
+                $tauthor = substr( $tstring, $byidx + 5 );
+                $tauthor =~ s/^\s+|\s+$//g;
+            }
+        }
+    }
+
     my $filepath  = $::lglobal{global_filename};
     my $outputdir = $::globallastpath;
 
@@ -2059,8 +2087,13 @@ sub ebookmaker {
     # Run ebookmaker, redirecting stdout and stderr to a file to analyse afterwards
     my $tmpfile = 'ebookmaker.tmp';
     my $runner  = ::runner::withfiles( undef, $tmpfile, $tmpfile );
-    $runner->run( $::ebookmakercommand, "--verbose", "--max-depth=3", "--make=epub.images",
-        "--make=kindle.images", "--output-dir=$outputdir.", "--title=$fname", "$filepath" );
+    $runner->run(
+        $::ebookmakercommand,   "--verbose",
+        "--max-depth=3",        "--make=epub.images",
+        "--make=kindle.images", "--output-dir=$outputdir.",
+        "--title=$ttitle",      "--author=$tauthor",
+        "$filepath"
+    );
 
     # Check for errors or warnings in ebookmaker output
     open my $ebmout, '<', $tmpfile;

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2053,8 +2053,8 @@ sub ebookmaker {
         my $tstring = $textwindow->get( $tbeg . '+7c', $tend );    # Get whole title/author string
         $tstring =~ s/\s+/ /g;                                     # Join into one line, single spaced
         if (
-            $tstring =~ s/The Project Gutenberg EBook of//         # Strip PG part - 2 formats
-            or $tstring =~ s/&mdash;A Project Gutenberg eBook//
+            $tstring =~ s/The Project Gutenberg EBook of//i         # Strip PG part - 2 formats
+            or $tstring =~ s/&mdash;A Project Gutenberg eBook//i
         ) {
             HTML::Entities::decode_entities($tstring);             # HTML entities need converting to characters
             $tstring = deaccentdisplay($tstring);                  # Remove accents since passing as argument in shell


### PR DESCRIPTION
Extract title and author from `<title>` element in HTML file and pass as arguments
to ebookmaker. This causes the epub/Kindle files to be named with the book title
and the title and author are also stored in the files, so they show correctly on the
reader's e-reading device. This is helpful for creating smooth-reading versions.

#Fixes #168