### PR TITLE
Convert all accented characters during "display" conversion

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -37,6 +37,7 @@ use File::Spec::Functions qw(catdir);
 use File::Copy;
 use File::Compare;
 use File::Which;
+use HTML::Entities;
 use HTML::TokeParser;
 use Image::Size;
 use IPC::Open2;

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -499,14 +499,13 @@ sub deaccentsort {
 
 sub deaccentdisplay {
     my $phrase = shift;
-    return $phrase unless ( $phrase =~ y/\xC0-\xFF// );
+    return $phrase unless ( $phrase =~ /[$::convertcharssinglesearch]/ );
 
     # first convert the characters specified by the language
     $phrase =~ s/([$::convertcharsdisplaysearch])/$::convertcharsdisplay{$1}/g;
 
-    # then convert anything that hasn't been converted already, using the default one character substitute
-    $phrase =~
-      tr/ÀÁÂÃÄÅàáâãäåÇçĞğÈÉÊËèéêëÌÍÎÏìíîïÒÓÔÕÖØòóôõöøÑñßŞşÙÚÛÜùúûüİÿı/AAAAAAaaaaaaCcDdEEEEeeeeIIIIiiiiOOOOOOooooooNnsTtUUUUuuuuYyy/;
+    # then convert anything that hasn't been converted already
+    eval "\$phrase =~ tr/$::convertcharssinglesearch/$::convertcharssinglereplace/";
     return $phrase;
 }
 
@@ -538,7 +537,7 @@ sub readlabels {
     $::convertcharssinglesearch =
 
       # Latin-1 Supplement
-      "ÀÁÂÃÄÅÆàáâãäåæÇçĞğÈÉÊËèéêëÌÍÎÏìíîïÒÓÔÕÖØòóôõöøÑñßŞşÙÚÛÜùúûüİÿı"
+      "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏ" . "ĞÑÒÓÔÕÖØÙÚÛÜİŞß" . "àáâãäåæçèéêëìíîï" . "ğñòóôõöøùúûüışÿ"
 
       # Latin Extended A
       . "\x{100}\x{101}\x{102}\x{103}\x{104}\x{105}\x{106}\x{107}\x{108}\x{109}\x{10a}\x{10b}\x{10c}\x{10d}\x{10e}\x{10f}"
@@ -587,7 +586,7 @@ sub readlabels {
     $::convertcharssinglereplace =
 
       # Latin-1 Supplement
-      "AAAAAAAaaaaaaaCcDdEEEEeeeeIIIIiiiiOOOOOOooooooNnsTtUUUUuuuuYyy"
+      "AAAAAAACEEEEIIII" . "DNOOOOOOUUUUYTs" . "aaaaaaaceeeeiiii" . "dnoooooouuuuyty"
 
       # Latin Extended A
       . "AaAaAaCcCcCcCcDd"

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2026,7 +2026,7 @@ sub seeindex {
 
 # Run EBookMaker tool on current HTML file to create epub and mobi versions
 sub ebookmaker {
-
+    my $textwindow = $::textwindow;
     ::busy();    # Change cursor to show user something is happening
     unless ($::ebookmakercommand) {
         ::locateExecutable( 'EBookMaker', \$::ebookmakercommand );
@@ -2043,6 +2043,34 @@ sub ebookmaker {
         )->Show;
         return;
     }
+
+    # Get title and author information
+    my $ttitle  = $fname;      # Title defaults to base filename
+    my $tauthor = 'Unknown';
+    my $tbeg    = $textwindow->search( '-exact', '--', '<title>',  '1.0', '20.0' );
+    my $tend    = $textwindow->search( '-exact', '--', '</title>', '1.0', '20.0' );
+    if ( $tbeg & $tend ) {
+        my $tstring = $textwindow->get( $tbeg . '+7c', $tend );    # Get whole title/author string
+        $tstring =~ s/\s+/ /g;                                     # Join into one line, single spaced
+        if (
+            $tstring =~ s/The Project Gutenberg EBook of//         # Strip PG part - 2 formats
+            or $tstring =~ s/&mdash;A Project Gutenberg eBook//
+        ) {
+            HTML::Entities::decode_entities($tstring);             # HTML entities need converting to characters
+            $tstring = deaccentdisplay($tstring);                  # Remove accents since passing as argument in shell
+            $tstring =~ s/[^[:ascii:]]/_/g;                        # Substitute "_" for any remaining non-ASCII characters
+
+            # Split into title/author - use last "by" in case "by" is in the book title
+            my $byidx = rindex( $tstring, ", by " );
+            if ( $byidx > -1 ) {
+                $ttitle = substr( $tstring, 0, $byidx );
+                $ttitle =~ s/^\s+|\s+$//g;
+                $tauthor = substr( $tstring, $byidx + 5 );
+                $tauthor =~ s/^\s+|\s+$//g;
+            }
+        }
+    }
+
     my $filepath  = $::lglobal{global_filename};
     my $outputdir = $::globallastpath;
 
@@ -2059,8 +2087,13 @@ sub ebookmaker {
     # Run ebookmaker, redirecting stdout and stderr to a file to analyse afterwards
     my $tmpfile = 'ebookmaker.tmp';
     my $runner  = ::runner::withfiles( undef, $tmpfile, $tmpfile );
-    $runner->run( $::ebookmakercommand, "--verbose", "--max-depth=3", "--make=epub.images",
-        "--make=kindle.images", "--output-dir=$outputdir.", "--title=$fname", "$filepath" );
+    $runner->run(
+        $::ebookmakercommand,   "--verbose",
+        "--max-depth=3",        "--make=epub.images",
+        "--make=kindle.images", "--output-dir=$outputdir.",
+        "--title=$ttitle",      "--author=$tauthor",
+        "$filepath"
+    );
 
     # Check for errors or warnings in ebookmaker output
     open my $ebmout, '<', $tmpfile;


### PR DESCRIPTION
If an accented character was not handled by the language-specific conversions for
display purposes, then only the Latin-1 supplement characters were also converted.

Changed to include all Latin characters from the Extended and Additional blocks.
Also ordered and split list of converted characters in the Latin-1 Supplement block
to match the handling of the other blocks.

Fixes #569 