### PR TITLE
Avoid interpreting `I/`, etc. in text as markup

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -722,7 +722,7 @@ sub html_convert_body {
         }
 
         # list
-        if ( $selection =~ /^\/[Ll]/ ) {
+        if ( $selection =~ /^\/[Ll]$/ ) {
             $listmark = 1;
             $ital     = 0;
             if ( ( $last5[2] ) && ( !$last5[3] ) ) {
@@ -756,7 +756,7 @@ sub html_convert_body {
         }
 
         #close list
-        if ( $selection =~ /^[Ll]\// ) {
+        if ( $selection =~ /^[Ll]\/$/ ) {
             $listmark = 0;
             $ital     = 0;
 
@@ -823,8 +823,8 @@ sub html_convert_body {
             next;
         }
 
-        # Start of index (/I)
-        if ( $selection =~ /^\/[Ii]/ ) {
+        # Start of index (/I) including possible [n.n,n] rewrap margin settings
+        if ( $selection =~ /^\/[Ii]$/ or $selection =~ /^\/[Ii]\[[\d\.,]+]/ ) {
             $indexline = 1;
             $textwindow->ntdelete( "$step.0", "$step.end" );
             $textwindow->ntinsert( "$step.0", '<ul class="index">' );
@@ -842,7 +842,7 @@ sub html_convert_body {
         }
 
         # End of index (I/)
-        if ( $selection =~ /^[Ii]\// ) {
+        if ( $selection =~ /^[Ii]\/$/ ) {
             $indexline = 0;
 
             # Insert first to avoid subsequent page marker moving back inside list


### PR DESCRIPTION
There were several places where 'I/' and potentially 'L/' and similar strings in the
text of the book could be wrongly interpreted as markup. These affected both text
rewrapping and HTML conversion. Various tests have been tightened up, such as
insisting `I/` is on a line on its own, or possibly with [n.n,n] rewrap directive.

Note that it is still possible that such a string in the text could end up on a line on
its own and be misinterpreted, but very unlikely. `I/J` or 'I/27' might occur, but rarely
`I/` with no punctuation or letters after it.

Fixes #564