### PR TITLE
Make page separator automaticity level persistent

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -155,6 +155,7 @@ our $nobell                 = 0;
 our $donotcenterpagemarkers = 0;
 our $nohighlights           = 0;
 our $notoolbar              = 0;
+our $pagesepauto            = 3;                           # How automatically to fix page separators
 our $intelligentWF          = 0;
 our $defaultpngspath        = ::os_normal('pngs/');
 our $pngspath               = q{};

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -902,7 +902,7 @@ EOM
             font_char fontname fontsize fontweight geometry
             gesperrt_char globalaspellmode highlightcolor history_size htmlimageallowpixels ignoreversionnumber
             intelligentWF ignoreversions italic_char jeebiesmode lastversioncheck lastversionrun lmargin markupthreshold
-            multisearchsize multiterm nobell nohighlights projectfileslocation notoolbar poetrylmargin projectfileslocation
+            multisearchsize multiterm nobell nohighlights pagesepauto projectfileslocation notoolbar poetrylmargin projectfileslocation
             recentfile_size rmargin rmargindiff rwhyphenspace sc_char scannos_highlighted spellcheckwithenchant stayontop toolside
             trackoperations txt_conv_bold txt_conv_font txt_conv_gesperrt txt_conv_italic txt_conv_sc txt_conv_tb
             txtfontname txtfontsize txtfontweight txtfontsystemuse

--- a/src/lib/Guiguts/PageSeparators.pm
+++ b/src/lib/Guiguts/PageSeparators.pm
@@ -74,7 +74,7 @@ sub refreshpageseparator {
       if $::searchstartindex;
 
     # Handle Automatic
-    if ( $::lglobal{pagesepauto} >= 2 and $::searchstartindex ) {
+    if ( $::pagesepauto >= 2 and $::searchstartindex ) {
         handleautomaticonrefresh() unless $noauto;
     }
     $textwindow->xviewMoveto(.0);
@@ -109,7 +109,7 @@ sub handleautomaticonrefresh {
         }
         $textwindow->insert( $index, "\n" );
 
-        if ( $::lglobal{pagesepauto} == 2 ) {
+        if ( $::pagesepauto == 2 ) {
             my $nothingdone = 1;
 
             # If the last character is a word, ";" or ","
@@ -145,7 +145,7 @@ sub handleautomaticonrefresh {
             }
             last if $nothingdone;
 
-        } elsif ( $::lglobal{pagesepauto} == 3 ) {
+        } elsif ( $::pagesepauto == 3 ) {
             my $linebefore = $textwindow->get( "page -10c",       "page -1c" );
             my $lineafter  = $textwindow->get( "page1 linestart", "page1 linestart +5c" );
             if ( $lineafter =~ /^\n\n\n\n/ ) {
@@ -277,7 +277,7 @@ sub processpageseparatorrefresh {
     $textwindow->addGlobStart;    # Single undo around all edits made from this click
     ::hidepagenums();
     processpageseparator($op);
-    refreshpageseparator() if $::lglobal{pagesepauto} >= 1;
+    refreshpageseparator() if $::pagesepauto >= 1;
     $textwindow->addGlobEnd;
 }
 
@@ -485,7 +485,6 @@ sub separatorpopup {
     my $textwindow = $::textwindow;
     my $top        = $::top;
     ::operationadd('Begin Fixup Page Separators');
-    $::lglobal{pagesepauto} = 1 if !defined $::lglobal{pagesepauto} || $::lglobal{pagesepauto} >= 2;
     if ( defined( $::lglobal{pageseppop} ) ) {
         $::lglobal{pageseppop}->deiconify;
         $::lglobal{pageseppop}->raise;
@@ -537,25 +536,25 @@ sub separatorpopup {
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         my $sf3 = $::lglobal{pageseppop}->Frame->pack( -side => 'top', -anchor => 'n', -padx => 5 );
         $sf3->Radiobutton(
-            -variable    => \$::lglobal{pagesepauto},
+            -variable    => \$::pagesepauto,
             -value       => 0,
             -selectcolor => $::lglobal{checkcolor},
             -text        => 'No Auto',
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         $sf3->Radiobutton(
-            -variable    => \$::lglobal{pagesepauto},
+            -variable    => \$::pagesepauto,
             -value       => 1,
             -selectcolor => $::lglobal{checkcolor},
             -text        => 'Auto Advance',
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         $sf3->Radiobutton(
-            -variable    => \$::lglobal{pagesepauto},
+            -variable    => \$::pagesepauto,
             -value       => 2,
             -selectcolor => $::lglobal{checkcolor},
             -text        => '80% Auto',
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         $sf3->Radiobutton(
-            -variable    => \$::lglobal{pagesepauto},
+            -variable    => \$::pagesepauto,
             -value       => 3,
             -selectcolor => $::lglobal{checkcolor},
             -text        => '99% Auto',
@@ -615,8 +614,8 @@ sub separatorpopup {
         $::lglobal{pageseppop}->Tk::bind( '<h>'            => sub { $chjoinbutton->invoke; } );
         $::lglobal{pageseppop}->Tk::bind(
             '<a>' => sub {
-                $::lglobal{pagesepauto}++;
-                $::lglobal{pagesepauto} = 0 if $::lglobal{pagesepauto} == 4;
+                $::pagesepauto++;
+                $::pagesepauto = 0 if $::pagesepauto == 4;
             }
         );
         $::lglobal{pageseppop}->Tk::bind( '<v>' => sub { $viewbutton->invoke; } );


### PR DESCRIPTION
The user can choose between 4 options to control how automatically page separators
are fixed. This commit makes that flag persistent rather than always defaulting to the
lowest automatic level.

Fixes #567