### PR TITLE
Add vertical alignment column highlight

### DIFF
--- a/src/hotkeys.txt
+++ b/src/hotkeys.txt
@@ -79,6 +79,7 @@ F8 -- open Stealth Scannos search
 <ctrl>+, -- highlight all apostrophes in selection
 <ctrl>+. -- highlight all double quotes in selection
 <ctrl>+<alt>+h -- highlight arbitrary characters in selection
+<ctrl>+<shift>+a -- toggle highlighting of vertical column at cursor
 <ctrl>+0 -- remove all highlights
 
 <ctrl>+1,2,3,4,5 -- go to bookmark 1,2,3,4,5

--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -14,10 +14,11 @@ sub keybindings {
     my $top        = $::top;
 
     # Highlight
-    keybind( '<Control-comma>',  sub { ::hilitesinglequotes(); } );
-    keybind( '<Control-period>', sub { ::hilitedoublequotes(); } );
-    keybind( '<Control-Alt-h>',  sub { ::hilitepopup(); } );
-    keybind( '<Control-0>',      sub { ::hiliteremove(); } );
+    keybind( '<Control-comma>',   sub { ::hilitesinglequotes(); } );
+    keybind( '<Control-period>',  sub { ::hilitedoublequotes(); } );
+    keybind( '<Control-Alt-h>',   sub { ::hilitepopup(); } );
+    keybind( '<Control-Shift-a>', sub { ::hilite_alignment_toggle(); } );
+    keybind( '<Control-0>',       sub { ::hiliteremove(); } );
 
     # File
     keybind( '<Control-o>',       sub { ::file_open($textwindow); } );

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -318,6 +318,20 @@ sub menu_search {
             -command     => \&::hilitepopup,
         ],
         [
+            Checkbutton  => 'Highlight Al~ignment Column',
+            -accelerator => 'Ctrl+Shift+a',
+            -variable    => \$::lglobal{highlightalignment},
+            -onvalue     => 1,
+            -offvalue    => 0,
+            -command     => sub {
+                if ( $::lglobal{highlightalignment} ) {
+                    ::hilite_alignment_start();
+                } else {
+                    ::hilite_alignment_stop();
+                }
+            }
+        ],
+        [
             'command', 'Re~move Highlights',
             -accelerator => 'Ctrl+0',
             -command     => \&::hiliteremove,

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1090,6 +1090,7 @@ sub initialize {
     $textwindow->tagConfigure( 'quotemark', -background => '#CCCCFF' );
     $textwindow->tagConfigure( 'highlight', -background => 'orange' );
     $textwindow->tagConfigure( 'linesel',   -background => '#8EFD94' );
+    $textwindow->tagConfigure( 'alignment', -background => '#8EFD94' );
     $textwindow->tagConfigure(
         'pagenum',
         -background  => 'yellow',


### PR DESCRIPTION
Add option to Select menu with other highlight options to toggle a vertical column
of highlights at the cursor to aid with alignment of long tables, frontmatter, etc. in
text version.
Also add shortcut Ctrl+Shift+a

Fixes #368 