### PR TITLE
Make Compose Sequence available via menus

### DIFF
--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -465,10 +465,15 @@ sub menu_tools_charactertools {
             'command', 'Convert ~Windows CP 1252 characters to Unicode',
             -command => \&::cp1252toUni
         ],
-        [ 'command',   'Search for ~Transliterations...', -command => \&::find_transliterations ],
-        [ 'command',   'Common~ly-Used Characters Chart', -command => \&::commoncharspopup ],
-        [ 'command',   'Unicode Character ~Entry',        -command => \&::utfcharentrypopup ],
-        [ 'command',   'Unicode Character ~Search',       -command => \&::utfcharsearchpopup ],
+        [ 'command', 'Search for ~Transliterations...', -command => \&::find_transliterations ],
+        [ 'command', 'Common~ly-Used Characters Chart', -command => \&::commoncharspopup ],
+        [ 'command', 'Unicode Character ~Entry',        -command => \&::utfcharentrypopup ],
+        [ 'command', 'Unicode Character ~Search',       -command => \&::utfcharsearchpopup ],
+        [
+            'command', 'C~ompose Sequence',
+            -accelerator => 'AltGr / Ctrl+m',
+            -command     => \&::composepopup
+        ],
         [ 'separator', '' ],
         [ 'command',   '~Greek Transliteration',     -command => \&::greekpopup ],
         [ 'command',   'Find and ~Convert Greek...', -command => \&::findandextractgreek ],


### PR DESCRIPTION
Add Compose Sequence to the Tools->Character Tools menu.
Previously only available via the Compose Key, this should be available via menus.

Fixes #589