### PR TITLE
Provide fraction conversion functionality

### DIFF
--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -415,6 +415,7 @@ sub menu_tools {
                 $textwindow->addGlobEnd;
             }
         ],
+        menu_cascade( 'Con~vert Fractions', &menu_tools_convertfractions ),
         [ 'separator', '' ],
         [
             'command',
@@ -472,6 +473,22 @@ sub menu_tools_charactertools {
         [ 'separator', '' ],
         [ 'command',   '~Greek Transliteration',     -command => \&::greekpopup ],
         [ 'command',   'Find and ~Convert Greek...', -command => \&::findandextractgreek ],
+    ];
+}
+
+sub menu_tools_convertfractions {
+    [
+        [ 'command', 'Unicode fractions only', -command => sub { ::fractionconvert('unicode'); } ],
+        [
+            'command',
+            'Unicode fractions or superscript/subscript',
+            -command => sub { ::fractionconvert('mixed'); }
+        ],
+        [
+            'command',
+            'All to superscript/subscript',
+            -command => sub { ::fractionconvert('supsub'); }
+        ],
     ];
 }
 


### PR DESCRIPTION
1. Converts fractions in DP format such as 2/3 or 1-1/4 to Unicode characters
2. Three options:
a. Only convert those that have a single Unicode character representation - leave
others in DP format
b. Convert all possible to a single Unicode character and use superscripts and
subscripts for the rest.
c. Use superscripts and subscripts for all.
3. Accepts either the Fraction Slash or standard slash characters as input.
4. Always uses Fraction Slash on output with subscripts and superscripts.
5. If character preceding match is an alphabetic, then don't convert the fraction,
to avoid altering strings such as ABC1/2 or A-B-1/2, which are more likely a
code number, serial number, etc. In maths, there would normally be a space, e.g.
"A - B - 1/2" - this fraction will be converted.

#Fixes #169