### PR TITLE
Avoid undefined variable errors when cancelling Save As

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -67,9 +67,9 @@ sub file_saveas {
             -initialdir  => $::globallastpath,
             -initialfile => $initialfile,
         );
-        last if bad_filename_chars($name);    # break out of block if bad filename
 
         if ( defined($name) and length($name) ) {
+            last if bad_filename_chars($name);    # break out of block if bad filename
             $::top->Busy( -recurse => 1 );
             $textwindow->SaveUTF($name);
             my ( $fname, $extension, $filevar );
@@ -81,7 +81,7 @@ sub file_saveas {
             _bin_save();
             ::_recentupdate($name);
             $::top->Unbusy( -recurse => 1 );
-            $textwindow->ResetUndo;    #necessary to reset edited flag
+            $textwindow->ResetUndo;               #necessary to reset edited flag
             ::setedited(0);
             ::update_indicators();
         }
@@ -154,8 +154,6 @@ sub file_import_preptext {
                 utf8::decode($line);
                 $line =~ s/^\x{FEFF}?//;
                 $line =~ s/\cM\cJ|\cM|\cJ/\n/g;
-
-                #$line = eol_convert($line);
                 $line =~ s/[\t \xA0]+$//smg;
                 $textwindow->ntinsert( 'end', $line );
                 close $file;
@@ -782,7 +780,7 @@ sub openfile {    # and open it
 # On failure, pops a dialog to warn the user.
 sub bad_filename_chars {
     my $name = shift;
-    return 0 if $name !~ /[^\x20-\x7F]/;
+    return 0 if not $name or $name !~ /[^\x20-\x7F]/;
     $::top->Dialog(
         -text    => 'Only ASCII characters are permitted in filenames.',
         -bitmap  => 'error',

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1388,8 +1388,6 @@ sub html_parse_header {
           or warn "Could not open header file. $!\n";
         while (<$infile>) {
             $_ =~ s/\cM\cJ|\cM|\cJ/\n/g;
-
-            # FIXME: $_ = eol_convert($_);
             $headertext .= $_;
         }
         close $infile;
@@ -1519,8 +1517,6 @@ sub html_wrapup {
         open my $infile, '<', 'footer.txt';
         while (<$infile>) {
             $_ =~ s/\cM\cJ|\cM|\cJ/\n/g;
-
-            # FIXME: $_ = eol_convert($_);
             $footertext .= $_;
         }
         close $infile;

--- a/src/lib/Guiguts/HelpMenu.pm
+++ b/src/lib/Guiguts/HelpMenu.pm
@@ -134,8 +134,6 @@ sub regexref {
             if ( open my $ref, '<', 'regref.txt' ) {
                 while (<$ref>) {
                     $_ =~ s/\cM\cJ|\cM|\cJ/\n/g;
-
-                    #$_ = eol_convert($_);
                     $regtext->insert( 'end', $_ );
                 }
             } else {

--- a/src/lib/Guiguts/TextUnicode.pm
+++ b/src/lib/Guiguts/TextUnicode.pm
@@ -19,22 +19,16 @@ sub Load {
         my $count = 1;
         my $progress;
         my $line = <$fh>;
-        utf8::decode($line);
-        $line =~ s/^\x{FEFF}?//;
-
-        #$line = ::eol_convert($line);
-        $line =~ s/\cM\cJ|\cM|\cJ/\n/g;
-
-        #$line = ::eol_whitespace($line);
-        $w->ntinsert( 'end', $line );
+        if ($line) {
+            utf8::decode($line);
+            $line =~ s/^\x{FEFF}?//;
+            $line =~ s/\cM\cJ|\cM|\cJ/\n/g;
+            $w->ntinsert( 'end', $line );
+        }
         while (<$fh>) {
             utf8::decode($_);
             $_ =~ s/\cM\cJ|\cM|\cJ/\n/g;
-
-            #$_ = ::eol_convert($_);
             $_ =~ s/[\t \xA0]+$//;
-
-            #$_ = ::eol_whitespace($_);
             $w->ntinsert( 'end', $_ );
             if ( ( $count++ % 1000 ) == 0 ) {
                 $progress = $w->TextUndoFileProgress(
@@ -91,10 +85,8 @@ sub SaveUTF {
         my $end  = $w->index("$index lineend +1c");
         my $line = $w->get( $index, $end );
         $line =~ s/[\t \xA0]+$//;
-
-        #$line = ::eol_whitespace($line);
         $line =~ s/\cM\cJ|\cM|\cJ/\cM\cJ/g if (OS_Win);
-        utf8::encode($line)                if $unicode;
+        utf8::encode($line) if $unicode;
         $w->BackTrace("Cannot write to temp file:$!\n") and return
           unless print $tempfh $line;
         $index = $end;
@@ -147,20 +139,13 @@ sub IncludeFile {
         utf8::decode($line);
         $line =~ s/^\x{FFEF}?//;
         $line =~ s/\cM\cJ|\cM|\cJ/\n/g;
-
-        #$line = ::eol_convert($line);
         $line =~ s/[\t \xA0]+$//;
-
-        #$line = ::eol_whitespace($line);
         $w->insert( 'insert', $line );
+
         while (<$fh>) {
             utf8::decode($_);
             $_ =~ s/\cM\cJ|\cM|\cJ/\n/g;
-
-            #$_ = ::eol_convert($_);
             $_ =~ s/[\t \xA0]+$//;
-
-            #$_ = ::eol_whitespace($_);
             $w->insert( 'insert', $_ );
             if ( ( $count++ % 1000 ) == 0 ) {
                 $progress = $w->TextUndoFileProgress(


### PR DESCRIPTION
1. Cancelling Save As caused an error when code tried to check undefined filename
for non-ASCII characters
2. Attempting to open an empty file also gave similar error.
3. Several commented out calls to eol_convert and eol_whitespace removed

Fixes #592 