### PR TITLE
Align search options on left of dialog

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1014,9 +1014,7 @@ sub searchpopup {
         );
         my $sf2 = $::lglobal{searchpop}->Frame->pack(
             -side   => 'top',
-            -anchor => 'n',
-            -expand => 'y',
-            -fill   => 'x',
+            -anchor => 'w',
             -pady   => 1
         );
         $::lglobal{searchop1} = $sf2->Checkbutton(


### PR DESCRIPTION
Previous changes to dialog left the search options centered meaning they moved
when the dialog was resized. Restored to be left justified.

Fixes #593 