### PR TITLE
Add ability to insert page labels to text file

### DIFF
--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -592,6 +592,13 @@ sub menu_txt {
         [ 'separator', '' ],
         [ 'command',   'Dra~w ASCII Boxes...',    -command => \&::asciibox_popup ],
         [ 'command',   'ASCII Table E~ffects...', -command => \&::tablefx ],
+        [
+            'command',
+            'Ins~ert Page Labels',
+            -command => sub {
+                ::pagetextinsert('labels');
+            }
+        ],
         [ 'separator', '' ],
         [
             'command',


### PR DESCRIPTION
Insert Page Makers was already in the Adjust Page Markers dialog, but this is not as
helpful as being able to insert the page labels as they would be displayed in the HTML
file. Button added to Adjust Page Markers dialog and to Txt menu where it belongs
in terms of PPing procedure.

Fixes #423