### PR TITLE
Fix small bugs relating to moving footnotes inline

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -360,6 +360,7 @@ sub clearvars {
     ::setedited(0);
     ::hidepagenums();
     @{ $::lglobal{fnarray} } = ();
+    $::lglobal{fntotal} = 0;
     undef $::lglobal{prepfile};
     return;
 }

--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -740,16 +740,9 @@ sub footnotefixup {
         $::lglobal{fntotal}++;
         $::lglobal{fnindex} = $::lglobal{fntotal};
         if ( $::lglobal{fnsecondpass} ) {
-            unless ($textwindow->markExists("fns$::lglobal{fnindex}")
-                and $textwindow->markExists("fne$::lglobal{fnindex}") ) {
-                $::top->Dialog(
-                    -text    => "Undo, then re-run First Pass and check for errors.",
-                    -bitmap  => 'error',
-                    -title   => 'Unexpected end of footnotes',
-                    -buttons => ['Ok']
-                )->Show;
-                last;
-            }
+            last
+              unless $textwindow->markExists("fns$::lglobal{fnindex}")
+              and $textwindow->markExists("fne$::lglobal{fnindex}");
             ( $start, $end ) = (
                 $textwindow->index("fns$::lglobal{fnindex}"),
                 $textwindow->index("fne$::lglobal{fnindex}")
@@ -1259,6 +1252,9 @@ sub setanchor {
         $::lglobal{fnarray}->[ $::lglobal{fnindex} ][3] = '';
         $::lglobal{fnarray}->[ $::lglobal{fnindex} ][6] = '';
         footnoteadjust();
+
+        # Ensure "current footnote" mark is set correctly after moving footnote
+        $textwindow->markSet( 'fnindex', $textwindow->index( 'fns' . $::lglobal{fnindex} ) );
     } else {
         $::lglobal{fnarray}->[ $::lglobal{fnindex} ][2] = $insert;
         if (

--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -920,14 +920,16 @@ sub setlz {
     my $prevMark = $textwindow->markPrevious("$lzindex +1l lineend");
 
     # Skip non-page marks
-    while ( $prevMark ne ""
+    while ( $prevMark
         and $prevMark !~ /Pg/
         and $textwindow->compare( $prevMark, '>=', "$lzindex-1l linestart" ) ) {
         $prevMark = $textwindow->markPrevious($prevMark);
     }
 
     # If we found a nearby page mark, then use it (unless it's within text)
-    if ( $prevMark =~ /Pg/ and $textwindow->compare( $prevMark, '>=', "$lzindex-1l linestart" ) ) {
+    if (    $prevMark
+        and $prevMark =~ /Pg/
+        and $textwindow->compare( $prevMark, '>=', "$lzindex-1l linestart" ) ) {
         $textwindow->markGravity( $prevMark, 'right' );    # Ensure mark stays to the right of inserted text
 
         # Cope with page mark being at start of first chapter blank line or at end of last chapter's text
@@ -1031,6 +1033,7 @@ sub footnotemove {
             $textwindow->delete( $start, "$index +1l linestart" );
         }
         $index .= '+4l';
+        last if $textwindow->compare( $index, '>=', 'end' );
     }
     ::delblanklines();
     $textwindow->addGlobEnd;


### PR DESCRIPTION
1. If several footnotes were moved inline (including removing the blank lines
surrounding them) the cached begin point for searching for the next footnote was
incorrect, meaning a footnote could be skipped. Fixed by resetting the mark after
the footnote is moved
2. A warning dialog could be popped incorrectly after dealing with the last footnote.
Fixed by removing the dialog, but still exiting the loop.
3. An error could be output if a file was loaded after working on a previous file with
footnotes. The list of footnotes was cleared on file load, but not the number of
footnotes. If the user clicked "Inline" before running First Pass, it attempted to
display a footnote that it didn't have in its (empty) list.

Fixes #600