### PR TITLE
Preserve page marker positions during Auto Table conversion

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -3292,8 +3292,7 @@ sub autotable {
     $selection =~ s/ +/ /g;
 
     $textwindow->addGlobStart;
-    $textwindow->delete( "$lsr.0", "$ler.end" );
-    $textwindow->insert( "$lsr.0", $selection );
+    $textwindow->replacewith( "$lsr.0", "$ler.end", $selection );
     $textwindow->addGlobEnd;
 }
 


### PR DESCRIPTION
When converting a text table to HTML using Auto Table, the page marker positions
all moved to the start of the table, due to the use of delete and insert. Using
replacewith instead means that page markers will be spread through the table in
the same proportions as they previously were.

Fixes #607