### PR TITLE
Avoid inserting capture group text at `$` in matched text

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -729,7 +729,7 @@ sub replaceeval {
         my $match = $matches[ $idx - 1 ];
         next unless defined $match;
         $match       =~ s/\\/\\\\/g;
-        $match       =~ s/\$/\\\$/;
+        $match       =~ s/\$/\\\$/g;
         $replaceterm =~ s/(?<!\\)\$$idx/$match/g;
     }
     $replaceterm =~ s/\\\$/\$/g;    # Unescape dollars


### PR DESCRIPTION
The fix in #376 was missing a `g` to escape ALL dollars, not just the first one. Doh!

Fixes #605