### PR TITLE
Remove consecutive page separators with 99% Auto

### DIFF
--- a/src/lib/Guiguts/PageSeparators.pm
+++ b/src/lib/Guiguts/PageSeparators.pm
@@ -147,7 +147,7 @@ sub handleautomaticonrefresh {
 
         } elsif ( $::pagesepauto == 3 ) {
             my $linebefore = $textwindow->get( "page -10c",       "page -1c" );
-            my $lineafter  = $textwindow->get( "page1 linestart", "page1 linestart +5c" );
+            my $lineafter  = $textwindow->get( "page1 linestart", "page1 linestart +9c" );
             if ( $lineafter =~ /^\n\n\n\n/ ) {
                 processpageseparator('h');
             } elsif ( $lineafter =~ /^\n\n/ ) {
@@ -155,7 +155,7 @@ sub handleautomaticonrefresh {
             } elsif ( $lineafter =~ /^\n/ ) {
                 processpageseparator('l');
             } elsif ( $lineafter =~ /^-----File/ ) {
-                processpageseparator('l');
+                processpageseparator('d');
             } elsif ( $lineafter =~ /^\S/ ) {
                 if ( closeupmarkup() ) {
                     $linebefore = $textwindow->get( "page -10c",       "page -1c" );


### PR DESCRIPTION
If 2 or more page separators directly follow one after the other, all but the last one
can be safely deleted when using 99% Auto.

There was an attempt in the code to do this, but it could never be triggered as the
first 5 characters of the next line were compared against a 9 character string. Also
the correct operation is to delete, not to insert a blank line.

Fixes #507 - though only implemented for 99% Auto (default), not 80% Auto.