### PR TITLE
Make stickiness of search options be a preference

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -174,6 +174,7 @@ our $scannosearch           = 0;
 our $scrollupdatespd        = 40;
 our $searchendindex         = 'end';
 our $searchstartindex       = '1.0';
+our $searchstickyoptions    = 1;
 our $multiterm              = 0;
 our $spellcheckwithenchant  = 0;
 our $spellindexbkmrk        = q{};

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -902,7 +902,8 @@ EOM
             gesperrt_char globalaspellmode highlightcolor history_size htmlimageallowpixels ignoreversionnumber
             intelligentWF ignoreversions italic_char jeebiesmode lastversioncheck lastversionrun lmargin markupthreshold
             multisearchsize multiterm nobell nohighlights pagesepauto projectfileslocation notoolbar poetrylmargin projectfileslocation
-            recentfile_size rmargin rmargindiff rwhyphenspace sc_char scannos_highlighted spellcheckwithenchant stayontop toolside
+            recentfile_size rmargin rmargindiff rwhyphenspace sc_char scannos_highlighted
+            searchstickyoptions spellcheckwithenchant stayontop toolside
             trackoperations txt_conv_bold txt_conv_font txt_conv_gesperrt txt_conv_italic txt_conv_sc txt_conv_tb
             txtfontname txtfontsize txtfontweight txtfontsystemuse
             twowordsinhyphencheck utf8save utfcharentrybase utffontname utffontsize utffontweight

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -1015,6 +1015,12 @@ sub menu_preferences_processing {
                 ::savesettings();
             }
         ],
+        [
+            Checkbutton => 'Sticky Search Options',
+            -variable   => \$::searchstickyoptions,
+            -onvalue    => 1,
+            -offvalue   => 0
+        ],
         [ 'separator', '' ],
         [ 'command',   'Set Spell Check Options...', -command => sub { ::spelloptions() } ],
         [ 'separator', '' ],

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -939,6 +939,12 @@ sub searchpopup {
         $::lglobal{searchpop}->focus;
         $::lglobal{searchentry}->focus;
     } else {
+
+        # If popping dialog when it has previously been dismissed, decide whether search options
+        # should be retained from last search (i.e. sticky) or reset
+        unless ($::searchstickyoptions) {
+            $::sopt[0] = $::sopt[1] = $::sopt[2] = $::sopt[3] = 0;
+        }
         $::lglobal{searchpop} = $top->Toplevel;
         $::lglobal{searchpop}->title('Search & Replace');
         my $sf1 = $::lglobal{searchpop}->Frame->pack( -side => 'top', -anchor => 'n', -pady => 1 );


### PR DESCRIPTION
Most search options are sticky, i.e. remembered the next time you search.

This commit adds a stickiness Prefs option (defaulting to on). If turned off, then when
the S&R dialog is dismissed and re-popped, the search options revert to their default
(off) settings.

Fixes #530