### PR TITLE
Improve curly quote conversion

### DIFF
--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -538,8 +538,9 @@ sub menu_txt {
             'command', "Auto-Convert ~Options...", -command => sub { ::text_convert_options($top); }
         ],
         [
-            'command', "Convert to Curly ~Quotes...", -command => sub { ::text_quotes_convert(); }
+            'command', "Convert to Curly ~Quotes", -command => sub { ::text_quotes_convert(); }
         ],
+        menu_cascade( 'Curly Quote Corrections', &menu_txt_curlycorrections ),
         [ 'separator', '' ],
         [
             'command',
@@ -609,6 +610,44 @@ sub menu_txt {
             -command => sub {
                 ::errorcheckpop_up( $textwindow, $top, 'pptxt' );
             },
+        ],
+    ];
+}
+
+sub menu_txt_curlycorrections {
+    [
+        [ 'command', '~Select Next @ Line', -command => sub { ::text_quotes_select(); } ],
+        [ 'command', '~Flip Double Quotes', -command => sub { ::text_quotes_flipdouble(); } ],
+        [
+            'command',
+            '~Use Spaces To Correct Double Quotes',
+            -command => sub { ::text_quotes_usespaces(); }
+        ],
+        [
+            'command',
+            'R~emove @ Symbols From Selection',
+            -command => sub { ::text_quotes_removeat(); }
+        ],
+        [ 'separator', '' ],
+        [
+            'command',
+            'Insert ~Left Double Quote',
+            -command => sub { ::text_quotes_insert("\x{201c}"); }
+        ],
+        [
+            'command',
+            'Insert ~Right Double Quote',
+            -command => sub { ::text_quotes_insert("\x{201d}"); }
+        ],
+        [
+            'command',
+            'Insert L~eft Single Quote',
+            -command => sub { ::text_quotes_insert("\x{2018}"); }
+        ],
+        [
+            'command',
+            'Insert R~ight Single Quote/Apostrophe',
+            -command => sub { ::text_quotes_insert("\x{2019}"); }
         ],
     ];
 }


### PR DESCRIPTION
1. Spot and convert ditto marks (2 spaces each side)
2. Force quotes at start of line to be open quotes
3. Force quotes at end of line to be close quotes
4. Add Curly Quote Corrections submenu - tear-off for easy use
5. Allow selection of next line with @ symbol - other correction options work on
selected region, so user can alter it if needed
6. Correction option 1: Flip all double quotes in selected region - once quotes are
out of sync, every quote for the rest of the paragraph often needs flipping.
7. Correction option 2: Use spacing to decide quotes in selected region, e.g. if a
quote is preceded by a space and followed by a non-space it must be an open quote.
8. Allow removal of all `@` signs in the selected region
9. Allow insertion of the four types of quote.