### PR TITLE
Move Convert Fractions and remove Insert Page Labels from Txt menu

### DIFF
--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -395,6 +395,7 @@ sub menu_tools {
             'Replace [::] with I~ncremental Counter',
             -command => \&::replace_incr_counter
         ],
+        menu_cascade( 'Con~vert Fractions', &menu_tools_convertfractions ),
         [ 'separator', '' ],
         [ 'command',   'Fixup ~Page Separators...', -command => \&::separatorpopup ],
         [
@@ -415,7 +416,6 @@ sub menu_tools {
                 $textwindow->addGlobEnd;
             }
         ],
-        menu_cascade( 'Con~vert Fractions', &menu_tools_convertfractions ),
         [ 'separator', '' ],
         [
             'command',
@@ -595,13 +595,6 @@ sub menu_txt {
         [ 'separator', '' ],
         [ 'command',   'Dra~w ASCII Boxes...',    -command => \&::asciibox_popup ],
         [ 'command',   'ASCII Table E~ffects...', -command => \&::tablefx ],
-        [
-            'command',
-            'Ins~ert Page Labels',
-            -command => sub {
-                ::pagetextinsert('labels');
-            }
-        ],
         [ 'separator', '' ],
         [
             'command',


### PR DESCRIPTION
Move Convert Fractions to a better position in the tools menu.
Insert Page Labels is already in the Adjust Page Markers dialog, so is not needed in
the Txt menu as well.

Fixes #617 