### PR TITLE
Avoid trying to shrink a column less than zero characters wide

### DIFF
--- a/src/lib/Guiguts/ASCIITables.pm
+++ b/src/lib/Guiguts/ASCIITables.pm
@@ -577,7 +577,8 @@ sub coladjust {
         }
         my $rowcount = 0;
         $cellheight = 0;
-        my $width     = $col[$colindex] - $col[ ( $colindex - 1 ) ] + $dir;
+        my $width = $col[$colindex] - $col[ ( $colindex - 1 ) ] + $dir;
+        return 0 if $width < 0;
         my @temptable = ();
         for (@tblwr) {
             my @temparray  = split( /\n/, $_ );


### PR DESCRIPTION
An error was output if the user tried to squeeze a column narrower that was already
zero characters wide. Now silently does nothing.

Fixes #619 