### PR TITLE
Implement new design for Configure Page Labels

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -3839,12 +3839,11 @@ sub fracconv {
         # Scrolled listbox to display the label information
         $::lglobal{pagelabellist} = $::lglobal{pagelabelpop}->Scrolled(
             'Listbox',
-            -scrollbars => 'osoe',
-            -background => $::bkgcolor,
-            -font       => 'proofing',
-            -selectmode => 'browse',
-
-            #-activestyle => 'none',
+            -scrollbars  => 'osoe',
+            -background  => $::bkgcolor,
+            -font        => 'proofing',
+            -selectmode  => 'browse',
+            -activestyle => 'none',
         )->pack(
             -anchor => 'n',
             -fill   => 'both',
@@ -3871,6 +3870,7 @@ sub fracconv {
         )->grid( -row => 1, -column => 2, -padx => 5 );
 
         ::drag( $::lglobal{pagelabellist} );
+        ::BindMouseWheel( $::lglobal{pagelabelpop}, $::lglobal{pagelabellist} );
 
         # Bindings for list box - basic selection first
         $::lglobal{pagelabellist}->bind(

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -19,7 +19,7 @@ BEGIN {
       &getprojectid &setprojectid &viewprojectcomments &viewprojectdiscussion &viewprojectpage
       &scrolldismiss &updatedrecently &hidelinenumbers &restorelinenumbers &displaylinenumbers
       &enable_interrupt &disable_interrupt &set_interrupt &query_interrupt &soundbell &busy &unbusy
-      &dieerror &warnerror &infoerror &poperror);
+      &dieerror &warnerror &infoerror &poperror &BindMouseWheel);
 
 }
 
@@ -2983,5 +2983,45 @@ sub printerror {
     }
 
 }    # End of block to localise error message array
+
+#
+# Subroutine to bind mouse wheel to scrolling behaviour so that the wheel scrolls
+# a list widget whenever focus is in the containing dialog.
+# Requires a widget to bind to (typically the dialog) and a Scrolled widget.
+# Adapted from https://docstore.mik.ua/orelly/perl3/tk/ch15_02.htm
+sub BindMouseWheel {
+    my $bindwidget = shift;
+    my $listwidget = shift;
+
+    if ( $^O eq 'MSWin32' ) {
+        $bindwidget->bind(
+            '<MouseWheel>' => [
+                sub {
+                    $listwidget->yview( 'scroll', -( $_[1] / 120 ) * 3, 'units' )
+                      unless $listwidget->focusCurrent == $listwidget->Subwidget('scrolled');
+                },
+                Tk::Ev('D')
+            ]
+        );
+    } else {
+
+        # Support for mousewheels on Linux commonly comes through
+        # mapping the wheel to buttons 4 and 5.  If you have a
+        # mousewheel ensure that the mouse protocol is set to
+        # "IMPS/2" in your /etc/X11/XF86Config (or XF86Config-4)
+        # file:
+        #
+        # Section "InputDevice"
+        #     Identifier  "Mouse0"
+        #     Driver      "mouse"
+        #     Option      "Device" "/dev/mouse"
+        #     Option      "Protocol" "IMPS/2"
+        #     Option      "Emulate3Buttons" "off"
+        #     Option      "ZAxisMapping" "4 5"
+        # EndSection
+        $bindwidget->bind( '<4>' => sub { $listwidget->yview( 'scroll', -3, 'units' ); } );
+        $bindwidget->bind( '<5>' => sub { $listwidget->yview( 'scroll', +3, 'units' ); } );
+    }
+}
 
 1;


### PR DESCRIPTION
The old design created 6 widgets per page in the text, all contained in a scrolled list.
This was slow to pop and operate in books with a moderate number of pages, and
crashed or failed to display in books with a large number of pages (e.g. 2000).

New design uses a scrolled list, with the details of the selected page shown in a
section of the dialog. Mouse-1 selects a page and the details can be edited -
reflected live in the scrolled list. Also, the two most common changes have
shortcuts: Shift-Mouse-1 to cycle Arabic/Roman/ditto, and Control-Mouse-1 to
cycle Start@/+1/No Count. Balloon help text reminds the user of the shortcut
if they hover over the areas of the dialog where they can change a value.

Click and drag in the list allows scrolling of the list and mouse-2 drag does rapid
scrolling - both Tk default behaviours.

There is no noticeable delay in popping the new dialog, even with 2000+ pages.

Fixes #614 