### PR TITLE
Clarify EBookMaker option in HTML menu

### DIFF
--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -693,7 +693,8 @@ sub menu_html {
                 ::errorcheckpop_up( $textwindow, $top, 'ppvimage' );
             }
         ],
-        [ 'command', 'EB~ookMaker', -command => sub { ::ebookmaker(); } ],
+        [ 'separator', '' ],
+        [ 'command',   'EB~ookMaker epub/mobi Generation', -command => sub { ::ebookmaker(); } ],
     ];
 }
 


### PR DESCRIPTION
1. Use a separator to distinguish it from the "tests"
2. Change the label to say 'EBookMaker epub/mobi Generation'

#Fixes #631