### PR TITLE
Turn on scanno highlighting when a scanno file is loaded

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -766,6 +766,7 @@ sub openfile {    # and open it
             $::pngspath = '';
         }
     }
+    ::highlight_scannos();
     ::update_indicators();
     file_mark_pages() if $::auto_page_marks;
     ::readlabels();

--- a/src/lib/Guiguts/StatusBar.pm
+++ b/src/lib/Guiguts/StatusBar.pm
@@ -234,7 +234,16 @@ AAAAACH5BAAAAAAALAAAAAAMAAwAAwQfMMg5BaDYXiw178AlcJ6VhYFXoSoosm7KvrR8zfXHRQA7
             ::highlight_scannos();
         }
     );
-    $::lglobal{highlightlabel}->bind( '<3>', sub { ::scannosfile() } );
+    $::lglobal{highlightlabel}->bind(
+        '<3>',
+        sub {
+            ::scannosfile();
+            return unless $::scannoslist;                         # abort if failed to load list
+            $::scannos_highlighted = 1;                           # turn on highlighting
+            $::lglobal{highlighttempcolor} = $::highlightcolor;
+            ::highlight_scannos();
+        }
+    );
     $::lglobal{highlightlabel}->bind(
         '<Enter>',
         sub {


### PR DESCRIPTION
1. RIght-clicking the "H" icon in the status bar allows loading of a scannos file, but
didn't turn on highlighting and the user then had to left click to turn it on.
Now turns on automatically if a scannos file is loaded successfully.

2. Although the setting of the "H" icon was saved, when GG was restarted, it did not
do the actual highlighting - now fixed when a new file is loaded.

Fixes #637