### PR TITLE
Automate Auto Illus Search even more

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -836,7 +836,7 @@ sub readsettings {
 
         # for dialogs that previously just stored position but now need geometry,
         # retain the position and delete the position hash entry
-        for ( 'gotolabpop', 'gotolinepop', 'gotopagpop', 'grpop', 'searchpop' ) {
+        for ( 'gotolabpop', 'gotolinepop', 'gotopagpop', 'grpop', 'searchpop', 'htmlimpop' ) {
             if ( $::positionhash{$_} and $::geometryhash{$_} ) {
                 $::geometryhash{$_} =~ s/^(\d+x\d+).*/$1$::positionhash{$_}/;
                 delete $::positionhash{$_};

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -740,7 +740,7 @@ sub initialize {
     $::geometryhash{hotkeyspop}       = '+144+119'        unless $::geometryhash{hotkeyspop};
     $::geometryhash{hpopup}           = '300x400+584+211' unless $::geometryhash{hpopup};
     $::positionhash{htmlgenpop}       = '+145+37'         unless $::positionhash{htmlgenpop};
-    $::positionhash{htmlimpop}        = '+45+37'          unless $::positionhash{htmlimpop};
+    $::geometryhash{htmlimpop}        = '+45+37'          unless $::geometryhash{htmlimpop};
     $::positionhash{intervalpop}      = '+300+137'        unless $::positionhash{intervalpop};
     $::geometryhash{linkpop}          = '+224+72'         unless $::geometryhash{linkpop};
     $::positionhash{marginspop}       = '+145+137'        unless $::positionhash{marginspop};


### PR DESCRIPTION
Once a file has been chosen to use for an illustration, give the option to automatically choose the next alphabetically for the next illustration. Illos are
frequently alphabetical anyway, or can be made so. This saves lots of time choosing
the correct file for each illustration.
Also provide a skip to next/previous file to make it easy to skip over a thumbnail or
large version of a file, etc.

Fixes #93 