### PR TITLE
Fix height and width of thumbnail in image insert dialog

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1765,11 +1765,11 @@ sub htmlimage {
             -width   => 8,
             -command => sub { htmlimageok($textwindow); htmlimagedestroy(); }
         )->pack( -side => 'left', -padx => 5, -pady => 5 );
-        my $f = $::lglobal{htmlimpop}->Frame->pack;
+        my $f = $::lglobal{htmlimpop}->LabFrame( -label => 'Thumbnail' )->pack;
         $::lglobal{imagelbl} = $f->Label(
-            -text       => 'Thumbnail',
-            -justify    => 'center',
-            -background => $::bkgcolor,
+            -justify => 'center',
+            -height  => 200,
+            -width   => 200
         )->grid( -row => 1, -column => 1 );
         $::lglobal{imagelbl}->bind( '<1>', sub { thumbnailbrowse(); } );
         $::lglobal{htmlimpop}->protocol( 'WM_DELETE_WINDOW' => sub { htmlimagedestroy(); } );


### PR DESCRIPTION
The thumbnail was scaled to fit in a 200x200 square, but now that the user can
set the dialog size, it meant a landscape thumbnail sometimes caused excess space
in earlier widgets and/or a portrait thumbnail was clipped off the bottom. This was
exacerbated by the fact that when the dialog is initially popped there is no image
to display in the thumbnail space.
Pre-allocating a 200x200 space eliminates these problems.