### PR TITLE
Right align numbers correctly when there is more than one

### DIFF
--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -917,7 +917,7 @@ sub tocalignselection {
 
     while ( $index < $thisblockend ) {
         my $line = $textwindow->get( $index, "$index lineend" );
-        if ( $line =~ /^(.*)  +(\d+(, *\d+)*\.?)$/ ) {
+        if ( $line =~ /^(.*?)  +(\d+([,-\x{2013}] *\d+)*\.?)$/ ) {
             my $len1     = length($1);
             my $len2     = length($2);
             my $spacelen = length($line) - $len1 - $len2;

--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -917,7 +917,7 @@ sub tocalignselection {
 
     while ( $index < $thisblockend ) {
         my $line = $textwindow->get( $index, "$index lineend" );
-        if ( $line =~ /^(.*)  +(\d+\.?)$/ ) {
+        if ( $line =~ /^(.*)  +(\d+(, *\d+)*\.?)$/ ) {
             my $len1     = length($1);
             my $len2     = length($2);
             my $spacelen = length($line) - $len1 - $len2;


### PR DESCRIPTION
Txt->Right Align Numbers in Selection only worked when there was just one
number, but some ToCs/tables have more than one, e.g.
`Look here      3, 4`

More than one number (separated by commas, optional with space too) will now
be right-aligned.

Fixes #655 