### PR TITLE
Transfer scannos folder better from release to release

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -2070,7 +2070,6 @@ sub loadscannos {
     @{ $::lglobal{scannosarray} } = ();
     $::lglobal{scannosindex} = 0;
     my $types = [ [ 'Scannos', ['.rc'] ], [ 'All Files', ['*'] ], ];
-    $::scannospath = ::os_normal($::scannospath);
     $::lglobal{scannosfilename} = $top->getOpenFile(
         -filetypes  => $types,
         -title      => 'Scannos list?',
@@ -2078,9 +2077,6 @@ sub loadscannos {
     );
 
     if ( $::lglobal{scannosfilename} ) {
-        my ( $name, $path, $extension ) =
-          ::fileparse( $::lglobal{scannosfilename}, '\.[^\.]*$' );
-        $::scannospath = $path;
         unless ( my $return = ::dofile( $::lglobal{scannosfilename} ) ) {    # load scannos list
             unless ( defined $return ) {
                 if ($@) {

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1076,11 +1076,12 @@ sub initialize {
 
     $::lglobal{guigutsdirectory} = ::dirname( ::rel2abs($0) )
       unless defined $::lglobal{guigutsdirectory};
-    $::scannospath = ::catfile( $::lglobal{guigutsdirectory}, 'scannos' )
-      unless $::scannospath;
 
     # Find tool locations. setdefaultpath handles differences in *nix/Windows
     # executable names and looks on the search path.
+    $::scannospath =~ s/[\/\\]$//;    # Remove trailing slash from scannos path
+    $::scannospath =
+      ::setdefaultpath( $::scannospath, ::catfile( $::lglobal{guigutsdirectory}, 'scannos' ) );
     $::ebookmakercommand = ::setdefaultpath( $::ebookmakercommand,
         ::catfile( $::lglobal{guigutsdirectory}, 'tools', 'ebookmaker', 'ebookmaker.exe' ) );
     $::validatecsscommand = ::setdefaultpath( $::validatecsscommand,


### PR DESCRIPTION
Similarly to #650 enable scannos folder setup to be transferred from release to
release by making it relative to release root folder if possible.


Fixes #659 