### PR TITLE
Allow user to resize text entry dialogs vertically

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2827,7 +2827,7 @@ sub textentrydialogpopup {
     $::lglobal{$key}->Tk::bind( '<Return>', sub { $okbtn->invoke(); } );
     $::lglobal{$key}->Tk::bind( '<Escape>', sub { $cancelbtn->invoke(); } );
 
-    $::lglobal{$key}->resizable( 'yes', 'no' );
+    $::lglobal{$key}->resizable( 'yes', 'yes' );
     ::initialize_popup_with_deletebinding($key);
     $entryw->focus;
     $entryw->selectionRange( $len, 'end' );


### PR DESCRIPTION
Now that the font size can be changed, it is possible for the OK button at the
bottom to get pushed off the bottom of the dialog, which remembers its size.
The user can now resize to fit their preferred font.

Fixes #671 