### PR TITLE
Avoid restoring focus to destroyed widget after spawning image viewer

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -64,7 +64,8 @@ sub openpng {
         my $grabperiod   = 200;                         # try to get focus back for 200 milliseconds
         my $grabinterval = 10;                          # try to get focus back every 10 milliseconds
         for ( 1 .. ( $grabperiod / $grabinterval ) ) {
-            $focuswidget->after($grabinterval);
+            $textwindow->after($grabinterval);
+            $focuswidget = $textwindow unless Tk::Exists($focuswidget);    # in case focus widget has been destroyed during delay
             $focuswidget->focusForce;
         }
     } else {


### PR DESCRIPTION
It could occasionally happen that the widget that previously had focus before the
image viewer was spawned no longer existed when attempting to restore focus
to it. If it doesn't exist, just return focus to the main text window, which always exists.

Fixes #670 