### PR TITLE
Allow user to change character highlight colour

### DIFF
--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -915,11 +915,12 @@ sub menu_preferences_appearance {
         ],
         [
             'command',
-            'Set Scanno Highlight Color...',
+            'Set Scanno/Quote Highlight Color...',
             -command => sub {
                 my $thiscolor = ::setcolor($::highlightcolor);
                 $::highlightcolor = $thiscolor if $thiscolor;
-                $textwindow->tagConfigure( 'scannos', -background => $::highlightcolor );
+                $textwindow->tagConfigure( 'scannos',   -background => $::highlightcolor );
+                $textwindow->tagConfigure( 'quotemark', -background => $::highlightcolor );
                 ::savesettings();
             }
         ],

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1105,7 +1105,7 @@ sub initialize {
     $textwindow->tagConfigure( 'bkmk',     -background => 'green' );
     $textwindow->tagConfigure( 'table',    -background => '#E7B696' );
     $textwindow->tagRaise('sel');
-    $textwindow->tagConfigure( 'quotemark', -background => '#CCCCFF' );
+    $textwindow->tagConfigure( 'quotemark', -background => $::highlightcolor );
     $textwindow->tagConfigure( 'highlight', -background => 'orange' );
     $textwindow->tagConfigure( 'linesel',   -background => '#8EFD94' );
     $textwindow->tagConfigure( 'alignment', -background => '#8EFD94' );


### PR DESCRIPTION
There's no real need for quote and other character highlighting to use a slightly
different lilac colour to the scanno highlighting. So, make them use the same
colour, which was already configurable via the Prefs menu.

Fixes #663