### PR TITLE
Make right-align numbers cope with removing as well as adding spaces

### DIFF
--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -921,9 +921,13 @@ sub tocalignselection {
             my $len1     = length($1);
             my $len2     = length($2);
             my $spacelen = length($line) - $len1 - $len2;
-            if ( $len1 + $len2 + 2 < $::rmargin ) {
+            if ( $len1 + $len2 + 2 <= $::rmargin ) {
                 my $paddval = $::rmargin - $len1 - $len2 - $spacelen + $indentval;
-                $textwindow->insert( $index . "+$len1 c", ' ' x $paddval );
+                if ( $paddval >= 0 ) {
+                    $textwindow->insert( $index . "+$len1 c", ' ' x $paddval );
+                } else {
+                    $textwindow->delete( $index . "+$len1 c", $index . "+$len1 c" . "-$paddval c" );
+                }
             }
         }
         $index++;


### PR DESCRIPTION
If numbers were beyond the right margin, then a "negative repeat count" error was
output. Now, if possible, spaces will be removed to align the numbers. If not
possible, i.e. line has too much non-space, then nothing is done.

Fixes #676