### PR TITLE
Fix errors revealed by test suite

### DIFF
--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -191,9 +191,10 @@ sub selectrewrap {
 
         $thisblockend = $end unless $thisblockend;    # if no end found, finish at end of selection
 
-        # Always start/end at beginning/end of lines
+        # Always start/end at beginning of lines
         $thisblockstart = $textwindow->index( $thisblockstart . ' linestart' );
-        $thisblockend   = $textwindow->index( $thisblockend . ' lineend' );
+        my ( $ll, $cc ) = split( /\./, $textwindow->index($thisblockend) );
+        $thisblockend = $textwindow->index( $thisblockend . ' +1l linestart' ) unless $cc == 0;
 
         $selection = $textwindow->get( $thisblockstart, $thisblockend ) if $thisblockend;    # get the paragraph of text
         unless ($selection) {

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -506,13 +506,14 @@ sub deaccentsort {
 
 sub deaccentdisplay {
     my $phrase = shift;
-    return $phrase unless ( $phrase =~ /[$::convertcharssinglesearch]/ );
+    return $phrase unless ( $phrase =~ /[$::convertlatinsinglesearch$::convertcharssinglesearch]/ );
 
     # first convert the characters specified by the language
     $phrase =~ s/([$::convertcharsdisplaysearch])/$::convertcharsdisplay{$1}/g;
 
     # then convert anything that hasn't been converted already
-    eval "\$phrase =~ tr/$::convertcharssinglesearch/$::convertcharssinglereplace/";
+    eval
+      "\$phrase =~ tr/$::convertlatinsinglesearch$::convertcharssinglesearch/$::convertlatinsinglereplace$::convertcharssinglereplace/";
     return $phrase;
 }
 

--- a/src/tests/bookloupebaseline.txt
+++ b/src/tests/bookloupebaseline.txt
@@ -1,9 +1,6 @@
 Beginning check: Bookloupe
   --> 26 lines in this file are VERY long!
   *** Verbose output is ON -- you asked for it! ***
-
-  --> 5585 queries.
-
 14:38 - Double punctuation?
 16:25 - Non-ASCII character 183
 21:31 - Non-ASCII character 183

--- a/src/tests/jeebiesbaseline.txt
+++ b/src/tests/jeebiesbaseline.txt
@@ -1,6 +1,5 @@
 Beginning check: Jeebies
   --> There are 214 "be"s and 142 "he"s. Calibrating...
-  --> 46 queries
 288:59 - Query phrase "trench he shot" 
 328:33 - Query phrase "when he narrowly" 
 426:0 - Query phrase "There he summoned" 


### PR DESCRIPTION
1. Bug introduced into wrapping - occasionally adds a blank line after a block, due
to error in extending end of block to end of line - should go to start of next line,
but only if not already at start of line. Caused by #665. 
2. Bug introduced into de-accenting for display when separating out Latin1
characters into their own array for sorting speed up. Caused by #667. 
3. Baseline test files needed updating now that error display dialog has its own
count of active errors, so error list doesn't need it. Caused by #597. 