### PR TITLE
Cope with block markup at end of footnote

### DIFF
--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -183,6 +183,7 @@ sub selectrewrap {
           $textwindow->search( '-regex', '--',
             "(^$TEMPPAGEMARK*\$|^$TEMPPAGEMARK*[$::allblocktypes]/$TEMPPAGEMARK*\$)",
             $thisblockstart, $end );    # find end of paragraph or end of markup
+        $thisblockend = "$thisblockend lineend" if $thisblockend;
 
         # if two start rewrap block markers aren't separated by a blank line, just let it become added
         $thisblockend = $thisblockstart


### PR DESCRIPTION
Block markup at end of footnote may not have a blank line after it. Although this is
a requirement according to the manual, it is better not to require it.

The end position of the block wasn't being placed correctly for this circumstance.
Now corrected to fix the second half of #688.

#685 already partially fixed #688