### PR TITLE
Fix errors in CSS when autogenerating 100% width illustrations

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1911,9 +1911,9 @@ sub htmlimageok {
     if ( $insertpoint and $::lglobal{htmlimgwidthtype} ne 'px' ) {    # px type uses style, not class
         my $cssdef = ".$classname {width: " . $width . "$::lglobal{htmlimgwidthtype};}";
 
-        # If % width and override flag set, then also add CSS to override width to 100% for epub
+        # If % width and override flag set (and not already 100%), then also add CSS to override width to 100% for epub
         my $cssovr =
-          ( $::lglobal{htmlimgwidthtype} eq '%' and $::epubpercentoverride )
+          ( $::lglobal{htmlimgwidthtype} eq '%' and $::epubpercentoverride and $width ne 100 )
           ? "\n.x-ebookmaker .$classname {width: 100%;}"
           : "";
 


### PR DESCRIPTION
Due to the override CSS for epubs being identical in the case where the width was
100%, the algorithm for replacing CSS was failing leading to alternate insertions
either leaving the override CSS or adding an extra standard class definition.

In the case of 100%, no override is needed, so by not outputting the override, the
algorithm doesn't get confused.

Fixes #692
