### PR TITLE
Show correct number of queries when bookloupe is run

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -379,11 +379,11 @@ sub errorcheckpop_up {
 
     ::working();
     if ( $errorchecktype eq 'Bookloupe' ) {
-        gcwindowpopulate();
+        gcwindowpopulate();    # Also handles query count display since it depends on shown/hidden error types
     } else {
         $::lglobal{errorchecklistbox}->insert( 'end', @errorchecklines );
+        eccountupdate( $mark + $countplus );
     }
-    eccountupdate( $mark + $countplus );
 
     $::lglobal{errorchecklistbox}->update;
     $::lglobal{errorchecklistbox}->focus;


### PR DESCRIPTION
When bookloupe is first run, the number of queries being shown was overwritten
by the total number of queries, not taking into account shown/hidden error types.

Bookloupe needs different handling to other checks since it is the only one with
shown/hidden error types. The window populating routine already handled the
query display correctly, so just avoid overwriting it.

Fixes #696 