### PR TITLE
Restore insert cursor to HTML when adding illo markup

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1968,6 +1968,8 @@ sub htmlimageok {
         }
     }
     $textwindow->addGlobEnd;
+    $textwindow->markSet( 'insert', 'thisblockstart' );
+    $textwindow->see('insert');
 }
 
 sub htmlimagedestroy {


### PR DESCRIPTION
Because the CSS code is added later, the insert cursor ends up in the CSS code not
the newly added illo HTML. Fixed by placing the cursor back in the HTML code.

Fixes #701