### PR TITLE
Make Help/About dialog resizable

### DIFF
--- a/src/lib/Guiguts/HelpMenu.pm
+++ b/src/lib/Guiguts/HelpMenu.pm
@@ -55,7 +55,7 @@ EOM
             -text             => 'OK',
             -command          => sub { ::killpopup('aboutpop'); }
         )->pack( -pady => 6 );
-        $::lglobal{aboutpop}->resizable( 'no', 'no' );
+        $::lglobal{aboutpop}->resizable( 'yes', 'yes' );
         $::lglobal{aboutpop}->raise;
         $::lglobal{aboutpop}->focus;
     }


### PR DESCRIPTION
Another one slipped through the net - when system font is made larger, not all text
shows in the dialog and it couldn't be resized to fix it.

Fixes #704 