### PR TITLE
Make Word Frequency Check Accents check Latin-1 characters again

### DIFF
--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -639,7 +639,7 @@ sub accentcheck {
     my $wordwo = 0;
 
     foreach my $word ( keys %{ $::lglobal{seenwords} } ) {
-        if ( $word =~ /[$::convertcharssinglesearch]/ ) {
+        if ( $word =~ /[$::convertlatinsinglesearch$::convertcharssinglesearch]/ ) {
             $wordw++;
             my $wordtemp = $word;
             $display{$word} = $::lglobal{seenwords}->{$word}


### PR DESCRIPTION
Inadvertently broken during #667 when latin1 characters were split from non-latin1
in order to speed up searching. This use needs to include both sets.
Fixes #714