### PR TITLE
Include File::HomeDir as a package dependency

### DIFF
--- a/src/install_cpan_modules.pl
+++ b/src/install_cpan_modules.pl
@@ -2,6 +2,9 @@
 
 my @modules = (
 
+    # Needed for locating tools
+    "File::HomeDir",
+
     # Needed for user interface
     "Tk",
     "Tk::ToolBar",


### PR DESCRIPTION
The homebrew-provided perl doesn't include `File::HomeDir` by default, so we need to be explicit about having it installed.