### PR TITLE
Fix error during Manual Smallcaps conversion

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1086,7 +1086,7 @@ sub searchpopup {
 
         # Button to increment number of multiterms (also switches to multi)
         # Add frame/field/buttons if necessary
-        $sf10->Button(
+        $::lglobal{searchmultiadd} = $sf10->Button(
             -activebackground => $::activecolor,
             -command          => sub {
                 if ( $::multisearchsize < 10 ) {    # don't go above 10 in multi-term mode

--- a/src/lib/Guiguts/TextProcessingMenu.pm
+++ b/src/lib/Guiguts/TextProcessingMenu.pm
@@ -488,6 +488,7 @@ sub text_remove_smallcaps_markup {
 sub txt_manual_sc_conversion {
     ::searchpopup();
     ::searchoptset(qw/0 x x 1/);
+    $::lglobal{searchmultiadd}->invoke while $::multisearchsize < 3;    # Ensure sufficient replacement fields
     $::lglobal{searchentry}->delete( 0, 'end' );
     $::lglobal{replaceentry}->delete( '1.0', 'end' );
     $::lglobal{replaceentry1}->delete( '1.0', 'end' );


### PR DESCRIPTION
If the Search dialog had fewer than 3 replacement fields in its Multi layout, an error
was output when Manual Smallcaps conversion was attempted from the Txt menu.
This was due to it attempting to write a replacement string into the third field.

Fixes #723 