### PR TITLE
Allow user to copy/paste from Version numbers dialog

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1983,12 +1983,9 @@ perl/Tk Version: $Tk::VERSION
 Tk patchLevel: $Tk::patchLevel
 Tk libraries: $Tk::library
 END
-    my $dialog = $top->Dialog(
-        -title   => 'Versions',
-        -popover => $top,
-        -justify => 'center',
-        -text    => $message,
-    );
+    my $dialog = $top->DialogBox( -title => 'Versions', -popover => $top );
+    my $text   = $dialog->add( 'ROText', -height => 10, -width => 40 )->pack;
+    $text->insert( 'end', $message );
     $dialog->Show;
 }
 


### PR DESCRIPTION
It would be useful for the user to be able to copy the version info when they want
to report an issue.

Replace the Dialog containing a message with a DialogBox containing a read-only
Text widget containing the information.

Fixes #724