### PR TITLE
Remove 100% image width setting from illos defined by pixel width

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1902,9 +1902,10 @@ sub htmlimageok {
     my $style = "";
     $style = " style=\"max-width: ${maxwidth}em;\"" if $::lglobal{htmlimgwidthtype} eq '%';
     $style = " style=\"width: ${width}px;\""        if $::lglobal{htmlimgwidthtype} eq 'px';
+    my $wclass = $::lglobal{htmlimgwidthtype} eq 'px' ? '' : ' class="w100"';
     $textwindow->insert( 'thisblockstart',
             "<div class=\"fig$::lglobal{htmlimgalignment}$divclass\" id=\"$idname\"$style>\n"
-          . "  <img class=\"w100\" src=\"$name\"$sizexy$alt$title />\n"
+          . "  <img$wclass src=\"$name\"$sizexy$alt$title />\n"
           . "$selection</div>"
           . $::lglobal{preservep} );
 


### PR DESCRIPTION
Since ebookmaker strips the pixel width setting from the div, the 100% image width
class caused some ereaders to display all pixel images at 100% width. Removing it
allows the image to always be displayed at its pixel width.

Edit is not necessary for em widths, because they are not stripped by ebookmaker.

Fixes #721 