### PR TITLE
Avoid leaving page boundaries within a word

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1282,6 +1282,9 @@ sub html_convert_pageanchors {
             @pagerefs = ();
         }
 
+        # if marker is not at whitespace, move it forward so pagenum span doesn't end up mid-word
+        $markindex = ::safemark($markindex);
+
         # comment only
         $textwindow->ntinsert( $markindex, "<!-- Page $lastref -->" )
           if ( $::pagecmt and $lastref );


### PR DESCRIPTION
When lines are joined during Page Separator Fixup, the page boundary could end up
mid-word. When HTML was generated, pagenum spans were output where the page
boundary mark was, even if it was mid-word.

Now, Page Separator Fixup and HTML autogeneration both shift the location
forward to find a position that is not mid-word.

Fixes #733