### PR TITLE
Avoid combining/skipping page numbers unless no text between them

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1247,13 +1247,13 @@ sub html_convert_pageanchors {
             last if $marknext =~ m{Pg(\S+)};
         }
 
-        # If no more marks (reached end of file) or next mark page marker at least a line
-        # beyond the current one, then convert batch of accumulated page markers to a string
+        # If no more marks (reached end of file) or there are word characters between the
+        # current mark and the next, then convert batch of accumulated page markers to a string
         my $pagereference = '';
         my $lastref       = '';
         if (
             not $marknext    # no next marker - end of file
-            or $textwindow->compare( $textwindow->index($marknext), '>=', "$markindex+1l" )
+            or $textwindow->get( $markindex, $marknext ) =~ /\w/
         ) {
             my $br      = "";                 # No br before first marker in batch
             my $numrefs = scalar @pagerefs;


### PR DESCRIPTION
Previous check for whether next page number was at least one line ahead of the
current one was unsafe when there is very little text on a page, e.g. with long,
continued footnotes, there is sometimes just one line of main body text on a
page. If this line was shorter than the previous one, it could lead to the page
being treated as a blank one, so the page numbers would be combined or
skipped. This has happened since 1.0.25 at least, but with the new feature
where consecutive page labels can be skipped rather than combined, the
consequences are more significant.

Now checks if there are any word characters between the page breaks or not.

Fixes #737 