### PR TITLE
Save image width type between runs of the program

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -148,6 +148,7 @@ our @gsopt;
 our $highlightcolor         = '#a08dfc';
 our $history_size           = 20;
 our $htmlimageallowpixels   = 0;                           # Don't allow user to specify image size in pixels by default
+our $htmlimagewidthtype     = '%';                         # Default to specifying image size by percentage
 our $ignoreversions         = "none";                      # Don't ignore any updates by default
 our $ignoreversionnumber    = "";                          # Ignore a specific version
 our $jeebiesmode            = 'p';

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -914,7 +914,7 @@ EOM
             blocklmargin blockrmargin bold_char charsuitewfhighlight composepopbinding cssvalidationlevel
             defaultindent donotcenterpagemarkers epubpercentoverride failedsearch
             font_char fontname fontsize fontweight gblfontname gblfontsize gblfontweight gblfontsystemuse
-            geometry gesperrt_char globalaspellmode highlightcolor history_size htmlimageallowpixels ignoreversionnumber
+            geometry gesperrt_char globalaspellmode highlightcolor history_size htmlimageallowpixels htmlimagewidthtype ignoreversionnumber
             intelligentWF ignoreversions italic_char jeebiesmode lastversioncheck lastversionrun lmargin markupthreshold
             multisearchsize multiterm nobell nohighlights pagesepauto projectfileslocation notoolbar poetrylmargin projectfileslocation
             recentfile_size rmargin rmargindiff rwhyphenspace sc_char scannos_highlighted

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1001,7 +1001,6 @@ sub initialize {
     $::lglobal{html_f}             = '<span class="antiqua">';    # HTML convert - default replacement for <f>
     $::lglobal{html_g}             = '<em class="gesperrt">';     # HTML convert - default replacement for <g>
     $::lglobal{html_i}             = '<i>';                       # HTML convert - default replacement for <i>
-    $::lglobal{htmlimgwidthtype}   = '%';                         # HTML image width in % or em
     $::lglobal{htmlimgalignment}   = 'center';                    # HTML image alignment
     $::lglobal{htmlimagesizex}     = 0;                           # HTML pixel width of file loaded in image dialog
     $::lglobal{htmlimagesizey}     = 0;                           # HTML pixel height of file loaded in image dialog


### PR DESCRIPTION
For PPers who use the pixel image width type, it is tedious that the default is
percent, so save the last-used setting, instead of reverting to percent.

Fixes #742