### PR TITLE
Accept a column number in error check files

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -304,7 +304,8 @@ sub errorcheckpop_up {
             $line =~ s/\&gt;/>/g;
 
             # if line has a number at the start, assume it is the error line number
-            $line =~ s/^\s*(\d+)\s*/$1:0 /;
+            # unless it already has a column number, set the column number to zero
+            $line =~ s/^\s*(\d+)[:\s]*/$1:0 / unless $line =~ /^\s*(\d+):(\d+)/;
 
         } elsif ( $errorchecktype eq "Bookloupe" ) {
             next if $line =~ /^File: /;


### PR DESCRIPTION
Previously the code assumed that only a line number would be at the start of
a line in an error check file and added an extra `:0`.

Don't do that if there is already a column number specified.

Fixes #741