### PR TITLE
Don't store width & height for bookloupe view options dialog

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -751,7 +751,7 @@ sub initialize {
     $::geometryhash{gotolabpop}       = '265x70+400+400'  unless $::geometryhash{gotolabpop};
     $::geometryhash{gotolinepop}      = '265x70+400+400'  unless $::geometryhash{gotolinepop};
     $::geometryhash{gotopagpop}       = '265x70+400+400'  unless $::geometryhash{gotopagpop};
-    $::geometryhash{gcviewoptspop}    = '+264+72'         unless $::geometryhash{gcviewoptspop};
+    $::positionhash{gcviewoptspop}    = '+264+72'         unless $::positionhash{gcviewoptspop};
     $::geometryhash{grpop}            = '750x540+100+100' unless $::geometryhash{grpop};
     $::positionhash{guesspgmarkerpop} = '+10+10'          unless $::positionhash{guesspgmarkerpop};
     $::positionhash{hilitepop}        = '+150+150'        unless $::positionhash{hilitepop};


### PR DESCRIPTION
There is no reason to resize the dialog as it has fixed labels in it. Having width
and height stored means that a font change can cause some of the dialog to
be hidden.

Change the entry from the geometryhash to the positionhash - there is already
code to handle such a change when the user upgrades to a new version in
FileMenu.pm

Fixes #746