### PR TITLE
Avoid advancing page markers into HTML tags

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1283,7 +1283,7 @@ sub html_convert_pageanchors {
         }
 
         # if marker is not at whitespace, move it forward so pagenum span doesn't end up mid-word
-        $markindex = ::safemark($markindex);
+        $markindex = ::safemark( $markindex, '<' );    # don't advance past '<' (HTML tag), e.g. abc<br />
 
         # comment only
         $textwindow->ntinsert( $markindex, "<!-- Page $lastref -->" )

--- a/src/lib/Guiguts/PageSeparators.pm
+++ b/src/lib/Guiguts/PageSeparators.pm
@@ -472,7 +472,8 @@ sub processpageseparator {
 # Given the index of a page marker return the index of a safe place for it,
 # specifically move it forward if it is mid-word
 sub safemark {
-    my $markindex  = shift;
+    my $markindex = shift;
+    my $blockers  = shift // '';        # Additional characters that page marker must not be advanced beyond
     my $textwindow = $::textwindow;
     my ( $markrow, $markcol ) = split /\./, $markindex;
     unless ( $markcol == 0 ) {    # No need to move if at beginning of line
@@ -481,11 +482,11 @@ sub safemark {
         # length of 1 means mark is already at end of line
         unless ( length($chkstr) <= 1 ) {
 
-            # trim from first whitespace character onwards to see how far mark needs moving
-            if ( $chkstr =~ s/\s.*// ) {
+            # trim from first blocker character / whitespace onwards to see how far mark needs moving
+            if ( $chkstr =~ s/[$blockers\s].*// ) {
                 my $len = length($chkstr) - 1;    # Allow for chkstr originally starting at preceding character
                 $markindex = $textwindow->index("$markindex + $len c") unless $len <= 0;
-            } else {    # No whitespace, so move to end of line
+            } else {    # No blocker characters / whitespace found, so move to end of line
                 $markindex = $textwindow->index("$markindex lineend");
             }
         }

--- a/src/lib/Guiguts/PageSeparators.pm
+++ b/src/lib/Guiguts/PageSeparators.pm
@@ -472,11 +472,11 @@ sub processpageseparator {
 # Given the index of a page marker return the index of a safe place for it,
 # specifically move it forward if it is mid-word
 sub safemark {
-    my $markindex = shift;
-    my $blockers  = shift // '';        # Additional characters that page marker must not be advanced beyond
+    my $markindex  = shift;
+    my $blockers   = shift // '';     # Additional characters that page marker must not be advanced beyond
     my $textwindow = $::textwindow;
     my ( $markrow, $markcol ) = split /\./, $markindex;
-    unless ( $markcol == 0 ) {    # No need to move if at beginning of line
+    unless ( $markcol == 0 ) {        # No need to move if at beginning of line
         my $chkstr = $textwindow->get( "$markindex -1c", "$markindex lineend" );    # Get from preceding character to end of line
 
         # length of 1 means mark is already at end of line


### PR DESCRIPTION
Page markers were advanced to the next whitespace to avoid them appearing
mid-word (#738).

However in HTML, it is possible to have a `<br />` or `<span...` immediately following a word, and the page marker could be advanced into it.

Avoid this by advancing to the next whitespace or `<` when inserting HTML
page number spans

Fixes #756 .