### PR TITLE
Stop using charset ascii when autogenerating HTML

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1407,10 +1407,8 @@ sub html_parse_header {
     $headertext =~ s/BOOKLANG/$::booklang/g;
     if ( $::lglobal{leave_utf} && ::currentfileisunicode() ) {
         $headertext =~ s/BOOKCHARSET/utf-8/;
-    } elsif ( $::lglobal{keep_latin1} && ::currentfileislatin1() ) {
-        $headertext =~ s/BOOKCHARSET/iso-8859-1/;
     } else {
-        $headertext =~ s/BOOKCHARSET/ascii/;
+        $headertext =~ s/BOOKCHARSET/iso-8859-1/;
     }
     eval( '$headertext =~ s#\{LANG=' . uc($::booklang) . '\}(.*?)\{/LANG\}#$1#gs' );    # code duplicated near footertext
 

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -16,7 +16,7 @@ BEGIN {
       &natural_sort_length &natural_sort_freq &drag &cut &paste &entrypaste &textcopy &colcut &colcopy &colpaste &showversion
       &checkforupdates &checkforupdatesmonthly &gotobookmark &setbookmark &seeindex &ebookmaker
       &sidenotes &poetrynumbers &get_page_number &externalpopup &add_entry_history &entry_history
-      &xtops &toolbar_toggle &killpopup &expandselection &currentfileisunicode &currentfileislatin1
+      &xtops &toolbar_toggle &killpopup &expandselection &currentfileisunicode
       &getprojectid &setprojectid &viewprojectcomments &viewprojectdiscussion &viewprojectpage
       &scrolldismiss &updatedrecently &hidelinenumbers &restorelinenumbers &displaylinenumbers
       &enable_interrupt &disable_interrupt &set_interrupt &query_interrupt &soundbell &busy &unbusy
@@ -2725,13 +2725,6 @@ sub currentfileisunicode {
     return 1 if $::utf8save;    # treat as unicode regardless of contents
     my $textwindow = $::textwindow;
     return $textwindow->search( '-regexp', '--', '[\x{100}-\x{FFFE}]', '1.0', 'end' );
-}
-
-sub currentfileislatin1 {
-    my $textwindow = $::textwindow;
-    return $textwindow->search( '-regexp', '--',
-        '[\xC0-\xCF\xD1-\xD6\xD9-\xDD\xE0-\xEF\xF1-\xF6\xF9-\xFD]',
-        '1.0', 'end' );
 }
 
 #FIXME: doesnt work quite right if multiple volumes held in same directory


### PR DESCRIPTION
If a file had no non-ascii characters, and the default option to treat all files
as utf-8 was turned off, the HTML header set the charset to ascii.
Although this is valid, some tools whine about it and suggest us-ascii instead.

Since for an ascii file, the charset iso-8859-1 is equally valid, use that when
ascii would have been used previously

Fixes #755