### PR TITLE
Avoid errors from Stealth Scannos when Hint dialog is already popped

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1600,6 +1600,7 @@ sub stealthscanno {
     my $textwindow = $::textwindow;
     my $top        = $::top;
     $::lglobal{doscannos} = 1;
+    ::killpopup('hintpop');
     ::killpopup('searchpop');
     searchoptset(qw/1 x x 0 1/);    # force search to begin at start of doc, whole word
     if ( ::loadscannos() ) {


### PR DESCRIPTION
Hint dialog gets destroyed when the S&R dialog is destroyed, but the internal
variable was only cleared if the S&R dialog was destroyed via the Window
Manager, not if destroyed by attempting to start a new Stealth Scanno search.

Fixes #764