### PR TITLE
Make regex scanno search case-sensitive by default

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -2109,7 +2109,7 @@ sub loadscannos {
             push @{ $::lglobal{scannosarray} }, $_;
         }
         if ( $::lglobal{scannosfilename} =~ /reg/i ) {
-            searchoptset(qw/0 x x 1/);
+            searchoptset(qw/0 0 x 1/);    # For a regex scannos file, force regex flag and case-sensitive
         } else {
             searchoptset(qw/x x x 0/);
         }


### PR DESCRIPTION
Code already detected if scannos file was a regex file (from its name), and set
the regex flag for searching. Since generally the regexes are intended to be
case-sensitive, also set the case-sensitive flag. Without this searches such as
"comma followed by uppercase" don't work as expected.

Fixes #767