### PR TITLE
Fix error when chosen scannos directory is guiguts install directory

### DIFF
--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -606,7 +606,8 @@ sub locateDirectory {
     ${$dirpathref} = ::os_normal( ${$dirpathref} );
 
     # If possible, convert to relative path by trimming release root directory and slash from start
-    if ( index( ${$dirpathref}, $::lglobal{guigutsdirectory} ) == 0 ) {
+    if ( index( ${$dirpathref}, $::lglobal{guigutsdirectory} ) == 0
+        and length( ${$dirpathref} ) > length( $::lglobal{guigutsdirectory} ) ) {
         ${$dirpathref} = substr( ${$dirpathref}, length( $::lglobal{guigutsdirectory} ) + 1 );
     }
     ::savesettings();


### PR DESCRIPTION
Although this seems unlikely at first glance, when Set File Paths is used to
select a scannos directory, the default is for it to open at the parent of the
current scannos directory, which is the main install directory. Clicking OK
at this point used to give an error due to a substr argument being out of
range when the code was trying to convert to a path relative to the install
directory.

Now checks the new path is long enough to for a legal substr call.

Fixes #769 