### PR TITLE
Don't store duplicate errors from bookloupe

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -371,6 +371,10 @@ sub errorcheckpop_up {
             my $colnum = $2 + $columnadjust;
             $line =~ s/^\d+:\d+/${linnum}:${colnum}/;
 
+            # Skip if already have identical error at same location already, since firstly it is not necessary,
+            # and secondly it would break logic using errors hash to store references to marks in file.
+            next if $::errors{$line};
+
             my $markname = "t" . ++$mark;
             $textwindow->markSet( $markname, "${linnum}.${colnum}" );    # add mark in main text
             $::errors{$line} = $markname;                                # cross-ref error with mark


### PR DESCRIPTION
A duplicate error (i.e. same error at same line and column) message from
bookloupe causes an error later when the user attempts to delete the lines
as they process them. This is because the errors are used as the keys into a
hash containing the position in the text to find the error. Therefore when the
first occurrence of the error is deleted by the user, the hash entry is cleared,
and then the second occurrence can't find an entry in the hash.

There is no benefit in exact duplicate errors anyway, since the user won't know
what the second one means.

An example of a file causing bookloupe to give a duplicate error is
```
"?
"D
```
which causes two errors warning about bad quote spacing, both referencing
the quotes in the first column of the first line.

Fixes #770