### PR TITLE
Fix minor character insert quibbles

### DIFF
--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -43,7 +43,8 @@ sub commoncharspopup {
             -text        => 'HTML Entity',
         )->grid( -row => 1, -column => 2 );
         $charradio->select;
-        my $frame       = $::lglobal{comcharspop}->Frame( -background => $::bkgcolor )->pack;
+        my $frame = $::lglobal{comcharspop}->Frame( -background => $::bkgcolor )
+          ->pack( -padx => 10, -pady => 10 );
         my @commonchars = (
             [ 'À', 'Á', 'Â', 'Ã', 'Ä', 'Å', 'Æ', 'Ç', 'È', 'É', 'Ê', 'Ë', 'Ì', 'Í', 'Î', 'Ï', ],
             [    # OE ligature and capital Y with diaresis not in allowed range for Perl source code
@@ -212,6 +213,8 @@ sub insertit {
     my $letter  = shift;
     my $isatext = 0;
     my $spot;
+
+    return unless Tk::Exists( $::lglobal{hasfocus} );    # Ensure saved focus widget still exists
 
     # Tk::Text/Tk::Entry match various text entry boxes
     $isatext = $::lglobal{hasfocus}->isa('Tk::Text') || $::lglobal{hasfocus} == $::textwindow;

--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -551,7 +551,7 @@ sub surround {
         my $f1      = $::lglobal{surpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         my $surstrt = $f1->Entry(
             -textvariable => \$::lglobal{surstrt},
-            -width        => 8,
+            -width        => 12,
             -background   => $::bkgcolor,
             -relief       => 'sunken',
         )->pack(
@@ -560,9 +560,15 @@ sub surround {
             -padx   => 2,
             -anchor => 'n'
         );
+        $surstrt->bind(
+            '<FocusIn>',
+            sub {
+                $::lglobal{hasfocus} = $surstrt;
+            }
+        );
         my $surend = $f1->Entry(
             -textvariable => \$::lglobal{surend},
-            -width        => 8,
+            -width        => 12,
             -background   => $::bkgcolor,
             -relief       => 'sunken',
         )->pack(
@@ -570,6 +576,12 @@ sub surround {
             -pady   => 5,
             -padx   => 2,
             -anchor => 'n'
+        );
+        $surend->bind(
+            '<FocusIn>',
+            sub {
+                $::lglobal{hasfocus} = $surend;
+            }
         );
         my $f2    = $::lglobal{surpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         my $gobut = $f2->Button(
@@ -634,6 +646,7 @@ sub flood {
             -background   => $::bkgcolor,
             -relief       => 'sunken',
             -textvariable => \$::lglobal{ffchar},
+            -width        => 24,
         )->pack(
             -side   => 'left',
             -pady   => 5,
@@ -641,6 +654,12 @@ sub flood {
             -anchor => 'w',
             -expand => 'y',
             -fill   => 'x'
+        );
+        $floodch->bind(
+            '<FocusIn>',
+            sub {
+                $::lglobal{hasfocus} = $floodch;
+            }
         );
         my $f2    = $::lglobal{floodpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         my $gobut = $f2->Button(


### PR DESCRIPTION
1. Small border added around common character insert buttons to make it
possible to click the border to raise the dialog to the top - useful since it is a
dialog that is likely to be left on-screen while other dialogs are used. Fixes #766
2. Check that the widget into which the inserted character will be placed still
exists - slightly more likely this will get triggered now that more widgets are
able to accept the inserted character. Will still be rare, but behaviour will be
appropriate - if focus is not on a widget that can accept special character input,
nothing will be inserted
3. Increase the width of the Surround and Flood dialogs - they are so narrow
that it is hard/impossible depending on your font sizes to pick up the banner to
reposition them.  Fixes #765
4. Allow the Surround and Flood dialog to accept special character input from
Common Characters, Compose Character, etc.  Fixes #759