### PR TITLE
Improve quote/bracket highlighting

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -781,6 +781,7 @@ sub openfile {    # and open it
         }
     }
     ::highlight_scannos();
+    ::highlight_quotbrac();
     ::update_indicators();
     file_mark_pages() if $::auto_page_marks;
     ::readlabels();

--- a/src/lib/Guiguts/Highlight.pm
+++ b/src/lib/Guiguts/Highlight.pm
@@ -8,7 +8,7 @@ BEGIN {
     @ISA = qw(Exporter);
     @EXPORT =
       qw(&scannosfile &hilite &hiliteremove &hilitesinglequotes &hilitedoublequotes &hilitepopup &highlight_scannos
-      &hilite_alignment_start &hilite_alignment_stop &hilite_alignment_toggle);
+      &highlight_quotbrac &hilite_alignment_start &hilite_alignment_stop &hilite_alignment_toggle);
 }
 
 # Routine to find highlight word list
@@ -302,6 +302,71 @@ sub highlight_scannos {    # Enable / disable word highlighting in the text
     }
     ::update_indicators();
     ::savesettings();
+}
+
+#
+# Enable/disable quote/bracket highlighting in the text
+sub highlight_quotbrac {
+    my $textwindow = $::textwindow;
+    my $top        = $::top;
+    if ($::nohighlights) {
+        highlightquotbrac();
+        $::lglobal{quotbrac_highlightedid} = $top->repeat( 400, \&highlightquotbrac );
+    } else {
+        $::lglobal{quotbrac_highlightedid}->cancel if $::lglobal{quotbrac_highlightedid};
+        undef $::lglobal{quotbrac_highlightedid};
+        highlight_quotbrac_remove();
+    }
+    ::update_indicators();
+    ::savesettings();
+}
+
+#
+# Action routine to highlight quotes/brackets
+# Calls to HighlightSinglePairBracketingCursor adapted from TextEdit.pm
+sub highlightquotbrac {
+    my $textwindow = $::textwindow;
+    my $top        = $::top;
+    return 0 unless $::nohighlights;
+    $textwindow->HighlightSinglePairBracketingCursor( '(', ')', '[()]', 'CURSOR_HIGHLIGHT_PARENS',
+        'CURSOR_HIGHLIGHT_PARENS', 0 );
+    $textwindow->HighlightSinglePairBracketingCursor( '{', '}', '[{}]', 'CURSOR_HIGHLIGHT_CURLIES',
+        'CURSOR_HIGHLIGHT_CURLIES', 0 );
+    $textwindow->HighlightSinglePairBracketingCursor( '[', ']', '[][]', 'CURSOR_HIGHLIGHT_BRACES',
+        'CURSOR_HIGHLIGHT_BRACES', 0 );
+    $textwindow->HighlightSinglePairBracketingCursor(
+        '"', '"', '"',
+        'CURSOR_HIGHLIGHT_DOUBLEQUOTE',
+        'CURSOR_HIGHLIGHT_DOUBLEQUOTE', 0
+    );
+    $textwindow->HighlightSinglePairBracketingCursor(
+        "\x{201c}", "\x{201d}", "[\x{201c}\x{201d}]",
+        'CURSOR_HIGHLIGHT_DOUBLECURLY',
+        'CURSOR_HIGHLIGHT_DOUBLECURLY', 0
+    );
+    $textwindow->HighlightSinglePairBracketingCursor(
+        "'", "'", "'",
+        'CURSOR_HIGHLIGHT_SINGLEQUOTE',
+        'CURSOR_HIGHLIGHT_SINGLEQUOTE', 0
+    );
+    $textwindow->HighlightSinglePairBracketingCursor(
+        "\x{2018}", "\x{2019}", "[\x{2018}\x{2019}]",
+        'CURSOR_HIGHLIGHT_SINGLECURLY',
+        'CURSOR_HIGHLIGHT_SINGLECURLY', 0
+    );
+}
+
+#
+# Remove quote/bracket highlighting tags from file
+sub highlight_quotbrac_remove {
+    my $textwindow = $::textwindow;
+    $textwindow->tagRemove( 'CURSOR_HIGHLIGHT_PARENS',      '1.0', 'end' );
+    $textwindow->tagRemove( 'CURSOR_HIGHLIGHT_CURLIES',     '1.0', 'end' );
+    $textwindow->tagRemove( 'CURSOR_HIGHLIGHT_BRACES',      '1.0', 'end' );
+    $textwindow->tagRemove( 'CURSOR_HIGHLIGHT_DOUBLEQUOTE', '1.0', 'end' );
+    $textwindow->tagRemove( 'CURSOR_HIGHLIGHT_DOUBLECURLY', '1.0', 'end' );
+    $textwindow->tagRemove( 'CURSOR_HIGHLIGHT_SINGLEQUOTE', '1.0', 'end' );
+    $textwindow->tagRemove( 'CURSOR_HIGHLIGHT_SINGLECURLY', '1.0', 'end' );
 }
 
 #

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -941,10 +941,11 @@ sub menu_preferences_appearance {
         ],
         [ 'separator', '' ],
         [
-            Checkbutton => 'Enable Quotes Highlighting',
+            Checkbutton => 'Enable Quotes/Brackets Highlighting',
             -variable   => \$::nohighlights,
             -onvalue    => 1,
-            -offvalue   => 0
+            -offvalue   => 0,
+            -command    => \&::highlight_quotbrac
         ],
         [
             Checkbutton => 'Enable Scanno Highlighting',

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -967,15 +967,7 @@ sub initialize {
     $top->configure( -menu => $::menubar = $top->Menu );
 
     # routines to call every time the text is edited
-    $::textwindow->SetGUICallbacks(
-        [
-            \&::update_indicators,
-            sub {
-                return unless $::nohighlights;
-                $::textwindow->HighlightAllPairsBracketingCursor;
-            },
-        ]
-    );
+    $::textwindow->SetGUICallbacks( [ \&::update_indicators, ] );
 
     # Ignore any watchdog timer alarms. Subroutines that take a long time to
     # complete can trip it
@@ -1160,6 +1152,17 @@ sub initialize {
     $textwindow->tagConfigure( 'highlight', -background => 'orange' );
     $textwindow->tagConfigure( 'linesel',   -background => '#8EFD94' );
     $textwindow->tagConfigure( 'alignment', -background => '#8EFD94' );
+    $textwindow->tagConfigure(
+        'CURSOR_HIGHLIGHT_DOUBLECURLY',
+        -foreground => 'black',
+        -background => 'green'
+    );    # From TextEdit.pm
+    $textwindow->tagConfigure(
+        'CURSOR_HIGHLIGHT_SINGLECURLY',
+        -foreground => 'black',
+        -background => 'grey'
+    );    # From TextEdit.pm
+
     $textwindow->tagConfigure(
         'pagenum',
         -background  => 'yellow',


### PR DESCRIPTION
Previously, it was necessary to change the text between two quotes or brackets
for them to be highlighted by the Preferences->Enable Quotes Highlighting
operation. There was also no easy way to remove the highlighting apart from
moving the cursor somewhere in the text where it wasn't between quotes or
brackets and modifying the text again. The code used a built-in feature of
the Text widget.

Now, combine the built-in Text widget feature with the control method used
for scanno highlighting, i.e. set a repeating callback to the highlight routine.

Also, adjust the default behaviour to make it check for matching quotes across
multiple lines as it does for brackets, instead of single line as before.
Also add curly quote support.

Fixes #780