### PR TITLE
Fix long-standing bug in Search Orphaned Brackets

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1981,6 +1981,8 @@ sub orphanedbrackets {
         $textwindow->tagRemove( 'highlight', '1.0', 'end' );
         while (1) {
 
+            last unless defined $::lglobal{brbrackets}[1];    # No attempt to close markup
+
             # The list of matches below must be the same as the radio buttons in sub orphanedbrackets
             if ( $::lglobal{brsel} eq '»|«' ) {
                 last
@@ -2019,6 +2021,8 @@ sub orphanedbrackets {
                         && ( $::lglobal{brbrackets}[1] =~ m{^f/}i ) )
                     || (   ( $::lglobal{brbrackets}[0] =~ m{^/l}i )
                         && ( $::lglobal{brbrackets}[1] =~ m{^l/}i ) )
+                    || (   ( $::lglobal{brbrackets}[0] =~ m{^/i}i )
+                        && ( $::lglobal{brbrackets}[1] =~ m{^i/}i ) )
                   );
             }
             shift @{ $::lglobal{brbrackets} };


### PR DESCRIPTION
If markup such as `/*` or `/P` was used and never closed, it was not flagged, but
an error message was output to the command window (at least 1.0.25 onwards).

This was due to the array element for the closing markup being accessed when
it wasn't defined.

Also added `/i` markup to the previous fix in #793.