### PR TITLE
Add shortcut key for toggling quote highlight feature

### DIFF
--- a/src/hotkeys.txt
+++ b/src/hotkeys.txt
@@ -79,6 +79,7 @@ F8 -- open Stealth Scannos search
 <ctrl>+, -- highlight all apostrophes in selection
 <ctrl>+. -- highlight all double quotes in selection
 <ctrl>+<alt>+h -- highlight arbitrary characters in selection
+<ctrl>+; -- toggle highlighting of quotes and brackets
 <ctrl>+<shift>+a -- toggle highlighting of vertical column at cursor
 <ctrl>+0 -- remove all highlights
 

--- a/src/lib/Guiguts/Highlight.pm
+++ b/src/lib/Guiguts/Highlight.pm
@@ -201,6 +201,8 @@ sub hiliteremove {
     $textwindow->tagRemove( 'highlight', '1.0', 'end' );
     $textwindow->tagRemove( 'quotemark', '1.0', 'end' );
     hilite_alignment_stop();
+    $::nohighlights = 0;
+    ::highlight_quotbrac();
 }
 
 # Highlight straight and curly single quotes in selection

--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -19,6 +19,13 @@ sub keybindings {
     keybind( '<Control-Alt-h>',   sub { ::hilitepopup(); } );
     keybind( '<Control-Shift-a>', sub { ::hilite_alignment_toggle(); } );
     keybind( '<Control-0>',       sub { ::hiliteremove(); } );
+    keybind(
+        '<Control-semicolon>',
+        sub {
+            $::nohighlights = 1 - $::nohighlights;
+            ::highlight_quotbrac();
+        }
+    );
 
     # File
     keybind( '<Control-o>',       sub { ::file_open($textwindow); } );

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -335,6 +335,14 @@ sub menu_search {
             -command     => \&::hilitepopup,
         ],
         [
+            Checkbutton  => 'Highlight Quotes & Brackets',
+            -variable    => \$::nohighlights,
+            -onvalue     => 1,
+            -offvalue    => 0,
+            -accelerator => "Ctrl+;",
+            -command     => \&::highlight_quotbrac
+        ],
+        [
             Checkbutton  => 'Highlight Al~ignment Column',
             -accelerator => 'Ctrl+Shift+a',
             -variable    => \$::lglobal{highlightalignment},
@@ -940,13 +948,6 @@ sub menu_preferences_appearance {
             }
         ],
         [ 'separator', '' ],
-        [
-            Checkbutton => 'Enable Quotes/Brackets Highlighting',
-            -variable   => \$::nohighlights,
-            -onvalue    => 1,
-            -offvalue   => 0,
-            -command    => \&::highlight_quotbrac
-        ],
         [
             Checkbutton => 'Enable Scanno Highlighting',
             -variable   => \$::scannos_highlighted,

--- a/src/lib/ppvchecks/pptxt.pl
+++ b/src/lib/ppvchecks/pptxt.pl
@@ -51,11 +51,11 @@ sub runProgram {
         $outfile = dirname($srctext) . "/pptxt.log";
     }
 
-    open LOGFILE, "> $outfile" || die "output file error\n";
+    open LOGFILE, ">:encoding(UTF-8)", $outfile || die "output file error\n";
 
     printf LOGFILE ( "%s\n", "-" x 80 );
 
-    open INFILE, $srctext;
+    open INFILE, "<:encoding(UTF-8)", $srctext;
 
     my ( $ln, $tmp );
     while ( $ln = <INFILE> ) {
@@ -67,7 +67,7 @@ sub runProgram {
 
     # read the book again, this time a paragraph at a time.
     @para = ();
-    open INFILE, $srctext;
+    open INFILE, "<:encoding(UTF-8)", $srctext;
 
     $tmp = "";
     while ( $ln = <INFILE> ) {

--- a/src/lib/ppvchecks/pptxt.pl
+++ b/src/lib/ppvchecks/pptxt.pl
@@ -11,7 +11,7 @@ use Getopt::Long;
 # http://www.opensource.org/licenses/mit-license.php
 # last edit: 03-Sep-2009 10:41 PM
 
-my $vnum = "1.19k";
+my $vnum = "1.20";
 
 my ( @book, @para );
 my $outfile = "xxx";
@@ -246,22 +246,34 @@ sub linelength_check {
     # find short line that does not end a paragraph and is not in poetry or bq.
     # find longest line of text.
     my $shortlen = 1000;
-    my $longlen  = 0;
+    my $longlen  = $lineln[0];    # Initialise longest line to be the first line
     my $shortln  = 0;
     my $longln   = 0;
-    for ( my $lc = 0 ; $lc <= $#lineld - 2 ; $lc++ ) {
+
+    # The loop logic assumes that the last line of the file is either
+    # zero length (i.e. a blank line) or must be last line of a paragraph
+
+    for ( my $lc = 1 ; $lc <= $#lineld ; $lc++ ) {
+
+        # Long lines check
         if ( $lineln[$lc] > $longlen ) {
             $longln  = $lc;
             $longlen = $lineln[$lc];
         }
-        if (    $lineln[$lc] > $lineln[ $lc + 1 ]
-            and $lineln[ $lc + 1 ] < $lineln[ $lc + 2 ]
-            and $lineln[ $lc + 1 ] > 0
-            and $lineld[ $lc + 1 ] == 0 ) {
-            if ( $lineln[ $lc + 1 ] < $shortlen ) {
-                $shortlen = $lineln[ $lc + 1 ];
-                $shortln  = $lc + 1;
-            }
+
+        # Current line is zero length so ignore previous line as it
+        # is last line of a paragraph or another blank line
+        next if $lineln[$lc] == 0;
+
+        # Current line is poetry/bq so ignore previous line as its either
+        # another poetry/bq line, a blank line or the last line of a paragraph.
+        next if $lineld[$lc] > 0;
+
+        # If we get here, current line is neither a blank line nor a poetry/bq line.
+        # It may also be the last line. Is the previous line the shortest and not blank?
+        if ( $lineln[ $lc - 1 ] < $shortlen and $lineln[ $lc - 1 ] > 0 ) {
+            $shortlen = $lineln[ $lc - 1 ];
+            $shortln  = $lc - 1;
         }
     }
 


### PR DESCRIPTION
1. Add shortcut Ctrl+semicolon to toggle the feature
2. Move the menu entry from Preferences to Search menu where most other
highlighting options reside, since it is not really a preference in that you would
not leave it turned on all the time.
3. Make the Ctrl+0 "remove all highlighting" option also turn off the feature.
4. Add to hotkeys text file for the help button.