### PR TITLE
Fix long-standing right-click bug

### DIFF
--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -246,10 +246,10 @@ sub keybindings {
     # Try to trap odd right click error under OSX and Linux
     keybind(
         '<3>',
-        sub {
-            ::scrolldismiss();
-            $::menubar->Popup( -popover => 'cursor' ) if ($::OS_WIN);
-        }
+        [
+            sub { ::scrolldismiss(); $::menubar->post( $_[1], $_[2] ) if ($::OS_WIN); },
+            ::Ev('X'), ::Ev('Y')
+        ]
     );
 
     # Extra bindings for Mac


### PR DESCRIPTION
If you right-clicked 100 times, you would hit a "deep recursion" error. If you persisted, the program would crash, presumably once the recursion got too
deep. The fault was that the code called `Popup` instead of `post`. The former
does not return, leading to an extra level of recursion each time the right-click
menu was used. The `post` method is the correct one for this case.

Fixes #801