### PR TITLE
Make right-click menu contain just a few useful options

### DIFF
--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -250,14 +250,7 @@ sub keybindings {
     keybind( '<<ScrollDismiss>>', sub { ::scrolldismiss(); } );
     keybind( '<FocusIn>',         sub { $::lglobal{hasfocus} = $textwindow; } );
 
-    # Try to trap odd right click error under OSX and Linux
-    keybind(
-        '<3>',
-        [
-            sub { ::scrolldismiss(); $::menubar->post( $_[1], $_[2] ) if ($::OS_WIN); },
-            ::Ev('X'), ::Ev('Y')
-        ]
-    );
+    keybind( '<3>', [ \&::showcontextmenu, ::Ev('X'), ::Ev('Y') ] );
 
     # Extra bindings for Mac
     if ($::OS_MAC) {


### PR DESCRIPTION
Instead of right-click bringing up the whole menu structure, which makes it
superfluous, align it with other programs by popping a small menu of useful
options, namely Cut, Copy, Paste and Bookmark options. Also, make it available
on all platforms - previous vague comment about trapping odd error may
refer to the long-standing bug fixed by #802.

In addition, previously the location of the right-click was ignored, meaning that
Paste and other options behaved in an unexpected manner. Now, the location
of the right-click is used for Pasting and Bookmarks.

Note that (fortuitously) if you right click over selected text and paste, it replaces
the selected text, but if you right click over a part that isn't selected, the
selected part is not replaced. I think this is desirable behaviour.

Fixes #800