### PR TITLE
Preserve white background for Windows check boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@
   such as emdashes. The shortest line determination was also incorrect
 - Right-clicking the text window over 100 times would cause an error, and
   eventually the program would exit
+- Checkbox backgrounds on Windows changed color instead of remaining white when
+  Preferences->Appearance->Set Button Highlight Color was used, even if the
+  color choosing was cancelled
 
 
 ## Version 1.3.1

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -934,9 +934,7 @@ sub menu_preferences_appearance {
             -command => sub {
                 my $thiscolor = ::setcolor($::activecolor);
                 $::activecolor = $thiscolor if $thiscolor;
-                $::OS_WIN
-                  ? $::lglobal{checkcolor} = 'white'
-                  : $::lglobal{checkcolor} = $::activecolor;
+                $::lglobal{checkcolor} = $::OS_WIN ? 'white' : $::activecolor;
                 ::savesettings();
             }
         ],


### PR DESCRIPTION
The logic was failing due to lack of brackets to enforce operation precedence
with the ternary operator, meaning that although on Windows systems check
boxes should remain white, they did not.
Note that this code was executed even if the Color Choose dialog was
cancelled, which is fine because with the correction it will have no effect, as
was probably the original coder's intent, and is the structure used in similar
Color Choose code nearby.

Fixes #806 