### PR TITLE
Turn off two Basic Fixup options by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
   as well as the Bookmarks submenu. In addition, the location of the
   right-click is used for the bookmark, the Paste position, and whether to
   overwrite previously selected text
+- Basic Fixup options to "Fix up spaces around hyphens" and "Format ellipses
+  correctly" are now unchecked by default
 
 ### Bug Fixes
 - Search/Replace dialog did not remember its position correctly under Linux

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1025,7 +1025,7 @@ sub initialize {
     $::lglobal{wflastsearchterm}   = '';
     $::lglobal{zoneindex}          = 0;
     @{ $::lglobal{ascii} }  = qw/+ - + | | | + - +/;
-    @{ $::lglobal{fixopt} } = ( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 );
+    @{ $::lglobal{fixopt} } = ( 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1 );
 
     # Bookloupe error types
     @{ $::lglobal{gcarray} } = (


### PR DESCRIPTION
It turns out that many experienced PPers either turn off some options, or don't
use Basic Fixup at all, or have to substantial comparison checks afterward,
because Fixup does some risky fixes, particularly relating to dashes/hyphens
and ellipses. On balance with what comes out of the rounds, it may do more
harm than good.

So, turn off the risky options by default. Also update change log.