### PR TITLE
Add Quick Count to count the number of occurrences of a word

### DIFF
--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -161,6 +161,7 @@ sub keybindings {
             }
         }
     );
+    keybind( '<Control-Shift-B>', sub { ::quickcount(); } );
 
     # Navigation
     keybind( '<Control-i>',       sub { ::seecurrentimage(); } );

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -246,6 +246,11 @@ sub menu_search {
             -accelerator => 'Ctrl+f',
             -command     => \&::searchpopup
         ],
+        [
+            'command', '~Quick Count',
+            -accelerator => 'Shift+Ctrl+b',
+            -command     => \&::quickcount
+        ],
         [ 'separator', '' ],
         [
             'command',


### PR DESCRIPTION
Report the number of occurrences of the selected text, doing a whole-word,
case-insensitive search, as would be completed by Ctrl+b in the S&R dialog.

Assign shortcut key of Shift+Ctrl+b

Fixes #810