### PR TITLE
Improve wording on Footnote Check dialog

### DIFF
--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -531,7 +531,8 @@ sub fnview {
             -background => 'yellow',
         )->grid( -row => 1, -column => 1 );
         $frame1->Label(
-            -text       => "No anchor found.\npossibly missing anchor,\nmissing colon, incorrect #",
+            -text =>
+              "No anchor found.\nmissing anchor/colon, incorrect #?\n(may need Unlimited Anchor Search)",
             -background => 'pink',
         )->grid( -row => 1, -column => 2 );
         $frame1->Label(


### PR DESCRIPTION
Make it clearer that "No anchor found" errors might just need the Unlimited
Anchor Search option.

Fixes #813