### PR TITLE
Make searches wrap during curly quote processing

### DIFF
--- a/src/lib/Guiguts/TextProcessingMenu.pm
+++ b/src/lib/Guiguts/TextProcessingMenu.pm
@@ -733,7 +733,7 @@ sub text_quotes_select {
     my $textwindow = $::textwindow;
     $textwindow->tagRemove( 'sel', '1.0', 'end' );
 
-    my $atindex = $textwindow->search( '-exact', '--', '@', 'insert', 'end' );
+    my $atindex = $textwindow->search( '-exact', '--', '@', 'insert' );
     if ($atindex) {
         $textwindow->tagAdd( 'sel', "$atindex linestart", "$atindex lineend" );
         $textwindow->markSet( 'insert' => "$atindex lineend" );
@@ -836,7 +836,7 @@ sub text_straight_quote_select {
     my $textwindow = $::textwindow;
     $textwindow->tagRemove( 'sel', '1.0', 'end' );
 
-    my $atindex = $textwindow->search( '-exact', '--', "'", 'insert', 'end' );
+    my $atindex = $textwindow->search( '-exact', '--', "'", 'insert' );
     if ($atindex) {
         $textwindow->tagAdd( 'sel', "$atindex", "$atindex+1c" );
         $textwindow->markSet( 'insert' => "$atindex+1c" );


### PR DESCRIPTION
To avoid the user thinking prematurely that they have done all straight to
curly quote processing, make the searches for "@" and straight single quotes
wrap at the end of the file. Now if the user gets a bell and icon flash, it's
because there are no more "@" or straight single quotes left in the file.

Fixes #816