### PR TITLE
Avoid crash when tool executable doesn't exist under Linux

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -342,7 +342,11 @@ sub dos_path {
 sub run {
     my @args = @_;
     if ( !$::OS_WIN ) {
-        system { $args[0] } @args;
+        if ( -x $args[0] ) {
+            system { $args[0] } @args;
+        } else {
+            warn "Executable file $args[0] not found";
+        }
     } else {
         require Win32;
         require Win32::Process;

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -342,10 +342,10 @@ sub dos_path {
 sub run {
     my @args = @_;
     if ( !$::OS_WIN ) {
-        if ( -x $args[0] ) {
+        if ( File::Which::which( $args[0] ) ) {
             system { $args[0] } @args;
         } else {
-            warn "Executable file $args[0] not found";
+            warn "Executable $args[0] not found nor is it on the path";
         }
     } else {
         require Win32;


### PR DESCRIPTION
Under Linux, the system call is used to spawn external tools like bookloupe.
If the file didn't exist, GG crashed, whereas under Windows it just gave an
error.

Add a check that the intended tool exists and is executable before attempting
to run it.

Fixes #814