### PR TITLE
Clear sort list of misspelled words when WF spellcheck is run

### DIFF
--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -900,6 +900,7 @@ sub hyphencheck {
 
 sub wordfrequencygetmisspelled {
     $::lglobal{misspelledlist} = ();
+    $::lglobal{spellsort}      = ();
     my ( $words, $uwords );
     my $wordw = 0;
     foreach ( sort ( keys %{ $::lglobal{seenwords} } ) ) {


### PR DESCRIPTION
Although the "misspelledlist" was cleared, the list used for sorting and display
in the Word Frequency dialog was not. This meant that when a spelling was
corrected and the tool re-run, the old spelling still remained in the list.

Fixes #821