### PR TITLE
Ensure replacement uses the same regex options as search

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -127,6 +127,10 @@ sub searchtext {
                     my $wholefile = $textwindow->get( '1.0', $end );
 
                     # search is case sensitive if $::sopt[1] is set
+                    # Note that regex match options "sm" are needed here and when handling ()/$ grouping
+                    # in sub replaceeval. These options should match or weird behaviour will ensue.
+                    # The "g" option is only required here, and finds all matches of the searchterm
+                    # within the file via the while loop
                     if ( $::sopt[1] ) {
                         while ( $wholefile =~ m/$searchterm/smgi ) {
                             push @{ $::lglobal{nlmatches} }, [ $-[0], ( $+[0] - $-[0] ) ];
@@ -725,6 +729,10 @@ sub replaceeval {
     # Handle regex grouping via () and $
     # Don't want dollars in text to be interpreted during substitution (e.g. $2 inserted
     # as a result of match 1 then being substituted for match 2), so escape dollars in match strings
+    # Note that regex match options "sm" are needed here and in the "search on the whole file"
+    # section of sub searchtext - these options should match or weird behaviour will ensue.
+    # The "g" option is not required here since that is to support multiple matches of the searchterm
+    # within the file.
     my @matches = $::sopt[1] ? ( $found =~ m/$searchterm/smi ) : ( $found =~ m/$searchterm/sm );
     for my $idx ( 1 .. 8 ) {    # Up to 8 groups supported
         my $match = $matches[ $idx - 1 ];

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -725,7 +725,7 @@ sub replaceeval {
     # Handle regex grouping via () and $
     # Don't want dollars in text to be interpreted during substitution (e.g. $2 inserted
     # as a result of match 1 then being substituted for match 2), so escape dollars in match strings
-    my @matches = $::sopt[1] ? ( $found =~ m/$searchterm/mi ) : ( $found =~ m/$searchterm/m );
+    my @matches = $::sopt[1] ? ( $found =~ m/$searchterm/smi ) : ( $found =~ m/$searchterm/sm );
     for my $idx ( 1 .. 8 ) {    # Up to 8 groups supported
         my $match = $matches[ $idx - 1 ];
         next unless defined $match;


### PR DESCRIPTION
When replacing `$n` with a bracketed section of the regex, the "s" flag was
not used on the regex search. This flag causes "." to include newlines. Since
the flag is used when the user is searching for the regex in the first place,
it needs to also be used when doing the replacement. Otherwise, the user
does a Search and finds a match, but when they try to replace, they just get
`$1` left in their file.

Note this should have no effect on the commonly used `(.|\n)` construction.

Fixes #829