### PR TITLE
Fix index text wrapping bug after page marker

### DIFF
--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -350,7 +350,7 @@ sub selectrewrap {
 
         # if there are blank lines before the next paragraph, advance past them
         while (1) {
-            $thisblockstart = $textwindow->index("$thisblockstart+1l");
+            $thisblockstart = $textwindow->index("$thisblockstart+1l linestart");
             last if $textwindow->compare( $thisblockstart, '>=', 'end' );
             next if $textwindow->get( $thisblockstart, "$thisblockstart lineend" ) eq '';
             last;


### PR DESCRIPTION
On the first line of each page, it was possible for the temporary character used
to replace the page markers to fool the wrapping code into starting the wrap
from the second character on the line, leaving the first character stranded at
the left margin.

Each chunk that gets wrapped should begin at the start of the line.

Fixes #834