### PR TITLE
Allow ebookmaker 0.11.13 to create HTML output files

### DIFF
--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -788,7 +788,7 @@ sub menu_html {
         [
             'command', 'EB~ookMaker epub/mobi Generation', -command => sub { ::ebookmaker("epub"); }
         ],
-        [ 'command', 'EB~ookMaker HTML Generation', -command => sub { ::ebookmaker("html"); } ],
+        [ 'command', 'EBookMa~ker HTML Generation', -command => sub { ::ebookmaker("html"); } ],
     ];
 }
 

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -785,7 +785,10 @@ sub menu_html {
             }
         ],
         [ 'separator', '' ],
-        [ 'command',   'EB~ookMaker epub/mobi Generation', -command => sub { ::ebookmaker(); } ],
+        [
+            'command', 'EB~ookMaker epub/mobi Generation', -command => sub { ::ebookmaker("epub"); }
+        ],
+        [ 'command', 'EB~ookMaker HTML Generation', -command => sub { ::ebookmaker("html"); } ],
     ];
 }
 

--- a/tools/ebookmaker/package.sh
+++ b/tools/ebookmaker/package.sh
@@ -11,7 +11,7 @@ mkdir $DEST
 cp README.md $DEST
 
 if [[ $OS == "win" ]]; then
-    VERSION=0.10.5
+    VERSION=0.11.13
     URL=https://github.com/DistributedProofreaders/ebm_builder/releases/download/v$VERSION/ebookmaker-$VERSION.zip
     curl -L -o ebookmaker.zip $URL
     unzip ebookmaker.zip -d $DEST


### PR DESCRIPTION
1. Bundle 0.11.13 ebookmaker
2. Add menu option to trigger ebookmaker output of HTML file
3. Pass correct args to ebookmaker to output the requested files

HTML file (with images) is output to a subfolder "out" by ebookmaker because
output folder is the same as input folder.