### PR TITLE
Display an error if user attempts to tidy inline footnotes

### DIFF
--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -307,9 +307,20 @@ sub footnotepop {
         my $frame8 = $::lglobal{footpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $frame8->Button(
             -activebackground => $::activecolor,
-            -command          => sub { footnotetidy() },
-            -text             => 'Tidy Up Footnotes',
-            -width            => 18
+            -command          => sub {
+                if ( $::lglobal{footstyle} eq 'inline' ) {
+                    $::top->Dialog(
+                        -text    => 'Inline footnotes cannot be tidied.',
+                        -bitmap  => 'error',
+                        -title   => 'Footnote Tidy Error',
+                        -buttons => ['Ok']
+                    )->Show;
+                    return;
+                }
+                footnotetidy();
+            },
+            -text  => 'Tidy Up Footnotes',
+            -width => 18
         )->grid( -row => 1, -column => 1, -padx => 6, -pady => 4 );
         ::initialize_popup_without_deletebinding('footpop');
         $::lglobal{footpop}->protocol(


### PR DESCRIPTION
Inline footnotes do not need tidying, since they are complete after the Inline
Reindex. Attempting to tidy them causes them to be corrupted since the code
is not expecting them to be inline.

Output an error when the user attempts to tidy while the "inline" flag is true.

Fixes #838