### PR TITLE
Make Goto Label dialog case insensitive

### DIFF
--- a/src/lib/Guiguts/StatusBar.pm
+++ b/src/lib/Guiguts/StatusBar.pm
@@ -786,13 +786,13 @@ sub gotolabel {
 }
 
 #
-# Callback for gotolabel dialog
+# Callback for gotolabel dialog - case insensitive
 sub gotolabelok {
     my $textwindow = $::textwindow;
     my $mark;
     for ( keys %::pagenumbers ) {
-        if (   $::pagenumbers{$_}{label}
-            && $::pagenumbers{$_}{label} eq $::lglobal{lastlabel} ) {
+        if ( $::pagenumbers{$_}{label}
+            && lc( $::pagenumbers{$_}{label} ) eq lc( $::lglobal{lastlabel} ) ) {
             $mark = $_;
             last;
         }


### PR DESCRIPTION
Roman numeral page labels are forced to lowercase by the label config
dialog, so it makes sense for the Goto Label dialog to be case insensitive.
Fixes #841