### PR TITLE
Avoid misidentifying indent markup as footnote anchor

### DIFF
--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -538,7 +538,7 @@ sub fnview {
               . "until you've addressed all warnings displayed here." )
           ->grid( -row => 0, -column => 1, -columnspan => 4 );
         $frame1->Label(
-            -text       => "Duplicate anchors.\nmore than one fn\npointing to same anchor",
+            -text       => "Duplicate footnotes.\nmore than one fn\npointing to same anchor",
             -background => 'yellow',
         )->grid( -row => 1, -column => 1 );
         $frame1->Label(
@@ -779,11 +779,18 @@ sub footnotefixup {
             $pointer = '';
             $textwindow->insert( "$start+9c", ':' );
         }
+
+        # Regexps below are to avoid mistaking /*[4], etc. for a footnote anchor,
+        # by checking the anchor is not preceded by /*, /#, /I, /i
         if ( $::lglobal{fnsearchlimit} ) {
-            $anchor = $textwindow->search( '-backwards', '--', "[$pointer]", $start, '1.0' )
+            $anchor =
+              $textwindow->search( '-regexp', '-backwards', '--', "(?<!/[*#Ii])\\[$pointer\\]",
+                $start, '1.0' )
               if $pointer;
         } else {
-            $anchor = $textwindow->search( '-backwards', '--', "[$pointer]", $start, "$start-80l" )
+            $anchor =
+              $textwindow->search( '-regexp', '-backwards', '--', "(?<!/[*#Ii])\\[$pointer\\]",
+                $start, "$start-80l" )
               if $pointer;
         }
         $textwindow->tagAdd( 'highlight', $anchor, $anchor . '+' . ( length($pointer) + 2 ) . 'c' )


### PR DESCRIPTION
The markup `/*[4]` is used to set the indent for a block to be 4.
This could sometimes be mistaken for a footnote anchor if the numbering
happened to match, e.g. it occurred between the actual `[4]` anchor and the
footnote itself.

Fixed by using a regex instead of a text match to make sure the potential
anchor is not preceded by the relevant markups `/* /# /I /i`

Also adjusted wording in Footnote Check dialog to better match the reason
for the warning.

Fixes #846