### PR TITLE
Clarify ebookmaker HTML generation button wording

### DIFF
--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -788,7 +788,7 @@ sub menu_html {
         [
             'command', 'EB~ookMaker epub/mobi Generation', -command => sub { ::ebookmaker("epub"); }
         ],
-        [ 'command', 'EBookMa~ker HTML Generation', -command => sub { ::ebookmaker("html"); } ],
+        [ 'command', 'EBookMa~ker HTML5 Generation', -command => sub { ::ebookmaker("html"); } ],
     ];
 }
 


### PR DESCRIPTION
Change HTML to HTML5 in the menu to make it clearer what ebookmaker
is doing.