### PR TITLE
Stop Unicode Character Search erroring on regex characters

### DIFF
--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -402,8 +402,9 @@ sub utfcharsearchpopup {
                 my $row = 0;
                 @textlabels = @textchars = ();
 
-                # split user entry into individual characteristics
-                my @chars = split /\s+/, uc( $characteristics->get );
+                # split user entry into individual characteristics, escaping regex characters
+                my @chars = split /\s+/,
+                  ::escape_regexmetacharacters( uc( $characteristics->get ) );
 
                 # check all the character names
                 for my $name ( sort { $cphash{$a} <=> $cphash{$b} } keys %cphash ) {


### PR DESCRIPTION
If regex metacharacters were entered into the Unicode Character Search
box, it could give errors, since the string entered is used as a regex search
to facilitate whole word searching.

Escape the characters to avoid this - there is no intention nor requirement
for regexes to be supported in the user's search box

Fixes #852