### PR TITLE
Correct misspelling of `caret` in bookloupe output

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -349,6 +349,7 @@ sub errorcheckpop_up {
                 $line =~ s/^\s*Line (\d+) column (\d+)\s*/$1:$2 /;
             }
             $line =~ s/^\s*Line (\d+)\s*/$1:0 /;
+            $line =~ s/ - Carat character\?/ - Caret character?/    # Correct bookloupe misspelling
 
         } elsif ( $errorchecktype eq "Jeebies" ) {
             next if $line =~ /^File: /;

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1037,7 +1037,7 @@ sub initialize {
         'Begins with punctuation',
         'Broken em-dash',
         'Capital "S"',
-        'Carat character',
+        'Caret character',
         'CR without LF',
         'Double punctuation',
         'endquote missing punctuation',


### PR DESCRIPTION
`Caret` is spelled `carat` in bookloupe output, and by necessity in the
Bookloupe View Options dialog.

Correct the spelling before displaying it, since bookloupe is not directly
part of Guiguts.

Fixes #851