### PR TITLE
Update testsuite baseline files to match recent code changes

### DIFF
--- a/tests/pphtmlbaseline.txt
+++ b/tests/pphtmlbaseline.txt
@@ -3,7 +3,7 @@ Beginning check: pphtml
 7:0 <title>
 8:0 The Project Gutenberg eBook of The Streets Of Ascalon, by Robert W. Chambers.
 9:0 </title>
-+unusedcss: CSS possibly not used
+15:0 CSS possibly not used: unusedcss
 +h1: CSS possibly not defined
 +pagenum: CSS possibly not defined
 27:0 Unconverted illustration: <p>[Illustration: "She excused the witness and turned her back to the

--- a/tests/pptxtbaseline.txt
+++ b/tests/pptxtbaseline.txt
@@ -88,6 +88,92 @@ unusual characters check
         { |                                                  { Killed during Air
         { |                                                  { To Com. in Rgt.
         { |       2  Ludlow, E.        S.M.            4947  { Raid in London.
+        £ |    named men, paying £2: 5s. per quarter for each fortnightly
+        £ | a subscription of £100; but it was found that families were so well
+        £ | and Captain T. F. J. N. Thorne each bequeathed £1000 to the Fund. A
+        £ | performance, and a sum of no less than £650 was raised. In January 1916
+        · |                         DALLAS · SAN FRANCISCO
+        · |     Hoare, G. H. R·, ii. 338, 340, 341, 342, iii. 278
+        · | On the far side of the gully an abandoned 5·9 was taken over by No.
+        · | enemy's 5·9 guns registered on them. These men remained unable to
+        ½ |    repulsed 4½ English Divisions to-day. The enemy has been beaten
+        â |      "    24.   " Châtelet.
+        â |      "    24.   " Châtelet.
+        â | Aigle, and by the Americans at Château-Thierry, the Germans launched
+        â | Company to the Château grounds. The King's and No. 4 Companies had in
+        â | grounds of Mecquignies Château were strongly held by machine-guns,
+        â | reached Château-Thierry. The stubborn resistance of the French made any
+        â | seized the Château. In this fighting Second Lieutenant A. D. Anderson
+        â | the Château grounds. There they remained till the end of the month,
+        â | the meantime made good the high ground north of the Château, driving
+        â | the orchards and fields of the Château. Touch was established with the
+        æ |     12472  Cæsar, A. J.
+        è |      "    10.   " Ferrières.
+        è |      "    19.   " Mont St. Geneviève.
+        è | Boussières to St. Hilaire, when it prepared for the forthcoming attack.
+        è | But as soon as they emerged from Cattenières, and came on to the ridge
+        è | Carter was killed, being hit in the head. On reaching Flesquières
+        è | Flesquières. The 2nd Battalion Grenadier Guards was to follow the Irish
+        è | Lakerlière and Larbret, where it was billeted. On the 17th drafts
+        è | Masnières. The canal was being shelled at the time, but the Battalion
+        è | The Battalion had to be in position east of Flesquières at 9.20 A.M.,
+        è | The Third Division had taken Flesquières, but the Sixty-third Division
+        è | at which time the Battalion was to advance towards Flesquières. At zero
+        è | attack and capture the village of Flesquières, and on the left the
+        è | between Graincourt and Flesquières. The 1st Battalion Irish Guards
+        è | called upon, moved on later to Masnières. Cambrai could be seen in the
+        è | day it moved on to Cattenières, and Major Bailey, accompanied by the
+        è | east of Flesquières, and established itself only just short of Premy
+        è | encountered was to pass through and continue the advance on La Henières
+        è | from Flesquières to Premy Chapel. On the right the Third Division would
+        è | from Flesquières. This enabled the 2nd Battalion to push through Orival
+        è | intervals to Seranvillers _via_ Masnières and Crevecour. The next
+        è | marched back to St. Vaast, where it "embussed" for Carnières. There it
+        è | nine were wounded. On the 17th the Battalion marched to Carmières,
+        è | on afterwards to the spur running from Flesquières to Cantaing with a
+        è | south. Flesquières was captured in conjunction with the Third Division,
+        è | to carry Beet Trench. On nearing Flesquières, the enemy's machine-gun
+        è | to push on in the general direction of Cattenières.
+        è | to within a short distance of Cattenières, where the patrols were sent
+        è | trench-system north-west, north, and north-east of Flesquières, moving
+        è | were able to enfilade the troops advancing to Flesquières. When the
+        é |     Dec.   5.   " Verlée.
+        é |    No. 3 Company will be in support écheloned behind No. 4
+        é | 3 Company dug in in échelon to the right flank, with No. 4 Company in
+        é | Company Commanders, rode on to Bévillers to reconnoitre.
+        é | Quiévy, but no halt was made here, as it was found that the advanced
+        é | Two days, the 14th and 15th, were spent at Quiévy cleaning up and
+        é | advance in échelon behind the right flank, in the hope of getting
+        é | east of Quiévy, they were met by heavy machine-gun fire from the
+        é | l'Abbé.
+        é | marched by companies to Quiévy. The casualties during the three days'
+        é | moved forward in their support in échelon to their left flank, while
+        é | post, and to put up a Véry light perpendicular at dusk from his post on
+        é | the line north of La Bassée, and General von Quast, who commanded the
+        é | the rendezvous just east of Bévillers at 4 A.M. It was a very
+        é | them, with the result that Véry lights went up in quick succession, no
+        é | then moved his company to a position écheloned in rear of the King's
+        é | while Véry lights were sent up. Captain Churchill therefore retired
+        é | yards and écheloned in depth. No. 4 Company was to lead the attack on a
+        é | écheloned at a distance of 250 yards on their right, No. 2 Company in
+        ê |    _Forêt de Nieppe_. These now took up the fight, and the way to
+        ê |    a front of nearly 10,000 yards east of the Forêt de Nieppe,
+        ê | In July 1918 the band attended the French Fêtes in Paris, and remained
+        ê | south of the Forêt de Nieppe, in prolongation of the Australian line.
+        ô | and full of barbed wire, its rôle was to march in the wake of the
+        ô | the special rôle of occupying and fortifying Quesnoy Farm, and two
+        ö |      "    15.   " Sötenich.
+        ü |      "    12.   " Mürringen.
+        ü |      "    13.   " Büllingen.
+        ü |      "    13.   " Büllingen.
+        œ |     Des Vœux, F. W., i. 12, 61, 62, iii. 237
+        œ | It was a skilful and daring manœuvre, as the platoon was fired at from
+        œ | Pœuilly. Its movements now depended on the Cavalry Corps, but as
+        œ | column was constantly under shell-fire. On leaving Pœuilly the
+        œ | however successful or daring a manœuvre like this may be, its
+        œ | men had an opportunity of seeing Lesbœufs and Morval, which had
+        œ | other features added to the difficulty of the manœuvre. The long
+        œ | with outposts some 300 yards in front. This manœuvre was carried
        #/ | #/
        () |                                (Signed) BEAUVOIR DE LISLE,
        () |                               (O.R.S.)
@@ -548,6 +634,7 @@ unusual characters check
        () | push forward at zero hour (7 A.M.), with the 2nd Battalion
        () | up (and the advance of a whole enemy division thus delayed) by a few
        () | with No. 1 Company (under Lieutenant Campbell) on the right, and No.
+       )œ |    the 1st Guards Brigade), they were magnificently manœuvred
        // |            to have died on or since                            14/9/14
        // |          Adams, A. C.                                          27/7/17
        // |          Adams, C. J. N.                                      14/11/18
@@ -951,106 +1038,29 @@ unusual characters check
        [] | [Sidenote: The Guards Division 1918.]
        [] | [Sidenote: The Guards Division.]
        [] | [Sidenote: The Guards Division.]
-       £ |    named men, paying £2: 5s. per quarter for each fortnightly
-       £ | a subscription of £100; but it was found that families were so well
-       £ | and Captain T. F. J. N. Thorne each bequeathed £1000 to the Fund. A
-       £ | performance, and a sum of no less than £650 was raised. In January 1916
-       · |                         DALLAS · SAN FRANCISCO
-       · |     Hoare, G. H. R·, ii. 338, 340, 341, 342, iii. 278
-       · | On the far side of the gully an abandoned 5·9 was taken over by No.
-       · | enemy's 5·9 guns registered on them. These men remained unable to
-       ½ |    repulsed 4½ English Divisions to-day. The enemy has been beaten
-       â |      "    24.   " Châtelet.
-       â |      "    24.   " Châtelet.
-       â | Aigle, and by the Americans at Château-Thierry, the Germans launched
-       â | Company to the Château grounds. The King's and No. 4 Companies had in
-       â | grounds of Mecquignies Château were strongly held by machine-guns,
-       â | reached Château-Thierry. The stubborn resistance of the French made any
-       â | seized the Château. In this fighting Second Lieutenant A. D. Anderson
-       â | the Château grounds. There they remained till the end of the month,
-       â | the meantime made good the high ground north of the Château, driving
-       â | the orchards and fields of the Château. Touch was established with the
-       æ |     12472  Cæsar, A. J.
-       è |      "    10.   " Ferrières.
-       è |      "    19.   " Mont St. Geneviève.
-       è | Boussières to St. Hilaire, when it prepared for the forthcoming attack.
-       è | But as soon as they emerged from Cattenières, and came on to the ridge
-       è | Carter was killed, being hit in the head. On reaching Flesquières
-       è | Flesquières. The 2nd Battalion Grenadier Guards was to follow the Irish
-       è | Lakerlière and Larbret, where it was billeted. On the 17th drafts
-       è | Masnières. The canal was being shelled at the time, but the Battalion
-       è | The Battalion had to be in position east of Flesquières at 9.20 A.M.,
-       è | The Third Division had taken Flesquières, but the Sixty-third Division
-       è | at which time the Battalion was to advance towards Flesquières. At zero
-       è | attack and capture the village of Flesquières, and on the left the
-       è | between Graincourt and Flesquières. The 1st Battalion Irish Guards
-       è | called upon, moved on later to Masnières. Cambrai could be seen in the
-       è | day it moved on to Cattenières, and Major Bailey, accompanied by the
-       è | east of Flesquières, and established itself only just short of Premy
-       è | encountered was to pass through and continue the advance on La Henières
-       è | from Flesquières to Premy Chapel. On the right the Third Division would
-       è | from Flesquières. This enabled the 2nd Battalion to push through Orival
-       è | intervals to Seranvillers _via_ Masnières and Crevecour. The next
-       è | marched back to St. Vaast, where it "embussed" for Carnières. There it
-       è | nine were wounded. On the 17th the Battalion marched to Carmières,
-       è | on afterwards to the spur running from Flesquières to Cantaing with a
-       è | south. Flesquières was captured in conjunction with the Third Division,
-       è | to carry Beet Trench. On nearing Flesquières, the enemy's machine-gun
-       è | to push on in the general direction of Cattenières.
-       è | to within a short distance of Cattenières, where the patrols were sent
-       è | trench-system north-west, north, and north-east of Flesquières, moving
-       è | were able to enfilade the troops advancing to Flesquières. When the
-       é |     Dec.   5.   " Verlée.
-       é |    No. 3 Company will be in support écheloned behind No. 4
-       é | 3 Company dug in in échelon to the right flank, with No. 4 Company in
-       é | Company Commanders, rode on to Bévillers to reconnoitre.
-       é | Quiévy, but no halt was made here, as it was found that the advanced
-       é | Two days, the 14th and 15th, were spent at Quiévy cleaning up and
-       é | advance in échelon behind the right flank, in the hope of getting
-       é | east of Quiévy, they were met by heavy machine-gun fire from the
-       é | l'Abbé.
-       é | marched by companies to Quiévy. The casualties during the three days'
-       é | moved forward in their support in échelon to their left flank, while
-       é | post, and to put up a Véry light perpendicular at dusk from his post on
-       é | the line north of La Bassée, and General von Quast, who commanded the
-       é | the rendezvous just east of Bévillers at 4 A.M. It was a very
-       é | them, with the result that Véry lights went up in quick succession, no
-       é | then moved his company to a position écheloned in rear of the King's
-       é | while Véry lights were sent up. Captain Churchill therefore retired
-       é | yards and écheloned in depth. No. 4 Company was to lead the attack on a
-       é | écheloned at a distance of 250 yards on their right, No. 2 Company in
-       ê |    _Forêt de Nieppe_. These now took up the fight, and the way to
-       ê |    a front of nearly 10,000 yards east of the Forêt de Nieppe,
-       ê | In July 1918 the band attended the French Fêtes in Paris, and remained
-       ê | south of the Forêt de Nieppe, in prolongation of the Australian line.
-       ô | and full of barbed wire, its rôle was to march in the wake of the
-       ô | the special rôle of occupying and fortifying Quesnoy Farm, and two
-       ö |      "    15.   " Sötenich.
-       ü |      "    12.   " Mürringen.
-       ü |      "    13.   " Büllingen.
-       ü |      "    13.   " Büllingen.
-       œ |     Des Vœux, F. W., i. 12, 61, 62, iii. 237
-       œ | It was a skilful and daring manœuvre, as the platoon was fired at from
-       œ | Pœuilly. Its movements now depended on the Cavalry Corps, but as
-       œ | column was constantly under shell-fire. On leaving Pœuilly the
-       œ | however successful or daring a manœuvre like this may be, its
-       œ | men had an opportunity of seeing Lesbœufs and Morval, which had
-       œ | other features added to the difficulty of the manœuvre. The long
-       œ | with outposts some 300 yards in front. This manœuvre was carried
+       ££ |    of £6: 15s. per man per quarter, or £2: 5s. per parcel per
+       ££ |    parcel. In some cases an adopter pays £4: 10s. for two, or £6:
+       ££ | total of £18,000 was invested in addition to the sum of £2100 placed at
+       ·· |                       NEW YORK · BOSTON · CHICAGO
+       èé | Portuguese front between Armentières and La Bassée, and the fighting
+       éé | and moved slowly forward through Fresnoy Farm, Bévillers, Quiévy,
+       œ( | and a general advance on Bourlon and Mœuvres was ordered (on the
       ()( |       1  Corkran, C. E., C.M.G. (Bt.-Col.) (Temp.
       ()( |     Aubrey-Fletcher, H. L., Capt. (Bt.-Major), M.V.O., D.S.O. (Four
       ()( |     Maitland, M. E. M. C., Major (Temp. Lieut.-Col.), D.S.O. (Five
       ()( |     Murray-Threipland, W., Lieut.-Col. (Temp. Col.), D.S.O. (Three
       ()( |     Vivian, V., Major (Bt.-Lieut.-Col.), C.M.G., M.V.O., D.S.O. (Seven
       ()+ |    minutes so as to cross the brown line (Beet Trench) at zero +4
+      ()½ |    (3) 250 cigarettes or ½ lb. of tobacco, as preferred, is sent
+      ()œ | (_b_) The heavy and continuous fighting for the village of Mœuvres
       (/) |       2  Beard, R., M.M.       C.S.M. (D/S) 12909
+      (é) | one company facing north, and one company (in échelon) facing east.
       )// |            Brig.-General)                                      16/6/15
       )// |            Brigade)                                            9/10/14
       )// |            Lancs. Fus.)                                         5/4/18
       )// |            Major-General)                                      14/4/16
       )// |            Naval Brigade)                                       7/5/15
       )// |            of war)                                            29/10/14
-      )œ |    the 1st Guards Brigade), they were magnificently manœuvred
       +++ |     ---------+------------+----------------+------
       +++ |     ---------+------------+----------------+------
       +++ |     ---------+------------+----------------+------
@@ -1125,7 +1135,8 @@ unusual characters check
       {// |       4  Simpson, J. H. C., M.C.                            {   2/9/18
       ||| |         30   |     64     |        199     |  293
       ||| |     Captains.|Lieutenants.|2nd Lieutenants.|Total.
-      œ( | and a general advance on Bourlon and Mœuvres was ordered (on the
+      ··· |                   LONDON · BOMBAY · CALCUTTA · MADRAS
+      œ// |       2  Des Vœux, F. W.                                       14/9/14
      ()() |       (Twice.) (Died.)
      ()() |     Arnold-Forster, M. N., Lieut. (Actg. Capt.). (Guards M.G. Regiment.)
      ()() |     Barrington-Kennett, B. H., Capt. (Bt.-Major). (Killed in action.)
@@ -1221,9 +1232,6 @@ unusual characters check
      ()// |       4  Hardinge, Hon. A. H. L., M.C. (Actg. Capt.)           1/12/17
      ()// |       4  Pryce, T. T., V.C., M.C. (Actg. Capt.)                13/4/18
      ()// |       4  Shelley, G. E. (Actg. Capt.)                          27/9/15
-     ()½ |    (3) 250 cigarettes or ½ lb. of tobacco, as preferred, is sent
-     ()œ | (_b_) The heavy and continuous fighting for the village of Mœuvres
-     (é) | one company facing north, and one company (in échelon) facing east.
      ++++ |     +---------------------+----------------+----------------+
      ++++ |     -------+------+---------------------------+--------------+-------------------
      /#[] | /#[5.3,60]
@@ -1235,13 +1243,6 @@ unusual characters check
      |||| |      Bat-  |Regtl.|   Rank and Name.          |   Regiment.  |Awards, Promotions,
      |||| |     talion.|  No. |                           |              |  etc.
      |||| |     |                     |    Officers.   |  Other Ranks.  |
-     ££ |    of £6: 15s. per man per quarter, or £2: 5s. per parcel per
-     ££ |    parcel. In some cases an adopter pays £4: 10s. for two, or £6:
-     ££ | total of £18,000 was invested in addition to the sum of £2100 placed at
-     ·· |                       NEW YORK · BOSTON · CHICAGO
-     èé | Portuguese front between Armentières and La Bassée, and the fighting
-     éé | and moved slowly forward through Fresnoy Farm, Bévillers, Quiévy,
-     œ// |       2  Des Vœux, F. W.                                       14/9/14
     (){// |            (Actg. Major)                                     { 29/5/16
     (){// |            (Temp. Lieut.-Col.)                               { 27/9/18
     (){// |            (Temp. Lieut.-Col.)                              {  27/9/15
@@ -1479,7 +1480,6 @@ unusual characters check
    |||||| |     |Other ranks|   4508  |   6939 |    21  |11,468 |
    |||||| |     |Scots Guards         |  107  |   149  | 2,072 |  4,002 |
    |||||| |     |Welsh Guards.        |   34  |    55  |   822 |  1,700 |
-   ··· |                   LONDON · BOMBAY · CALCUTTA · MADRAS
   (////)( |          Clive, P. A. (wounded 6/8/15 and 3/11/16) (attached
   )(//)// |            Lancs. Fusiliers) (wounded 4/11/14)                10/10/17
   |||||() |            |      |         |                 |              | (Croix de Guerre).
@@ -1540,7 +1540,7 @@ line spacing check
 --------------------------------------------------------------------------------
 line length check
  longest line 83 at line 14025
- shortest line 56 at line 2072
+ shortest line 10 at line 419
 --------------------------------------------------------------------------------
 repeated word check
  Capt. H. H. Sloane

--- a/tests/testhtml2baseline.html
+++ b/tests/testhtml2baseline.html
@@ -542,7 +542,7 @@ to prove it.</p>
 <p>Another important influence on early American instrument-making
 which must be noted was that of the clockmaker as an
 artisan. A comprehensive study of surviving instruments and
-related records has revealed that only a few of the many cl<span class="pagenum" id="Page_11">[Pg 11]</span>ockmakers
+related records has revealed that only a few of the many clockmakers<span class="pagenum" id="Page_11">[Pg 11]</span>
 working in the American Colonies in the 18th century made
 mathematical instruments. Yet, a large proportion of the surviving
 surveying and nautical instruments produced before 1800 were
@@ -772,7 +772,7 @@ repentance, he was permitted to rejoin the Society of Friends.</p>
 the American Philosophical Society for the observation of the
 transit of Venus. With Joel Baily he was sent to Cape Henlopen,
 Delaware, with a large reflecting telescope borrowed from the
-Library Company. The expedition was described in the <i>Trans<span class="pagenum" id="Page_22">[Pg 22]</span>actions
+Library Company. The expedition was described in the <i>Transactions<span class="pagenum" id="Page_22">[Pg 22]</span>
 of the American Philosophical Society</i> in 1771 in an article entitled
 "An Account of the Transit of Venus, over the Sun's Disk, as
 observed near Cape Henlopen, on Delaware Bay, June 3rd, 1769
@@ -815,7 +815,7 @@ Andrew's cousin, as a subject of possible interest. Apparently
 George Ellicott turned it over to the Honorable James McHenry
 of Baltimore, who in turned submitted it to the Philadelphia firm
 of Goddard &amp; Angell, who published it (fig. 13). Banneker mailed
-a copy of his <i>Benjamin Banneker's Pennsylvania, Delaware, Vir<span class="pagenum" id="Page_24">[Pg 24]</span>ginia
+a copy of his <i>Benjamin Banneker's Pennsylvania, Delaware, Virginia<span class="pagenum" id="Page_24">[Pg 24]</span>
 And Maryland Almanac and Ephemeris For the Year of Our
 Lord, 1792</i> to Thomas Jefferson, who was so impressed with it
 that he forwarded it to the Marquis de Condorcet, secretary of the
@@ -859,7 +859,7 @@ Philosophical Society.</p>
 
 <p>Another noteworthy mathematical practitioner of the period was
 the Reverend John Prince (1751-1836) of Salem, Massachusetts.
-The son of a hatter and mechanic, Prince studied natural phil<span class="pagenum" id="Page_26">[Pg 26]</span>osophy
+The son of a hatter and mechanic, Prince studied natural philosophy<span class="pagenum" id="Page_26">[Pg 26]</span>
 under John Winthrop at Harvard and received his B.A.
 degree in 1776. He was a student of divinity under Samuel
 Williams and was ordained in 1779 at the First Church in Salem.
@@ -991,7 +991,7 @@ instruments for sea or land, by wholesale or retail at reasonable rates.<a id="F
 
 <p>Lamb had served an apprenticeship with Henry Carter, a
 mathematical  instrument maker in  London. In July 1724 he
-became an accomplice of Jack Sheppard, a notorious burglar<span class="pagenum" id="Page_29">[Pg 29]</span>, and
+became an accomplice of Jack Sheppard, a notorious burglar,<span class="pagenum" id="Page_29">[Pg 29]</span> and
 was arrested and sentenced to the gallows in 1724. As he was
 awaiting execution on the gallows at Tyburn, his sentence was
 commuted to transportation to Virginia for a period of seven

--- a/tests/testhtml3baseline.html
+++ b/tests/testhtml3baseline.html
@@ -566,7 +566,7 @@ answer by underlining your request.</p>
 
 <p>"Proud and flattered by your generous interest I hasten to inform
 you that I am leading the same useful, serious, profitable,
-purposeful, ambitious, and en<span class="pagenum" id="Page_128">[Pg 128]</span>nobling life which I was leading when
+purposeful, ambitious, and ennobling<span class="pagenum" id="Page_128">[Pg 128]</span> life which I was leading when
 I first met you. Such a laudable existence makes for one's
 self-respect; and, happy in that consciousness, undisturbed by
 journalistic accusations concerning marmosets and vulgarity, I
@@ -704,7 +704,7 @@ commodity at me?</p>
 
 <p>"To be asked to marry a man no longer distresses me. I am all over
 the romantic idea of being sorry for wealthy amateurs who make me a
-plain business propo<span class="pagenum" id="Page_132">[Pg 132]</span>sition, offering to invest a fortune in my
+plain business proposition,<span class="pagenum" id="Page_132">[Pg 132]</span> offering to invest a fortune in my
 good looks. To amateurs, connoisseurs, and collectors, there is no
 such thing as a fixed market value to anything. An object of art is
 worth what it can be bought for. I don't yet know how much I am
@@ -777,7 +777,7 @@ personally conducted him all over Tappan-Zee Park on the Hudson, through
 mud and slush in a skidding touring car, with the result that the man
 had become a pioneer and had promised to purchase a building site.</p>
 
-<p>So Quarren came back to the Legation that after<span class="pagenum" id="Page_136">[Pg 136]</span>noon feeling almost
+<p>So Quarren came back to the Legation that afternoon<span class="pagenum" id="Page_136">[Pg 136]</span> feeling almost
 buoyant, and discovered Westguard in all kinds of temper, smoking a huge
 faïence pipe which he always did when angry, and which had become known
 as "The Weather-breeder."</p>
@@ -1198,7 +1198,7 @@ features showed it.</p>
 <p>But nervous exhaustion alone could not account for the subtle change in
 her expression. Eyes and lips were still sweet, even in repose, but
 there was now a jaded charm about them&mdash;something unspoiled had
-dis<span class="pagenum" id="Page_148">[Pg 148]</span>appeared from them&mdash;something of that fearlessness which vanishes
+disappeared<span class="pagenum" id="Page_148">[Pg 148]</span> from them&mdash;something of that fearlessness which vanishes
 after too close and too constant contact with the world of men.</p>
 
 <p>Evidently her mind was quite as weary as her body, though even to
@@ -1719,7 +1719,7 @@ whispers of servants; and these ceased presently.</p>
 <p>All alone, amid the lighted magnificence of the vast room sat the old
 woman hunched in her chair, bloodless, motionless as a mass of dead
 flesh. Even the spark in her eyes was gone, the lids closed, the gross
-lower lip pendulous. Later two maids, being summoned, accom<span class="pagenum" id="Page_166">[Pg 166]</span>panied her
+lower lip pendulous. Later two maids, being summoned, accompanied<span class="pagenum" id="Page_166">[Pg 166]</span> her
 to her boudoir, and were dismissed. Her social secretary, a pretty girl,
 came and left with instructions to cancel invitations for the evening.</p>
 
@@ -2797,7 +2797,7 @@ confusion here&mdash;<i>was</i> Quarren on trial? Or was she herself?</p>
 <p>This threatened to become a serious question; she strove to think
 clearly, to reason; but only evoked the pale, amused face of Quarren
 from inner and chaotic consciousness until the visualisation remained
-fixed, de<span class="pagenum" id="Page_200">[Pg 200]</span>fying obliteration. And she accepted the mental spectre for
+fixed, defying<span class="pagenum" id="Page_200">[Pg 200]</span> obliteration. And she accepted the mental spectre for
 the witness box.</p>
 
 <p>"Ricky," she said, "do you really love me?"</p>
@@ -3603,7 +3603,7 @@ make&mdash;except by my saying that I hope to see you again. Will you be
 content with that admission of guilt?</p>
 
 <p>"I meant to speak to you again that day at the Charity affair, only
-there were so many people bother<span class="pagenum" id="Page_224">[Pg 224]</span>ing&mdash;and you seemed to be so
+there were so many people bothering&mdash;and<span class="pagenum" id="Page_224">[Pg 224]</span> you seemed to be so
 delightfully preoccupied with that pretty Cyrille Caldera. I really
 had no decent opportunity to speak to you again without making her
 my mortal enemy&mdash;and you, too, perhaps.</p>
@@ -4245,7 +4245,7 @@ much&mdash;not nearly enough to live on.</p>
 to sit down and write you about it. I was horribly scared, and
 wanted you to know it.</p>
 
-<p>"I didn't yield to the impulse as you know&mdash;I can<span class="pagenum" id="Page_245">[Pg 245]</span>not give you the
+<p>"I didn't yield to the impulse as you know&mdash;I cannot<span class="pagenum" id="Page_245">[Pg 245]</span> give you the
 reasons why. They were merely intuitions at first; later they
 became reasons as my financial situation developed in all its
 annoying proportions.</p>
@@ -4391,7 +4391,7 @@ is it?"</p>
 
 <p>"I hope not," said the young fellow absently.</p>
 
-<p>"Egad! So do I." And to the workmen&mdash;"Phile<span class="pagenum" id="Page_253">[Pg 253]</span>mon and Baucis by Rembrandt!
+<p>"Egad! So do I." And to the workmen&mdash;"Philemon<span class="pagenum" id="Page_253">[Pg 253]</span> and Baucis by Rembrandt!
 Hang 'em up next to that Romney&mdash;over the Jan Steen ... Quarren?"</p>
 
 <p>"Yes?"</p>
@@ -4430,7 +4430,7 @@ Wycherly:</p>
 </div>
 
 <p>The following morning after the workmen had departed, he and Dankmere
-stood contemplating the trans<span class="pagenum" id="Page_254">[Pg 254]</span>formations wrought in the office, back
+stood contemplating the transformations<span class="pagenum" id="Page_254">[Pg 254]</span> wrought in the office, back
 parlour, and extension of Quarren's floor in the shabby old Lexington
 Avenue house.</p>
 
@@ -4601,7 +4601,7 @@ absence. First he arranged with Valasco to identify as nearly as
 possible, and to appraise, the French and Italian pictures. Then he made
 an arrangement with Van Boschoven for the Dutch and Flemish; secured
 Drayton-Quinn for the English; and warned Dankmere not to bother or
-interfere with these tempera<span class="pagenum" id="Page_259">[Pg 259]</span>mental and irascible gentlemen while in
+interfere with these temperamental<span class="pagenum" id="Page_259">[Pg 259]</span> and irascible gentlemen while in
 exercise of their professional duties.</p>
 
 <p>"Don't whistle, don't do abrupt skirt-dances, don't sing comic songs,
@@ -4742,7 +4742,7 @@ the sale of some of his treasures.</p>
 hears, however, of only a few isolated cases. The number of private
 deals that are executed, week in, week out, between impoverished
 members of the highest nobility&mdash;some of them bound, like Lord
-Blith<span class="pagenum" id="Page_263">[Pg 263]</span>erington and the Duke of Putney by close official ties to the
+Blitherington<span class="pagenum" id="Page_263">[Pg 263]</span> and the Duke of Putney by close official ties to the
 Court&mdash;and the agents of either new-rich Britishers or wealthy
 Americans has reached its maximum, and by degrees unentailed
 treasures and heirlooms are passing from owners of many centuries
@@ -4773,7 +4773,7 @@ society. The desire to acquire riches quickly seems to have taken
 hold of the erstwhile staid and conventional upper ten, just as it
 has seized upon the smart set. The recent booms in oil and rubber
 have had the effect of transferring many a comfortable rent roll
-from its own<span class="pagenum" id="Page_264">[Pg 264]</span>er's bankers&mdash;milady's just as often as milord's&mdash;to
+from its owner's<span class="pagenum" id="Page_264">[Pg 264]</span> bankers&mdash;milady's just as often as milord's&mdash;to
 the chartered mortgagors of the financial world. The panic in
 America in 1907 showed to what extent the English nobility was
 interested, not only in gilt-edged securities, but also to what
@@ -5008,7 +5008,7 @@ strangers. Only here and there a glimpse of familiar sweet-william or
 the faint perfume of lemon-verbena brought a friendly warmth into his
 heart; but, in hostile silence he passed by hydrangea and althea,
 syringa and preposterous canna, quietly detesting the rose garden where
-scores of frail and frivo<span class="pagenum" id="Page_273">[Pg 273]</span>lous strangers nodded amid anæmic leaves, or
+scores of frail and frivolous<span class="pagenum" id="Page_273">[Pg 273]</span> strangers nodded amid anæmic leaves, or
 where great, blatant, aniline-coloured blossoms bulged in the sun,
 seeming to repeat with every strapping bud their Metropolitan price per
 dozen.</p>
@@ -6271,7 +6271,7 @@ strike you?"</p>
 
 <p>"Not over me," he said grimly; but added: "How do you know she did?"</p>
 
-<p>"Her maid told mine," admitted Molly shame<span class="pagenum" id="Page_310">[Pg 310]</span>lessly. "Now if you are going
+<p>"Her maid told mine," admitted Molly shamelessly.<span class="pagenum" id="Page_310">[Pg 310]</span> "Now if you are going
 to criticise my channels of information I'll remind you that Richelieu
 himself&mdash;&mdash;"</p>
 
@@ -6652,7 +6652,7 @@ they still knew me&mdash;you were very kind to me, Quarren."</p>
 <p>Ledwith was now picking at his fingers, and Quarren saw that they were
 dreadfully scarred and maltreated.</p>
 
-<p>"You've always been kind to me," repeated Led<span class="pagenum" id="Page_322">[Pg 322]</span>with, his extinct eyes
+<p>"You've always been kind to me," repeated Ledwith,<span class="pagenum" id="Page_322">[Pg 322]</span> his extinct eyes
 fixed on space. "Other people would have halted at sight of me and gone
 the other way&mdash;or passed by cutting me dead.... <i>You</i> sat down beside
 me."</p>
@@ -7423,7 +7423,7 @@ show-windows.</p>
 
 <p>Firemen lounged outside the Eighth Battalion quarters; here and there a
 grocer's or wine-seller's windows remained illuminated where those who
-were neither well-<span class="pagenum" id="Page_341">[Pg 341]</span>to-do nor very poor passed to and fro with little
+were neither well-to-do<span class="pagenum" id="Page_341">[Pg 341]</span> nor very poor passed to and fro with little
 packages which seemed a burden under the sultry skies.</p>
 
 <p>At last, ahead, the pseudo-oriental towers of a synagogue varied the
@@ -7525,7 +7525,7 @@ mute answer which I have given you?"</p>
 <p>"De merry mitt," said a voice, promptly. Mr. De Groot smiled with
 sweetness and indulgence.</p>
 
-<p>"I apprehend your quaint and trenchant vernacu<span class="pagenum" id="Page_348">[Pg 348]</span>lar," he said. "It <i>is</i>
+<p>"I apprehend your quaint and trenchant vernacular,"<span class="pagenum" id="Page_348">[Pg 348]</span> he said. "It <i>is</i>
 the 'merry mitt'&mdash;the 'glad glove,' the 'happy hand'! Fifth Avenue
 clasps palms with Doyers Street&mdash;&mdash;"</p>
 
@@ -7633,7 +7633,7 @@ either De Groot or the clergy, if we used our leisure in
 self-examination."</p>
 
 <p>His lordship went on piling up chairs. When he finished he started
-wandering around, hands in his pock<span class="pagenum" id="Page_351">[Pg 351]</span>ets. Then he turned out all the
+wandering around, hands in his pockets.<span class="pagenum" id="Page_351">[Pg 351]</span> Then he turned out all the
 electric lamps, drew the bay-window curtains wide so that the silvery
 radiance from the arc-light opposite made the darkness dimly lustrous.</p>
 
@@ -8248,7 +8248,7 @@ and cunning falsehoods.</p>
 relined; canvases showing portions of original colour; old canvases and
 panels repainted and artificially darkened and cleverly covered with
 both paint and varnish cracks; canvases that almost defied detection by
-needle-point or glass or thumb fric<span class="pagenum" id="Page_373">[Pg 373]</span>tion or solvent, so ingenious was
+needle-point or glass or thumb friction<span class="pagenum" id="Page_373">[Pg 373]</span> or solvent, so ingenious was
 the forgery simulating age.</p>
 
 <p>Every known adjunct was provided to carry out deception&mdash;genuinely old
@@ -8516,7 +8516,7 @@ the work of silversmiths, goldsmiths, of sculptors in ivory or in
 wood long dead; or in the untinted marbles of the immortal masters.</p>
 
 <p>"Never before did I understand how indissolubly all arts are
-linked, how closely and eternally knit to<span class="pagenum" id="Page_381">[Pg 381]</span>gether in the vast fabric
+linked, how closely and eternally knit together<span class="pagenum" id="Page_381">[Pg 381]</span> in the vast fabric
 fashioned by man from the beginning of time, and in the cryptograms
 of which lie buried all that man has ever thought and hoped.</p>
 
@@ -8586,7 +8586,7 @@ Water' for you; Miss Vining will talk pretty platitudes to you,
 Daisy will purr for you, and the painted eyes of Dankmere's
 ancestors will look down approvingly at you from the wall; and all
 our little world will know that the loveliest and best of all the
-greater world is break<span class="pagenum" id="Page_387">[Pg 387]</span>ing bread with us under our roof, and that
+greater world is breaking<span class="pagenum" id="Page_387">[Pg 387]</span> bread with us under our roof, and that
 one for once, unlike man's dealings with your celestial sisters,
 our entertainment of you will not be wholly unawares.</p>
 </div>
@@ -8621,7 +8621,7 @@ keepers of the house shall tremble"? Perhaps he was unconsciously
 obeying nature's first law.</p>
 
 <p>And yet, slowly within him grew a certainty that these reasons were not
-the real ones&mdash;not the vital im<span class="pagenum" id="Page_388">[Pg 388]</span>pulse that moved his hand steadily
+the real ones&mdash;not the vital impulse<span class="pagenum" id="Page_388">[Pg 388]</span> that moved his hand steadily
 through critical and delicate moments as he bent, breathless, over the
 faded splendours of ancient canvases. No; somehow or other he had
 already begun to work for the sake of the work itself&mdash;whatever that
@@ -9501,7 +9501,7 @@ Of what, then?"</p>
 
 <p>"We're a hardened lot&mdash;some of us. But our most deadly fear is that the
 papers may <i>not</i> notice us. No matter what they say if they'll only say
-something!&mdash;that's our necessity and our unadmitted prayer. Be<span class="pagenum" id="Page_411">[Pg 411]</span>cause
+something!&mdash;that's our necessity and our unadmitted prayer. Because<span class="pagenum" id="Page_411">[Pg 411]</span>
 we've neither brains nor culture nor any distinguishing virtue or
 ability&mdash;and we're nothing&mdash;absolutely nothing unless the papers create
 us! Don't tell me that any one among us is afraid of publicity!&mdash;not in
@@ -10021,7 +10021,7 @@ her. Quickly the hint of tears dried out in her gray eyes&mdash;from whatever
 cause they sprang glimmering there to dim her eyesight. She bent her
 head, absently arranging, rearranging and shifting her bridle.</p>
 
-<p>"The thing to do," he said, curling his long mous<span class="pagenum" id="Page_428">[Pg 428]</span>tache with powerful
+<p>"The thing to do," he said, curling his long moustache<span class="pagenum" id="Page_428">[Pg 428]</span> with powerful
 fingers&mdash;"is for the Wycherlys to stand by us now&mdash;and the others
 there&mdash;that little Lacy girl&mdash;and Sir Charles if he chooses. We'll have
 to take the whole lot of them aboard I suppose."</p>
@@ -10141,7 +10141,7 @@ her friends."</p>
 Strelsa, and then let us be reconciled."</p>
 
 <p>"No, it is too late. It was too late even before we started out
-together. Why&mdash;I didn't realise it then&mdash;<span class="pagenum" id="Page_431">[Pg 431]</span>but it was too late long
+together. Why&mdash;I didn't realise it then&mdash;but<span class="pagenum" id="Page_431">[Pg 431]</span> it was too late long
 ago&mdash;from the day you spoke as you did in my presence to Mr. Quarren.
 That finished you, Langly&mdash;if, indeed, you ever really began to mean
 anything at all to me."</p>
@@ -10448,7 +10448,7 @@ wait. I thought you ought to know. He acts queerly."</p>
 
 <p>"If there was I'd tell you, wouldn't I?"</p>
 
-<p>Kyte's lowered gaze stole upward toward his em<span class="pagenum" id="Page_443">[Pg 443]</span>ployer, sustained his
+<p>Kyte's lowered gaze stole upward toward his employer,<span class="pagenum" id="Page_443">[Pg 443]</span> sustained his
 expressionless glare for a second, then shifted.</p>
 
 <p>"Very well," he said unlocking the library door; "I thought he might be
@@ -10490,7 +10490,7 @@ there, his sunken eyes fixed on the westering sun.</p>
 
 <p>The man's clothing hung loosely on his frame, showing bony angles at
 elbow and knee. Burrs and black swamp-mud stuck to his knickerbockers
-and golf-stock<span class="pagenum" id="Page_444">[Pg 444]</span>ings; he sat very still save for a constant twitching of
+and golf-stockings;<span class="pagenum" id="Page_444">[Pg 444]</span> he sat very still save for a constant twitching of
 the muscles.</p>
 
 <p>The necessity for nervous and physical fatigue drove Sprowl back into
@@ -10808,7 +10808,7 @@ last? Do you understand clearly?&mdash;you fat-headed, meddlesome old fool!"</p>
 <p>He sprang to his feet in an access of fury and began loping up and down
 the room, gesticulating, almost mouthing out his hatred and
 abuse&mdash;rendered more furious still by the knowledge of his own weakness
-and dis<span class="pagenum" id="Page_452">[Pg 452]</span>integration&mdash;his downfall from that silent citadel of
+and disintegration&mdash;his<span class="pagenum" id="Page_452">[Pg 452]</span> downfall from that silent citadel of
 self-control which had served him so many years as a stronghold for
 defiance or refuge.</p>
 
@@ -11586,7 +11586,7 @@ ever since under its ignoble integument of foolish paint.</p>
 <p>"No, I promise not to say one word about it until I have your
 permission. I understand quite well why you desire to keep the
 matter from the newspapers for the present. But&mdash;won't it make you
-and Lord Dank<span class="pagenum" id="Page_479">[Pg 479]</span>mere rich? Tell me&mdash;please tell me. I don't want
+and Lord Dankmere<span class="pagenum" id="Page_479">[Pg 479]</span> rich? Tell me&mdash;please tell me. I don't want
 money for myself any more, but I do want it for you. You need it;
 you can do so much with it, use it so intelligently, so gloriously,
 make the world better with it,&mdash;make it more beautiful, and people
@@ -12076,7 +12076,7 @@ see those people at Witch-Hollow."</p>
 <p>"Perhaps," she said, making a few erasures in her type-written folio and
 rewriting the blank spaces. Then she glanced over the top of the machine
 at his lordship, who, as it happened, was gazing at her with such
-pecu<span class="pagenum" id="Page_492">[Pg 492]</span>liar intensity that it took him an appreciable moment to rouse
+peculiar<span class="pagenum" id="Page_492">[Pg 492]</span> intensity that it took him an appreciable moment to rouse
 himself and take his eyes elsewhere.</p>
 
 <p>"When do you take your vacation?" he asked, carelessly.</p>
@@ -12754,7 +12754,7 @@ often accompanies it, coolness, obstinacy, and effrontery.</p>
 
 <p>He had decided to wait until his cigar had been leisurely finished.
 Then, other measures&mdash;perhaps walking upstairs, unannounced, perhaps an
-unresentful with<span class="pagenum" id="Page_511">[Pg 511]</span>drawal, a note by messenger, and another attempt to see
+unresentful withdrawal,<span class="pagenum" id="Page_511">[Pg 511]</span> a note by messenger, and another attempt to see
 her to-morrow&mdash;he did not yet know&mdash;had arrived at no conclusion&mdash;but
 would make up his mind when he finished his cigar and then do whatever
 caution dictated.</p>
@@ -12981,7 +12981,7 @@ he?"</p>
 
 <p>"But where is he? You&mdash;you don't mean to say&mdash;&mdash;"</p>
 
-<p>"Yes, I do. He went upstairs and didn't re<span class="pagenum" id="Page_519">[Pg 519]</span>turn.... So I waited for a
+<p>"Yes, I do. He went upstairs and didn't return....<span class="pagenum" id="Page_519">[Pg 519]</span> So I waited for a
 while and then&mdash;came back."</p>
 
 <p>They sat silent for a while, then Molly lifted her eyes to his and they
@@ -13137,7 +13137,7 @@ Finally she relented.</p>
 
 <p>"You <i>are</i> satisfactory," she said as they returned to the front veranda
 and seated themselves. "And really, Rix, I'm so terribly glad to see you
-that I for<span class="pagenum" id="Page_528">[Pg 528]</span>give your neglect.... Are you well? You don't look very
+that I forgive<span class="pagenum" id="Page_528">[Pg 528]</span> your neglect.... Are you well? You don't look very
 well," she added earnestly. "Why are you so white?"</p>
 
 <p>[Illustration: "'I wanted to surprise you,' he explained feebly."]</p>
@@ -13176,7 +13176,7 @@ unpinning and untying it, her gray eyes never leaving him in their
 unabashed delight in him.</p>
 
 <p>Then she disappeared for a few minutes only to reappear wearing a pair
-of stout little shoes and carry<span class="pagenum" id="Page_529">[Pg 529]</span>ing a walking-stick which she said she
+of stout little shoes and carrying<span class="pagenum" id="Page_529">[Pg 529]</span> a walking-stick which she said she
 used in rough country.</p>
 
 <p>And first they visited her garden where all the old-fashioned autumn
@@ -13759,7 +13759,7 @@ me for one when we were at&mdash;our house?"</p>
 
 <p>Her gray eyes met his with a frightened sort of courage.</p>
 
-<p>"<i>Our house</i>&mdash;if you wish&mdash;" But her lips had be<span class="pagenum" id="Page_544">[Pg 544]</span>gun to tremble and she
+<p>"<i>Our house</i>&mdash;if you wish&mdash;" But her lips had begun<span class="pagenum" id="Page_544">[Pg 544]</span> to tremble and she
 could not control them or force from them another word for all her
 courage.</p>
 

--- a/tests/testhtml5baseline.html
+++ b/tests/testhtml5baseline.html
@@ -521,7 +521,7 @@ other criminals. In spite, however, of the efforts
 of two of my men, who were immediately sent to
 the scene of the robbery, the guilty parties escaped
 into the almost impenetrable swamps along
-the Mississippi River, and the chase was reluct<span class="pagenum" id="Page_10">[Pg 10]</span>antly
+the Mississippi River, and the chase was reluctantly<span class="pagenum" id="Page_10">[Pg 10]</span>
 abandoned, as it was impossible to tell where
 they would come out or cross the river. The
 amount stolen was not sufficiently large to warrant
@@ -1475,7 +1475,7 @@ about the clearing did not prevent William from
 exercising his usual caution in approaching the
 house; but he did consider it unnecessary to take
 any stronger force into an apparently unoccupied
-log-cabin, where at most he had only vague sus<span class="pagenum" id="Page_38">[Pg 38]</span>picions
+log-cabin, where at most he had only vague suspicions<span class="pagenum" id="Page_38">[Pg 38]</span>
 of finding the objects of his search;
 hence, he left Gordon and Bledsoe behind. Knowing
 the general construction of this class of
@@ -1896,7 +1896,7 @@ the middle of October, the three storekeepers
 went away, and were gone until October 24, three
 days after the robbery, on which day Lester met
 Clark and Barton walking toward his house, on
-the way from Hickman. They seemed quite ex<span class="pagenum" id="Page_52">[Pg 52]</span>cited,
+the way from Hickman. They seemed quite excited,<span class="pagenum" id="Page_52">[Pg 52]</span>
 and said that they had been engaged in a
 difficulty, but they did not state what it was.
 They asked him whether he had seen Russell recently,
@@ -3199,7 +3199,7 @@ the house and saddling their animals, it was nearly
 dark by the time they started for Verona. Farrington
 and Barton were carefully tied upon the
 horse and mule respectively, and, after thanking
-the neighboring farmers for their assistance, Cot<span class="pagenum" id="Page_92">[Pg 92]</span>trell
+the neighboring farmers for their assistance, Cottrell<span class="pagenum" id="Page_92">[Pg 92]</span>
 took the road back, accompanied by the
 eleven men who belonged in and about Verona.
 The greatest care was taken that the prisoners
@@ -3308,7 +3308,7 @@ When quite young, I left home and
 took to following the army. About five or six
 years ago I moved to Normandy, Tennessee, and
 lived with the family of Major Landis, and two
-or three years later, I went to work on the Nash<span class="pagenum" id="Page_95">[Pg 95]</span>ville
+or three years later, I went to work on the Nashville<span class="pagenum" id="Page_95">[Pg 95]</span>
 and Northwestern Railroad as a brakeman,
 remaining as such over two years. About three
 years since I formed the acquaintance of Hillary
@@ -3651,7 +3651,7 @@ could before being killed himself; to release his
 arms, therefore, would enable him to draw a
 weapon, as he was undoubtedly well armed, hence
 Robert never relaxed his hold. Having a professional
-pride in securing his prisoner alive, more<span class="pagenum" id="Page_105">[Pg 105]</span>over,
+pride in securing his prisoner alive, moreover,<span class="pagenum" id="Page_105">[Pg 105]</span>
 he did not wish to resort to extreme measures
 except to save the lives of other persons, and, as
 a large crowd had gathered around the moment
@@ -3995,7 +3995,7 @@ and Connell were sent to arrest him.</p>
 
 <p>At Mr. Merrick's they obtained a good guide,
 and four other citizens joined them, so that they
-had quite a formidable party. After visiting sev<span class="pagenum" id="Page_115">[Pg 115]</span>eral
+had quite a formidable party. After visiting several<span class="pagenum" id="Page_115">[Pg 115]</span>
 houses in the cane-brake, they learned where
 Taylor was staying, and, on going there, they
 saw him looking at them from a front window.
@@ -4338,7 +4338,7 @@ not only as a punishment for their past crimes,
 but as a means of security in the future. Believing
 that a sentence to the penitentiary was
 wholly inadequate, and that their escape therefrom
-was not only possible, but probable, the cit<span class="pagenum" id="Page_127">[Pg 127]</span>izens
+was not only possible, but probable, the citizens<span class="pagenum" id="Page_127">[Pg 127]</span>
 preferred to take no risks of future robberies
 and murders by these desperadoes, and
 they therefore took the most effectual method of
@@ -4534,7 +4534,7 @@ where he lived in regal splendor; indeed,
 his extravagance was so great as to make him
 conspicuous even among the reckless throng who
 filled the Golden City. After wasting a fortune
-with a prodigal hand, however, he suddenly van<span class="pagenum" id="Page_134">[Pg 134]</span>ished,
+with a prodigal hand, however, he suddenly vanished,<span class="pagenum" id="Page_134">[Pg 134]</span>
 and, although little was known positively
 on the subject, it was commonly understood that
 he had swindled a number of bankers and capitalists
@@ -4633,7 +4633,7 @@ the parties, and to make a complete review of
 their past history so far as it might be possible to
 obtain it. No harm could result from such a
 course, whether they were honest or the reverse;
-and so, having decided upon a simple plan, I re<span class="pagenum" id="Page_137">[Pg 137]</span>turned
+and so, having decided upon a simple plan, I returned<span class="pagenum" id="Page_137">[Pg 137]</span>
 to Chicago to select the persons to represent
 me in Gloster.</p>
 
@@ -4940,7 +4940,7 @@ Esq., formerly Member of Congress, and late
 Minister Plenipotentiary at an important European
 court. The suggestion having once been
 made to him by some waggish diplomat that he
-resembled the first Napoleon, he was ever after<span class="pagenum" id="Page_146">[Pg 146]</span>ward
+resembled the first Napoleon, he was ever afterward<span class="pagenum" id="Page_146">[Pg 146]</span>
 desirous of drawing attention to this fancied
 resemblance. He was a vain, fussy, consequential
 politician, whose principal strength was
@@ -5249,7 +5249,7 @@ Madame Sevier was to be her near neighbor in
 her new residence, became very intimate with
 her, especially as Donna Lucia was desirous of
 reviving her knowledge and practice of the French
-language. Consequently, when Don Pedro's ar<span class="pagenum" id="Page_155">[Pg 155]</span>rangements
+language. Consequently, when Don Pedro's arrangements<span class="pagenum" id="Page_155">[Pg 155]</span>
 were all completed and the new
 house occupied, Madame Sevier used to drop in
 for a few minutes' chat every day. As she was
@@ -5643,7 +5643,7 @@ He had a very retentive memory, and, when once
 introduced to any gentleman, he immediately
 took pains to learn everything possible about him.
 By careful observation and perseverance, he had
-learned the general history of a very large num<span class="pagenum" id="Page_166">[Pg 166]</span>ber
+learned the general history of a very large number<span class="pagenum" id="Page_166">[Pg 166]</span>
 of the leading people in society, and his droll
 comments and half-sarcastic criticism of them,
 expressed <i>sotto voce</i> to the Don on various occasions,
@@ -5987,7 +5987,7 @@ necessary, Madame Sevier paid this woman her
 wages and discharged her without a moment's
 warning. The effect upon the other servants
 was most satisfactory, and although the Madame
-was obliged to make some minor changes after<span class="pagenum" id="Page_180">[Pg 180]</span>ward,
+was obliged to make some minor changes afterward,<span class="pagenum" id="Page_180">[Pg 180]</span>
 she was never again annoyed by impertinence
 or presumption. The dinner for that day
 was prepared by the assistant cook, under
@@ -6136,7 +6136,7 @@ before you were sent for?"</p>
 <p>"Yes, indeed; the very minor details were provided
 for, and I could not raise an objection
 which had not already been discussed and removed.
-Both propositions provided for the for<span class="pagenum" id="Page_184">[Pg 184]</span>mation
+Both propositions provided for the formation<span class="pagenum" id="Page_184">[Pg 184]</span>
 of a stock company for the mining, cutting,
 and sale of diamonds. According to the first
 plan, I was to fix a price upon my diamond fields,
@@ -6237,7 +6237,7 @@ to Don Pedro were correct. I immediately visited
 the Senator, and laid the latest developments
 before him. We could not help admiring the consummate
 knowledge of human nature which the
-Don displayed; he had baited his hook so skill<span class="pagenum" id="Page_187">[Pg 187]</span>fully
+Don displayed; he had baited his hook so skillfully<span class="pagenum" id="Page_187">[Pg 187]</span>
 that the gudgeons were actually fearful lest
 something should prevent them from swallowing
 it; but there seemed to be no probability of defeating
@@ -6679,7 +6679,7 @@ the performance of his regular tasks, and even
 when caught in a place where he had no right to
 be, he could invent a plausible reason on the instant,
 which would divert all suspicion from him.
-On his arrival in Gloster, he was sent to ask em<span class="pagenum" id="Page_200">[Pg 200]</span>ployment
+On his arrival in Gloster, he was sent to ask employment<span class="pagenum" id="Page_200">[Pg 200]</span>
 of Monsieur Lesparre, and, of course,
 the latter was so pleased with him as to engage
 him at once. He made himself very useful in
@@ -7553,7 +7553,7 @@ are you really married as you said? Is she as
 handsome as the other was?"</p>
 
 <p>"Yes, she is very handsome," replied the Don,
-curtly; "but she knows nothing about my his<span class="pagenum" id="Page_226">[Pg 226]</span>tory
+curtly; "but she knows nothing about my history<span class="pagenum" id="Page_226">[Pg 226]</span>
 previous to our meeting, and I do not wish
 that she should; so let us leave her out of our
 discussion. I have some money left, though it is
@@ -7665,7 +7665,7 @@ understand that you cannot treat me like a doll,
 to be thrown away when you are tired of me.
 I am able and anxious to help you in all your
 plans, but I must have your full confidence. You
-know that I love you, and you say that you re<span class="pagenum" id="Page_229">[Pg 229]</span>turn
+know that I love you, and you say that you return<span class="pagenum" id="Page_229">[Pg 229]</span>
 my love, but sometimes I distrust you. You
 deserted a señorita in Lima, and some day you
 may try to desert me; but I warn you that I
@@ -7963,7 +7963,7 @@ him," suggested Newton.</p>
 <p>"I'd like to see him try it," Bernardi exclaimed,
 with a volley of oaths. "I guess two
 could play at the game of swearing out warrants,
-and when the account was balanced, his impris<span class="pagenum" id="Page_237">[Pg 237]</span>onment
+and when the account was balanced, his imprisonment<span class="pagenum" id="Page_237">[Pg 237]</span>
 would be twenty times as long as mine.
 No, no; I have no fear that he will attempt such
 a thing."</p>
@@ -8257,7 +8257,7 @@ again?" asked the Don, in a vexed tone.</p>
 
 <p>"Yes, and I have won constantly, so that I
 don't like to change my luck by making a move
-right away. You know gamblers are superst<span class="pagenum" id="Page_245">[Pg 245]</span>itious,
+right away. You know gamblers are superstitious,<span class="pagenum" id="Page_245">[Pg 245]</span>
 and I have a strong feeling that it will be
 for my interest to remain here for some time
 yet."</p>
@@ -8682,7 +8682,7 @@ should like to go back to New Orleans, if I could
 fit up a good place there, and deal a first-class
 game."</p>
 
-<p>"How much would you need for that pur<span class="pagenum" id="Page_258">[Pg 258]</span>pose?"
+<p>"How much would you need for that purpose?"<span class="pagenum" id="Page_258">[Pg 258]</span>
 asked the Don. "If I can let you have it,
 I will do so, and you can stay here or go back to
 New Orleans, as you may prefer; only I shall
@@ -8860,7 +8860,7 @@ dispatched to Gloster at once, to obtain the arrest
 of Don Pedro, though there were a great many
 difficulties in the way, owing to the lack of an
 extradition treaty. Every effort would be made,
-however, to bring him to justice, and the Peru<span class="pagenum" id="Page_263">[Pg 263]</span>vian
+however, to bring him to justice, and the Peruvian<span class="pagenum" id="Page_263">[Pg 263]</span>
 Minister at Washington would be instructed
 to confer with me.</p>
 
@@ -8964,7 +8964,7 @@ will regard a surrender to the Peruvian authorities
 as preferable to a long trial and detention
 here, with the possibility of being sent to California
 or Great Britain for trial on a more serious
-charge. When he knows that we are fully ac<span class="pagenum" id="Page_266">[Pg 266]</span>quainted
+charge. When he knows that we are fully acquainted<span class="pagenum" id="Page_266">[Pg 266]</span>
 with his past career, he may be willing
 to accept our terms rather than to defy us."</p>
 
@@ -9149,7 +9149,7 @@ in your past life and actions."</p>
 entered, and the former, seeing the abject appearance
 of her husband, asked what was the matter.</p>
 
-<p>"Your husband is a prisoner, madam," I re<span class="pagenum" id="Page_271">[Pg 271]</span>plied;
+<p>"Your husband is a prisoner, madam," I replied;<span class="pagenum" id="Page_271">[Pg 271]</span>
 "and as our interview would be painful to
 you, I must ask you to withdraw for the present
 at least."</p>
@@ -9437,7 +9437,7 @@ the weather was so lovely that nothing could
 have been more auspicious for the grand occasion.
 As the hour approached for the departure
 of the steamer, carriage after carriage drew up
-at the dock to discharge its load of brilliantly-<span class="pagenum" id="Page_279">[Pg 279]</span>dressed
+at the dock to discharge its load of brilliantly-dressed<span class="pagenum" id="Page_279">[Pg 279]</span>
 and masked ladies and gentlemen. The
 only person who was not completely protected
 from recognition was Monsieur Lesparre, who
@@ -9471,7 +9471,7 @@ substituted an identification of each person with
 the character which that person represented. The
 balmy airs of a perfect spring day wafted to them
 the sounds of country life along the shores of the
-river, and gave sensations both novel and pleas<span class="pagenum" id="Page_282">[Pg 282]</span>ing
+river, and gave sensations both novel and pleasing<span class="pagenum" id="Page_282">[Pg 282]</span>
 to the gay denizens of the city, who rarely
 experienced any change from their routine of
 fashionable entertainments. During the trip by
@@ -9895,7 +9895,7 @@ This threat brought the party to his terms, and
 he was ordered to bring his steamer over. He
 refused to make more than one trip, however,
 and so the dancers were called away from the
-ballroom at the end of the first waltz, thus spoil<span class="pagenum" id="Page_296">[Pg 296]</span>ing
+ballroom at the end of the first waltz, thus spoiling<span class="pagenum" id="Page_296">[Pg 296]</span>
 their gayety almost ere it had begun. As the
 motley groups gathered on shore awaiting the
 steamer's approach, a more deeply disgusted and
@@ -10077,7 +10077,7 @@ Among those whom I thus noticed was a lady,
 about forty-five years of age, and her son, who
 was about twenty-six years old. The mother,
 Mrs. R. S. Trafton, was a pleasant woman, well
-preserved, and comparatively youthful in appear<span class="pagenum" id="Page_301">[Pg 301]</span>ance.
+preserved, and comparatively youthful in appearance.<span class="pagenum" id="Page_301">[Pg 301]</span>
 She was afflicted by a rheumatic affection,
 which caused her to visit these springs for relief;
 and her son accompanied her partly to look after
@@ -10488,7 +10488,7 @@ were sometimes almost stifling. To venture, at
 any time, into the waste of ruins, which stretched
 more than three miles in one direction, through
 the formerly richest portion of the city, was not
-a pleasant undertaking; but to make such an ex<span class="pagenum" id="Page_315">[Pg 315]</span>cursion
+a pleasant undertaking; but to make such an excursion<span class="pagenum" id="Page_315">[Pg 315]</span>
 at night was attended with more hazard
 than most peaceably-disposed men would care to
 run. There were no gaslights, no sidewalks, no
@@ -11879,7 +11879,7 @@ being the assailant of Robert Adamson. She denied
 ever having done so, and offered to swear
 that she had never betrayed him. He replied
 that he felt sure there must be a mistake, as he
-could not believe it possible that she would be<span class="pagenum" id="Page_354">[Pg 354]</span>tray
+could not believe it possible that she would betray<span class="pagenum" id="Page_354">[Pg 354]</span>
 him. He felt perfect confidence in her, and
 had no fears that she would try to have him arrested.</p>
 
@@ -12770,7 +12770,7 @@ became quiet, and about midnight she fell asleep.</p>
 
 <p>Morton said to me, on making one of his
 reports, that she would often determine to give
-up morphine and liquor, and live more respect<span class="pagenum" id="Page_377">[Pg 377]</span>ably.
+up morphine and liquor, and live more respectably.<span class="pagenum" id="Page_377">[Pg 377]</span>
 Then she would become excited from the
 craving for the drug, and would take a dose,
 which would soothe her, make her amiable, and
@@ -12921,7 +12921,7 @@ when I go to buy."</p>
 go to buy yours."</p>
 
 <p>She then put the bonds into the pocket-book
-again and went into her bedroom. On her re<span class="pagenum" id="Page_381">[Pg 381]</span>turn,
+again and went into her bedroom. On her return,<span class="pagenum" id="Page_381">[Pg 381]</span>
 Barlow told her that he must go down town
 to get paid for his cattle, and he asked Morton to
 go with him. Accordingly, the two men went
@@ -13407,7 +13407,7 @@ quantities.</p>
 
 <p>The jury retired at three o'clock, and, on the
 first ballot, they stood nine for conviction and
-three for acquittal. After discussing the testi<span class="pagenum" id="Page_395">[Pg 395]</span>mony
+three for acquittal. After discussing the testimony<span class="pagenum" id="Page_395">[Pg 395]</span>
 for more than four hours, a compromise
 was reached, and the judge having been informed
 that the jury had agreed upon a verdict,
@@ -13479,7 +13479,7 @@ sentence was pronounced in accordance with the
 verdict of the jury, and Mrs. Sanford was consigned
 to the Illinois State Penitentiary at Joliet.</p>
 
-<p>In regard to the manner in which young Traf<span class="pagenum" id="Page_397">[Pg 397]</span>ton
+<p>In regard to the manner in which young Trafton<span class="pagenum" id="Page_397">[Pg 397]</span>
 was murdered, I have always had a theory of
 my own; and, while of course I do not pretend to
 any surgical learning, I give it for what it is


### PR DESCRIPTION
1. pphtml now outputs a line number with unused CSS warnings
2. pptxt opens files with utf8 encoding, and finds shortest line correctly
3. HTML conversion no longer inserts a page number span mid-word