### PR TITLE
Update to ebookmaker 0.11.26

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2296,13 +2296,14 @@ sub ebookmaker {
     # Run ebookmaker, redirecting stdout and stderr to a file to analyse afterwards
     my $tmpfile = 'ebookmaker.tmp';
     my $runner  = ::runner::withfiles( undef, $tmpfile, $tmpfile );
-    $outputdir =~ s/[\/\\]$//;    # Remove trailing slash from output dir to avoid confusing ebookmaker
+    $outputdir =~ s/[\/\\]$//;                          # Remove trailing slash from output dir to avoid confusing ebookmaker
+    my $configdir = ::dirname($::ebookmakercommand);    # Ebookmaker dir contains tidy.conf file
     $runner->run(
-        $::ebookmakercommand, "--verbose",
-        "--max-depth=3",      $makeoption,
-        $kindleoption,        "--output-dir=$outputdir",
-        "--title=$ttitle",    "--author=$tauthor",
-        "$filepath"
+        $::ebookmakercommand,      "--verbose",
+        "--max-depth=3",           $makeoption,
+        $kindleoption,             "--output-dir=$outputdir",
+        "--config-dir=$configdir", "--title=$ttitle",
+        "--author=$tauthor",       "$filepath"
     );
 
     # Check for errors or warnings in ebookmaker output

--- a/tools/ebookmaker/README.md
+++ b/tools/ebookmaker/README.md
@@ -9,6 +9,9 @@ https://github.com/gutenbergtools/ebookmaker
 
 We bundle a Windows binary of ebookmaker manually created by the 
 [ebm_builder](https://github.com/DistributedProofreaders/ebm_builder) tool.
+Also included is a tidy.conf file which is required by the ebookmaker process.
+If you intend to run the Windows binary outside of Guiguts, you may need to
+refer to the troubleshooting section below to direct it to the tidy.conf file.
 
 ### Installing the python version manually
 
@@ -82,3 +85,10 @@ been installed.
 EBookMaker requires Python 3.6 or later. If you have earlier versions of
 Python installed via Homebrew, you may get errors unless you uninstall them
 first.
+
+Ebookmaker requires a [tidy.conf file](https://github.com/gutenbergtools/ebookmaker/blob/master/ebookmaker/parsers/tidy.conf)
+to operate correctly. The default location it looks for this is the same
+directory as the main ebookmaker script resides. If ebookmaker is unable
+to find this file in your configuration, you can use the `--config-dir=<dir>`
+command line argument to point to the directory where a copy of tidy.conf
+is located.

--- a/tools/ebookmaker/package.sh
+++ b/tools/ebookmaker/package.sh
@@ -11,7 +11,7 @@ mkdir $DEST
 cp README.md $DEST
 
 if [[ $OS == "win" ]]; then
-    VERSION=0.11.13
+    VERSION=0.11.26
     URL=https://github.com/DistributedProofreaders/ebm_builder/releases/download/v$VERSION/ebookmaker-$VERSION.zip
     curl -L -o ebookmaker.zip $URL
     unzip ebookmaker.zip -d $DEST


### PR DESCRIPTION
Ebookmaker 0.11.26 includes a command line option to indicate the location
of a tidy config file. In the config file, tidy is instructed to convert named
HTML entities to numeric. This is required for ebookmaker's conversion to
HTML5.
The config file is included in the ebm_builder release which package.sh grabs
during the release process, and is placed in the ebookmaker tools folder.

Fixes #856