### PR TITLE
Stop HTML convert loop for certain footnote configurations

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1153,8 +1153,9 @@ sub html_convert_footnoteblocks {
               $textwindow->search( '-exact', '--', '</div>', $endoflastfootnoteinblock );
             if ($endoflastfootnoteinblock) {
 
-                # Get 6 characters before </div> in case of blank line between </p> and </div>
-                my $pdiv = $textwindow->get( $endoflastfootnoteinblock . '-6c',
+                # Get 8 characters before </div> in case of blank lines between </p> and </div>
+                # Can be two blank lines if footnote ends in block markup
+                my $pdiv = $textwindow->get( $endoflastfootnoteinblock . '-8c',
                     $endoflastfootnoteinblock . '+6c' );
 
                 # If find </p> followed by </div> assume it's the end of this last footnote.


### PR DESCRIPTION
In #483, a more flexible search was added to find the end of a footnote even
if there was a blank line before the end. Unfortunately, it is possible to get
2 blank lines, e.g. footnote ending with `*/` markup. The search therefore needs
to be extended slightly. 7 characters would probably be OK, 8 to be safe :)

Fixes #859