### PR TITLE
Update ebookmaker to v0.11.28

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2299,11 +2299,12 @@ sub ebookmaker {
     $outputdir =~ s/[\/\\]$//;                          # Remove trailing slash from output dir to avoid confusing ebookmaker
     my $configdir = ::dirname($::ebookmakercommand);    # Ebookmaker dir contains tidy.conf file
     $runner->run(
-        $::ebookmakercommand,      "--verbose",
-        "--max-depth=3",           $makeoption,
-        $kindleoption,             "--output-dir=$outputdir",
-        "--config-dir=$configdir", "--title=$ttitle",
-        "--author=$tauthor",       "$filepath"
+        $::ebookmakercommand,   "--verbose",
+        "--max-depth=3",        $makeoption,
+        $kindleoption,          "--output-dir=$outputdir",
+        "--output-file=$fname", "--config-dir=$configdir",
+        "--title=$ttitle",      "--author=$tauthor",
+        "$filepath"
     );
 
     # Check for errors or warnings in ebookmaker output

--- a/tools/ebookmaker/package.sh
+++ b/tools/ebookmaker/package.sh
@@ -11,7 +11,7 @@ mkdir $DEST
 cp README.md $DEST
 
 if [[ $OS == "win" ]]; then
-    VERSION=0.11.26
+    VERSION=0.11.28
     URL=https://github.com/DistributedProofreaders/ebm_builder/releases/download/v$VERSION/ebookmaker-$VERSION.zip
     curl -L -o ebookmaker.zip $URL
     unzip ebookmaker.zip -d $DEST


### PR DESCRIPTION
Ebookmaker 0.11.28 includes a bug fix to make the output filename work
correctly. This is now used to set the base filenames for the epub, mobi and
HTML5 files, e.g. `myfile.htm` will generate `myfile-images-epub.epub`