### PR TITLE
Remove option to create HTML5 ebookmaker output

### DIFF
--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -788,7 +788,6 @@ sub menu_html {
         [
             'command', 'EB~ookMaker epub/mobi Generation', -command => sub { ::ebookmaker("epub"); }
         ],
-        [ 'command', 'EBookMa~ker HTML5 Generation', -command => sub { ::ebookmaker("html"); } ],
     ];
 }
 


### PR DESCRIPTION
Things have moved on since the HTML5 output feature was added by #823
PPers can now submit an HTML5 master file, so it is confusing to have
ebookmaker create HTML5 files, which incidentally should not be submitted.
So, remove the menu option, but leave the argument to the ebookmaker
routine, since it, or something like it could easily be needed again.