### PR TITLE
Fix minor test suite issues

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -310,7 +310,8 @@ sub _bin_save {
 
             # output page and offset
             print $fh " '$page' => {";
-            print $fh "'offset' => '$::pagenumbers{$page}{offset}', ";
+            print $fh "'offset' => '$::pagenumbers{$page}{offset}', "
+              if defined $::pagenumbers{$page}{offset};
 
             # if labels have been set up, output label information too
             print $fh "'label' => '" .  ( $::pagenumbers{$page}{label}  || "" ) . "', ";

--- a/tests/pphtmlbaseline.txt
+++ b/tests/pphtmlbaseline.txt
@@ -4,7 +4,7 @@ Beginning check: pphtml
 8:0 The Project Gutenberg eBook of The Streets Of Ascalon, by Robert W. Chambers.
 9:0 </title>
 15:0 CSS possibly not used: unusedcss
-+h1: CSS possibly not defined
-+pagenum: CSS possibly not defined
+25:0 CSS possibly not defined: h1
+24:0 CSS possibly not defined: pagenum
 27:0 Unconverted illustration: <p>[Illustration: "She excused the witness and turned her back to the
 Check is complete: pphtml


### PR DESCRIPTION
1. PPhtml output has changed slightly to give the line number of the error
2. In one test, avoid an error message due to page offsets being undefined
(doesn't seem to happen in real-life usage)