### PR TITLE
Make rewrap code recognise thought breaks at end-of-page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@
 - Caret is now spelled correctly in bookloupe checks
 - Certain footnote layouts could cause HTML generation to loop forever
 - Custom Commands dialog added blank commands when cancelled
-- Occasional `uninitialised variable` errors fixed
+- Occasional `uninitialised variable` errors were output by Custom Commands
+- Thought breaks at end of page could get rewrapped
 
 
 ## Version 1.3.2

--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -262,8 +262,8 @@ sub selectrewrap {
         if ( $selection =~ /^$TEMPPAGEMARK*\/[fF]/ ) {
             $inblock = 1;
         }
-        $textwindow->markSet( 'rewrapend', $thisblockend );             #Set a mark at the end of the text so it can be found after rewrap
-        unless ( $selection =~ /^$TEMPPAGEMARK*\s*?(\*\s*){4}\*/ ) {    #skip rewrap if paragraph is a thought break
+        $textwindow->markSet( 'rewrapend', $thisblockend );                             # Set a mark at the end of the text so it can be found after rewrap
+        unless ( $selection =~ /^[$TEMPPAGEMARK\s]*?(\*[$TEMPPAGEMARK\s]*){4}\*/ ) {    # skip rewrap if paragraph is a thought break
             if ($inblock) {
                 if ($enableindent) {
                     $indentblockend = $textwindow->search( '-regex', '--',


### PR DESCRIPTION
The character used to temporarily flag page markers during rewrapping
meant thought breaks were not always recognised, so get rewrapped in error.

Fixes #868