### PR TITLE
Generate HTML5 files

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -197,7 +197,6 @@ our $utfcharentrybase      = 'dec';           # 'dec' or 'hex' allowed
 our $utffontname           = 'Courier New';
 our $utffontsize           = 14;
 our $utffontweight         = 'normal';
-our $utf8save              = 1;               # True = always save utf8, false = only if unicode characters in file
 our $verboseerrorchecks    = 0;
 our $vislnnm               = 0;
 our $wfstayontop           = 0;

--- a/src/headerdefault.txt
+++ b/src/headerdefault.txt
@@ -1,12 +1,13 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="BOOKLANG" lang="BOOKLANG">
-  <head>
-    <meta http-equiv="Content-Type" content="text/html;charset=BOOKCHARSET" />
-    <meta http-equiv="Content-Style-Type" content="text/css" />
+<head>
+    <meta charset="UTF-8" />
     <title>
-      TITLE, by AUTHOR&mdash;A Project Gutenberg eBook
+      TITLE, by AUTHOR—A Project Gutenberg eBook
     </title>
+    <link rel="icon" href="images/cover.jpg" type="image/x-cover" />
+    <style> /* <![CDATA[ */
+ 
     <link rel="coverpage" href="images/cover.jpg" />
     <style type="text/css">
 
@@ -245,6 +246,6 @@ img.w100 {width: 100%;}
      margin-bottom:5em;
      font-family:sans-serif, serif; }
 
-    </style>
-  </head>
+    /* ]]> */ </style>
+</head>
 <body>

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -188,7 +188,6 @@ sub errorcheckpop_up {
             $textwindow->markUnset($_);
         }
     }
-    my $unicode = ::currentfileisunicode();
     ::working($errorchecktype);
 
     my $errname;
@@ -242,7 +241,7 @@ sub errorcheckpop_up {
 
     # Read and process one line at a time
     while ( $line = <$fh> ) {
-        utf8::decode($line) if $unicode;
+        utf8::decode($line);
 
         # Remove leading space and end-of-line characters
         $line =~ s/^\s//g;
@@ -494,17 +493,12 @@ sub errorcheckrun {    # Runs error checks
     ::savesettings();
     $top->Busy( -recurse => 1 );
 
-    my $unicode = ::currentfileisunicode();
     savetoerrortmpfile($tmpfname);
     if ( $errorchecktype eq 'HTML Tidy' ) {
-        if ($unicode) {
-            ::run( $::tidycommand, "-f", $errname, "-e", "-utf8", $tmpfname );
-        } else {
-            ::run( $::tidycommand, "-f", $errname, "-e", $tmpfname );
-        }
+        ::run( $::tidycommand, "-f", $errname, "-e", "-utf8", $tmpfname );
     } elsif ( $errorchecktype eq 'W3C Validate' ) {
         my $validatepath = ::dirname($::validatecommand);
-        $ENV{SP_BCTF} = 'UTF-8' if $unicode;
+        $ENV{SP_BCTF} = 'UTF-8';
         ::run(
             $::validatecommand,
             "--directory=$validatepath",
@@ -547,7 +541,6 @@ sub savetoerrortmpfile {
     my $textwindow = $::textwindow;
     my $top        = $::top;
 
-    my $unicode = ::currentfileisunicode();
     open my $td, '>', $tmpfname or die "Could not open $tmpfname for writing. $!";
     my $count   = 0;
     my $index   = '1.0';
@@ -555,7 +548,7 @@ sub savetoerrortmpfile {
     while ( $textwindow->compare( $index, '<', 'end' ) ) {
         my $end     = $textwindow->index("$index  lineend +1c");
         my $gettext = $textwindow->get( $index, $end );
-        utf8::encode($gettext) if ($unicode);
+        utf8::encode($gettext);
         print $td $gettext;
         $index = $end;
     }

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -196,9 +196,8 @@ sub file_export_preptext {
         mkdir $directory or warn "Could not make directory $!\n" and return;
     }
     $top->Busy( -recurse => 1 );
-    my @marks   = $textwindow->markNames;
-    my @pages   = sort grep ( /^Pg\S+$/, @marks );
-    my $unicode = ::currentfileisunicode();
+    my @marks = $textwindow->markNames;
+    my @pages = sort grep ( /^Pg\S+$/, @marks );
     my ( $f, $globalfilename, $e ) =
       ::fileparse( $::lglobal{global_filename}, qr{\.[^\.]*$} );
     if ( $exporttype eq 'onefile' ) {
@@ -236,11 +235,7 @@ sub file_export_preptext {
         }
         $file =~ s/-*\s?File:\s?(\S+)\.(png|jpg)---[^\n]*\n//;
         $file =~ s/\n+$//;
-        if ($unicode) {
-
-            #$file = "\x{FEFF}" . $file;    # Add the BOM to beginning of file.
-            utf8::encode($file);
-        }
+        utf8::encode($file);
         if ( $exporttype eq 'onefile' ) {
             open my $fh, '>>', "$directory/prep.txt";
             print $fh $file;
@@ -923,7 +918,7 @@ EOM
             searchstickyoptions spellcheckwithenchant stayontop toolside
             trackoperations txt_conv_bold txt_conv_font txt_conv_gesperrt txt_conv_italic txt_conv_sc txt_conv_tb
             txtfontname txtfontsize txtfontweight txtfontsystemuse
-            twowordsinhyphencheck utf8save utfcharentrybase utffontname utffontsize utffontweight
+            twowordsinhyphencheck utfcharentrybase utffontname utffontsize utffontweight
             urlprojectpage urlprojectdiscussion
             verboseerrorchecks vislnnm wfstayontop/
         ) {
@@ -1056,9 +1051,8 @@ sub file_export_pagemarkup {
 
         # write the file with page markup
         open my $fh2, '>', "$name" or die "Could not write $name";
-        my $unicode      = ::currentfileisunicode();
         my $filecontents = $textwindow->get( '1.0', 'end -1c' );
-        utf8::encode($filecontents) if $unicode;
+        utf8::encode($filecontents);
         print $fh2 "##### Do not edit this line. File exported from guiguts #####\n";
         print $fh2 $filecontents;
 

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -78,195 +78,18 @@ sub html_convert_ampersands {
     return;
 }
 
-# double hyphens go to character entity ref. FIXME: Add option for real emdash.
+# double hyphens go to emdash.
 sub html_convert_emdashes {
     ::working("Converting Emdashes");
 
     # Avoid converting double hyphens in HTML comments <!--  -->
     # Probably not strictly necessary, since no HTML comments in the file at this time
     # Use negative lookbehind for "<!" and negative lookahead for ">"
-    ::named( '(?<!<!)--(?!>)', '&mdash;' );
+    ::named( '(?<!<!)--(?!>)', "\x{2014}" );
 
-    ::named( "\x{A0}", '&nbsp;' );
+    # Convert non-breaking space character to numeric entity, since character looks just like a regular space
+    ::named( "\x{A0}", '&#160;' );
     return;
-}
-
-# convert latin1 and utf charactes to HTML Character Entity Reference's.
-sub html_convert_latin1 {
-    ::working("Converting Latin-1 Characters...");
-    for ( 128 .. 255 ) {
-        ::named( chr($_), ::entity($_) );
-    }
-    return;
-}
-
-sub html_convert_codepage {
-    ::working("Converting Windows Codepage 1252\ncharacters to Unicode");
-    ::cp1252toUni();
-    return;
-}
-
-sub html_convert_utf {
-    my ( $textwindow, $leave_utf, $keep_latin1 ) = @_;
-    my $blockstart;
-    unless ($leave_utf) {
-        ::working("Converting UTF-8...");
-        while ( $blockstart =
-            $textwindow->search( '-regexp', '--', '[\x{100}-\x{65535}]', '1.0', 'end' ) ) {
-            my $xchar = ord( $textwindow->get($blockstart) );
-            $textwindow->ntdelete($blockstart);
-            $textwindow->ntinsert( $blockstart, "&#$xchar;" );
-        }
-    }
-    ::working("Converting Named\n and Numeric Characters");
-    ::named( ' >', ' &gt;' );    # see html_convert_ampersands -- probably no effect
-    ::named( '< ', '&lt; ' );
-    if ( !$keep_latin1 ) { html_convert_latin1(); }
-    return;
-}
-
-sub html_string_convert_utf {
-    my ( $string, $leave_utf, $keep_latin1 ) = @_;
-    return                                                         unless $string;
-    $string =~ s/([\x{100}-\x{65535}])/sprintf("&x%x;",ord($1))/eg unless $leave_utf;
-    $string = html_string_convert_latin1($string)                  unless $keep_latin1;
-    return $string;
-}
-
-sub html_string_convert_latin1 {
-    my $string     = shift;
-    my %markuphash = (
-        "\x80" => "&#8364;",
-        "\x81" => "&#129;",
-        "\x82" => "&#8218;",
-        "\x83" => "&#402;",
-        "\x84" => "&#8222;",
-        "\x85" => "&#8230;",
-        "\x86" => "&#8224;",
-        "\x87" => "&#8225;",
-        "\x88" => "&#710;",
-        "\x89" => "&#8240;",
-        "\x8a" => "&#352;",
-        "\x8b" => "&#8249;",
-        "\x8c" => "&#338;",
-        "\x8d" => "&#141;",
-        "\x8e" => "&#381;",
-        "\x8f" => "&#143;",
-        "\x90" => "&#144;",
-        "\x91" => "&#8216;",
-        "\x92" => "&#8217;",
-        "\x93" => "&#8220;",
-        "\x94" => "&#8221;",
-        "\x95" => "&#8226;",
-        "\x96" => "&#8211;",
-        "\x97" => "&#8212;",
-        "\x98" => "&#732;",
-        "\x99" => "&#8482;",
-        "\x9a" => "&#353;",
-        "\x9b" => "&#8250;",
-        "\x9c" => "&#339;",
-        "\x9d" => "&#157;",
-        "\x9e" => "&#382;",
-        "\x9f" => "&#376;",
-        "\xa0" => "&nbsp;",
-        "\xa1" => "&iexcl;",
-        "\xa2" => "&cent;",
-        "\xa3" => "&pound;",
-        "\xa4" => "&curren;",
-        "\xa5" => "&yen;",
-        "\xa6" => "&brvbar;",
-        "\xa7" => "&sect;",
-        "\xa8" => "&uml;",
-        "\xa9" => "&textcopy;",
-        "\xaa" => "&ordf;",
-        "\xab" => "&laquo;",
-        "\xac" => "&not;",
-        "\xad" => "&shy;",
-        "\xae" => "&reg;",
-        "\xaf" => "&macr;",
-        "\xb0" => "&deg;",
-        "\xb1" => "&plusmn;",
-        "\xb2" => "&sup2;",
-        "\xb3" => "&sup3;",
-        "\xb4" => "&acute;",
-        "\xb5" => "&micro;",
-        "\xb6" => "&para;",
-        "\xb7" => "&middot;",
-        "\xb8" => "&cedil;",
-        "\xb9" => "&sup1;",
-        "\xba" => "&ordm;",
-        "\xbb" => "&raquo;",
-        "\xbc" => "&frac14;",
-        "\xbd" => "&frac12;",
-        "\xbe" => "&frac34;",
-        "\xbf" => "&iquest;",
-        "\xc0" => "&Agrave;",
-        "\xc1" => "&Aacute;",
-        "\xc2" => "&Acirc;",
-        "\xc3" => "&Atilde;",
-        "\xc4" => "&Auml;",
-        "\xc5" => "&Aring;",
-        "\xc6" => "&AElig;",
-        "\xc7" => "&Ccedil;",
-        "\xc8" => "&Egrave;",
-        "\xc9" => "&Eacute;",
-        "\xca" => "&Ecirc;",
-        "\xcb" => "&Euml;",
-        "\xcc" => "&Igrave;",
-        "\xcd" => "&Iacute;",
-        "\xce" => "&Icirc;",
-        "\xcf" => "&Iuml;",
-        "\xd0" => "&ETH;",
-        "\xd1" => "&Ntilde;",
-        "\xd2" => "&Ograve;",
-        "\xd3" => "&Oacute;",
-        "\xd4" => "&Ocirc;",
-        "\xd5" => "&Otilde;",
-        "\xd6" => "&Ouml;",
-        "\xd7" => "&times;",
-        "\xd8" => "&Oslash;",
-        "\xd9" => "&Ugrave;",
-        "\xda" => "&Uacute;",
-        "\xdb" => "&Ucirc;",
-        "\xdc" => "&Uuml;",
-        "\xdd" => "&Yacute;",
-        "\xde" => "&THORN;",
-        "\xdf" => "&szlig;",
-        "\xe0" => "&agrave;",
-        "\xe1" => "&aacute;",
-        "\xe2" => "&acirc;",
-        "\xe3" => "&atilde;",
-        "\xe4" => "&auml;",
-        "\xe5" => "&aring;",
-        "\xe6" => "&aelig;",
-        "\xe7" => "&ccedil;",
-        "\xe8" => "&egrave;",
-        "\xe9" => "&eacute;",
-        "\xea" => "&ecirc;",
-        "\xeb" => "&euml;",
-        "\xec" => "&igrave;",
-        "\xed" => "&iacute;",
-        "\xee" => "&icirc;",
-        "\xef" => "&iuml;",
-        "\xf0" => "&eth;",
-        "\xf1" => "&ntilde;",
-        "\xf2" => "&ograve;",
-        "\xf3" => "&oacute;",
-        "\xf4" => "&ocirc;",
-        "\xf5" => "&otilde;",
-        "\xf6" => "&ouml;",
-        "\xf7" => "&divide;",
-        "\xf8" => "&oslash;",
-        "\xf9" => "&ugrave;",
-        "\xfa" => "&uacute;",
-        "\xfb" => "&ucirc;",
-        "\xfc" => "&uuml;",
-        "\xfd" => "&yacute;",
-        "\xfe" => "&thorn;",
-        "\xff" => "&yuml;",
-    );
-    $string =~ s/([\x80-\xff])/$markuphash{$1}/g;
-    return $string;
 }
 
 sub html_cleanup_markers {
@@ -900,7 +723,7 @@ sub html_convert_body {
             if ( $selection =~ /^(\s+)/ ) {
                 $indent = ( length($1) / 2 );    # left margin of 1em for every 2 spaces
                 $selection =~ s/^\s+//;
-                $selection =~ s/  /&nbsp; /g;    # attempt to maintain multiple spaces
+                $selection =~ s/  /&#160; /g;    # attempt to maintain multiple spaces
                 $textwindow->ntdelete( "$step.0", "$step.end" );
                 $textwindow->ntinsert( "$step.0", $selection );
 
@@ -1367,7 +1190,7 @@ sub html_convert_pageanchors {
               if $::lglobal{pageanch};
         }
     }
-    ::working();
+    ::working("");
     return;
 }
 
@@ -1392,7 +1215,7 @@ sub html_parse_header {
         unless ( -e 'header.txt' ) {
             ::copy( 'headerdefault.txt', 'header.txt' );
         }
-        open my $infile, '<', 'header.txt'
+        open my $infile, '<:encoding(utf8)', 'header.txt'
           or warn "Could not open header file. $!\n";
         while (<$infile>) {
             $_ =~ s/\cM\cJ|\cM|\cJ/\n/g;
@@ -1401,21 +1224,10 @@ sub html_parse_header {
         close $infile;
     }
 
-    $author =~ s/&/&amp;/g if $author;
-    unless ( $::lglobal{leave_utf} ) {
-        $title = html_string_convert_utf( $title, $::lglobal{leave_utf}, $::lglobal{keep_latin1} );
-        $author =
-          html_string_convert_utf( $author, $::lglobal{leave_utf}, $::lglobal{keep_latin1} );
-    }
+    $author     =~ s/&/&amp;/g       if $author;
     $headertext =~ s/TITLE/$title/   if $title;
     $headertext =~ s/AUTHOR/$author/ if $author;
     $headertext =~ s/BOOKLANG/$::booklang/g;
-    if ( $::lglobal{leave_utf} && ::currentfileisunicode() ) {
-        $headertext =~ s/BOOKCHARSET/utf-8/;
-    } else {
-        $headertext =~ s/BOOKCHARSET/iso-8859-1/;
-    }
-    eval( '$headertext =~ s#\{LANG=' . uc($::booklang) . '\}(.*?)\{/LANG\}#$1#gs' );    # code duplicated near footertext
 
     # locate and markup title
     $step = 0;
@@ -1513,7 +1325,7 @@ sub get_title_author {
 }
 
 sub html_wrapup {
-    my ( $textwindow, $headertext, $leave_utf, $autofraction ) = @_;
+    my ( $textwindow, $headertext, $autofraction ) = @_;
     my $thisblockstart;
     ::fracconv( $textwindow, '1.0', 'end' ) if $autofraction;
     $textwindow->ntinsert( '1.0', $headertext );
@@ -2094,7 +1906,6 @@ sub htmlautoconvert {
     ::_bin_save();
     $::lglobal{global_filename} = $savefn;
     $textwindow->FileName($savefn);
-    html_convert_codepage();
     html_convert_ampersands($textwindow);
     $headertext = html_parse_header( $textwindow, $headertext, $title, $author );
     html_convert_emdashes();
@@ -2116,8 +1927,7 @@ sub htmlautoconvert {
     html_convert_sidenotes($textwindow);
     html_convert_pageanchors();
     html_convert_chapterdivs($textwindow);    # after page anchors, so they can be included in div
-    html_convert_utf( $textwindow, $::lglobal{leave_utf}, $::lglobal{keep_latin1} );
-    html_wrapup( $textwindow, $headertext, $::lglobal{leave_utf}, $::lglobal{autofraction} );
+    html_wrapup( $textwindow, $headertext, $::lglobal{autofraction} );
     $textwindow->ResetUndo;
     ::setedited(1);
 }
@@ -2280,48 +2090,6 @@ sub htmlgenpopup {
             -sticky => 'w'
         );
 
-        # Leave utf8 characters rather than convert to numeric entities
-        $f0->Checkbutton(
-            -variable    => \$::lglobal{leave_utf},
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Keep UTF-8 Chars',
-            -anchor      => 'w',
-        )->grid(
-            -row    => 2,
-            -column => 1,
-            -padx   => 1,
-            -pady   => 2,
-            -sticky => 'w'
-        );
-
-        # Leave Latin-1 characters rather than convert to HTML entities
-        $f0->Checkbutton(
-            -variable    => \$::lglobal{keep_latin1},
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Keep Latin-1 Chars',
-            -anchor      => 'w',
-        )->grid(
-            -row    => 2,
-            -column => 2,
-            -padx   => 1,
-            -pady   => 2,
-            -sticky => 'w'
-        );
-
-        # Automatically convert 1/2, 1/4, 3/4 to named entities
-        $f0->Checkbutton(
-            -variable    => \$::lglobal{autofraction},
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Convert Fractions',
-            -anchor      => 'w',
-        )->grid(
-            -row    => 2,
-            -column => 3,
-            -padx   => 1,
-            -pady   => 2,
-            -sticky => 'w'
-        );
-
         # Use <div> with CSS class rather than HTML <blockquote> element
         $f0->Checkbutton(
             -variable    => \$::lglobal{cssblockmarkup},
@@ -2329,7 +2097,7 @@ sub htmlgenpopup {
             -text        => 'CSS blockquote',
             -anchor      => 'w',
         )->grid(
-            -row    => 3,
+            -row    => 2,
             -column => 1,
             -padx   => 1,
             -pady   => 2,
@@ -2343,8 +2111,22 @@ sub htmlgenpopup {
             -text        => 'Short FN Anchors',
             -anchor      => 'w',
         )->grid(
-            -row    => 3,
+            -row    => 2,
             -column => 2,
+            -padx   => 1,
+            -pady   => 2,
+            -sticky => 'w'
+        );
+
+        # Automatically convert 1/2, 1/4, 3/4 to entities
+        $f0->Checkbutton(
+            -variable    => \$::lglobal{autofraction},
+            -selectcolor => $::lglobal{checkcolor},
+            -text        => 'Convert Fractions',
+            -anchor      => 'w',
+        )->grid(
+            -row    => 2,
+            -column => 3,
             -padx   => 1,
             -pady   => 2,
             -sticky => 'w'
@@ -2861,15 +2643,15 @@ sub markup {
         ( $lsr, $lsc ) = split /\./, $thisblockstart;
         ( $ler, $lec ) = split /\./, $thisblockend;
         if ( $lsr eq $ler ) {
-            $textwindow->insert( 'insert', '&nbsp;' );
+            $textwindow->insert( 'insert', '&#160;' );
         } else {
             $step = $lsr;
             while ( $step <= $ler ) {
                 $selection = $textwindow->get( "$step.0", "$step.end" );
                 if ( $selection =~ /\s\s/ ) {
-                    $selection =~ s/^\s/&nbsp;/;
-                    $selection =~ s/  /&nbsp; /g;
-                    $selection =~ s/&nbsp; /&nbsp;&nbsp;/g;
+                    $selection =~ s/^\s/&#160;/;
+                    $selection =~ s/  /&#160; /g;
+                    $selection =~ s/&#160; /&#160;&#160;/g;
                     $textwindow->delete( "$step.0", "$step.end" );
                     $textwindow->insert( "$step.0", $selection );
                 }
@@ -3163,7 +2945,7 @@ sub clearmarkupinselection {
               if ( $selection =~ s/<span.*?margin-left: (\d+\.?\d?)em.*?>/' ' x ($1 *2)/e );
             $edited++ if ( $selection =~ s/<\/?span[^>]*?>//g );
             $edited++ if ( $selection =~ s/<\/?[hscalupt].*?>//g );
-            $edited++ if ( $selection =~ s/&nbsp;/ /g );
+            $edited++ if ( $selection =~ s/&#160;/ /g );
             $edited++ if ( $selection =~ s/<\/?blockquote>//g );
             $textwindow->delete( "$step.$lsc", "$step.$stepend" ) if $edited;
             $textwindow->insert( "$step.$lsc", $selection )       if $edited;
@@ -3200,14 +2982,14 @@ sub hyperlinkpagenums {
 sub makeanchor {
     my $linkname = shift;
     return unless $linkname;
-    $linkname =~ s/-/\x00/g;              # preserve hyphens
-    $linkname =~ s/_/\x01/g;              # preserve underscores
-    $linkname =~ s/&amp;|&mdash;/\xFF/;
+    $linkname =~ s/-/\x00/g;             # preserve hyphens
+    $linkname =~ s/_/\x01/g;             # preserve underscores
+    $linkname =~ s/&amp;/\xFF/;
     $linkname =~ s/<sup>.*?<\/sup>//g;
     $linkname =~ s/<\/?[^>]+>//g;
     $linkname =~ s/\p{Punct}//g;
-    $linkname =~ s/\x00/-/g;              # restore hyphens
-    $linkname =~ s/\x01/_/g;              # restore underscores
+    $linkname =~ s/\x00/-/g;             # restore hyphens
+    $linkname =~ s/\x01/_/g;             # restore underscores
     $linkname =~ s/\s+/_/g;
 
     while ( $linkname =~ m/([\x{100}-\x{ffef}])/ ) {
@@ -3412,7 +3194,7 @@ sub autotable {
 
     my @cformat = split( //, $format ) if ($format);
 
-    $selection = '<table class="autotable" summary="">' . "\n";
+    $selection = '<table class="autotable">' . "\n";
 
     # Each row is a <tr>
     for my $row ( 0 .. $#tbl ) {
@@ -3609,7 +3391,7 @@ sub poetryhtml {
                 last;
             }
         }
-        $selection =~ s/&nbsp;/ /g;
+        $selection =~ s/&#160;/ /g;
         $selection =~ s/^(\s+)//;
         my $indent = 0;
         $indent = length($1) if $1;
@@ -3708,36 +3490,9 @@ sub linkpopulate {
 }
 
 #
-# Convert ordinal to a named or number HTML entity
+# Convert ordinal to a number HTML entity
 sub entity {
-    my $ord      = shift;
-    my @entities = (
-        '&#8364;',  '&#129;',   '&#8218;',  '&#402;',   '&#8222;',  '&#8230;',
-        '&#8224;',  '&#8225;',  '&#710;',   '&#8240;',  '&#352;',   '&#8249;',
-        '&#338;',   '&#141;',   '&#381;',   '&#143;',   '&#144;',   '&#8216;',
-        '&#8217;',  '&#8220;',  '&#8221;',  '&#8226;',  '&#8211;',  '&#8212;',
-        '&#732;',   '&#8482;',  '&#353;',   '&#8250;',  '&#339;',   '&#157;',
-        '&#382;',   '&#376;',   '&nbsp;',   '&iexcl;',  '&cent;',   '&pound;',
-        '&curren;', '&yen;',    '&brvbar;', '&sect;',   '&uml;',    '&textcopy;',
-        '&ordf;',   '&laquo;',  '&not;',    '&shy;',    '&reg;',    '&macr;',
-        '&deg;',    '&plusmn;', '&sup2;',   '&sup3;',   '&acute;',  '&micro;',
-        '&para;',   '&middot;', '&cedil;',  '&sup1;',   '&ordm;',   '&raquo;',
-        '&frac14;', '&frac12;', '&frac34;', '&iquest;', '&Agrave;', '&Aacute;',
-        '&Acirc;',  '&Atilde;', '&Auml;',   '&Aring;',  '&AElig;',  '&Ccedil;',
-        '&Egrave;', '&Eacute;', '&Ecirc;',  '&Euml;',   '&Igrave;', '&Iacute;',
-        '&Icirc;',  '&Iuml;',   '&ETH;',    '&Ntilde;', '&Ograve;', '&Oacute;',
-        '&Ocirc;',  '&Otilde;', '&Ouml;',   '&times;',  '&Oslash;', '&Ugrave;',
-        '&Uacute;', '&Ucirc;',  '&Uuml;',   '&Yacute;', '&THORN;',  '&szlig;',
-        '&agrave;', '&aacute;', '&acirc;',  '&atilde;', '&auml;',   '&aring;',
-        '&aelig;',  '&ccedil;', '&egrave;', '&eacute;', '&ecirc;',  '&euml;',
-        '&igrave;', '&iacute;', '&icirc;',  '&iuml;',   '&eth;',    '&ntilde;',
-        '&ograve;', '&oacute;', '&ocirc;',  '&otilde;', '&ouml;',   '&divide;',
-        '&oslash;', '&ugrave;', '&uacute;', '&ucirc;',  '&uuml;',   '&yacute;',
-        '&thorn;',  '&yuml;',
-    );
-    return $entities[ $ord - 128 ] if $ord >= 128 and $ord <= 255;
-
-    # If we don't have an HTML name, return the number form
+    my $ord = shift;
     return '&#' . $ord . ';';
 }
 
@@ -3778,11 +3533,10 @@ sub fromnamed {
         $textwindow->addGlobStart;
         $textwindow->markSet( 'srchend', $end );
         my ( $thisblockstart, $length );
-        ::named( '&amp;',   '&',  $start, 'srchend' );
-        ::named( '&quot;',  '"',  $start, 'srchend' );
-        ::named( '&mdash;', '--', $start, 'srchend' );
-        ::named( ' &gt;',   ' >', $start, 'srchend' );
-        ::named( '&lt; ',   '< ', $start, 'srchend' );
+        ::named( '&amp;',  '&',  $start, 'srchend' );
+        ::named( '&quot;', '"',  $start, 'srchend' );
+        ::named( ' &gt;',  ' >', $start, 'srchend' );
+        ::named( '&lt; ',  '< ', $start, 'srchend' );
 
         for ( 160 .. 255 ) {
             ::named( ::entity($_), chr($_), $start, 'srchend' );
@@ -3805,6 +3559,7 @@ sub fromnamed {
     }
 }
 
+# Note that double hyphen is converted to numeric (not named) emdash
 sub tonamed {
     my ($textwindow) = @_;
     my @ranges       = $textwindow->tagRanges('sel');
@@ -3819,9 +3574,9 @@ sub tonamed {
         ::named( '&(?![\w#])',           '&amp;',   $start, 'srchend' );
         ::named( '&$',                   '&amp;',   $start, 'srchend' );
         ::named( '"',                    '&quot;',  $start, 'srchend' );
-        ::named( '(?<=[^-!])--(?=[^>])', '&mdash;', $start, 'srchend' );
-        ::named( '(?<=[^-])--$',         '&mdash;', $start, 'srchend' );
-        ::named( '^--(?=[^-])',          '&mdash;', $start, 'srchend' );
+        ::named( '(?<=[^-!])--(?=[^>])', '&#8212;', $start, 'srchend' );
+        ::named( '(?<=[^-])--$',         '&#8212;', $start, 'srchend' );
+        ::named( '^--(?=[^-])',          '&#8212;', $start, 'srchend' );
         ::named( '& ',                   '&amp; ',  $start, 'srchend' );
         ::named( '&c\.',                 '&amp;c.', $start, 'srchend' );
         ::named( ' >',                   ' &gt;',   $start, 'srchend' );
@@ -3845,9 +3600,9 @@ sub tonamed {
 sub fracconv {
     my ( $textwindow, $start, $end ) = @_;
     my %frachash = (
-        '\b1\/2\b' => '&frac12;',
-        '\b1\/4\b' => '&frac14;',
-        '\b3\/4\b' => '&frac34;',
+        '\b1\/2\b' => '&#189;',
+        '\b1\/4\b' => '&#188;',
+        '\b3\/4\b' => '&#190;',
     );
     my ( $ascii, $html, $length );
     my $thisblockstart = 1;

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -1117,12 +1117,6 @@ sub menu_preferences_processing {
         ],
         [ 'command', 'Set Rewrap ~Margins...', -command => \&::setmargins ],
         [
-            Checkbutton => "Always Treat as ~UTF-8",
-            -variable   => \$::utf8save,
-            -onvalue    => 1,
-            -offvalue   => 0,
-        ],
-        [
             Checkbutton => "CSS Validation Level 2.1",
             -variable   => \$::cssvalidationlevel,
             -onvalue    => 'css21',

--- a/src/lib/Guiguts/Tests.pm
+++ b/src/lib/Guiguts/Tests.pm
@@ -34,8 +34,6 @@ sub runtests {
         "deaccentdisplay('ÀÁÂÃÄÅàáâãäåÇçÈÉÊËèéêëÌÍÎÏìíîïÒÓÔÕÖØòóôõöøÑñÙÚÛÜùúûüİÿı')"
     );
 
-    ok( ( ::entity(255) eq '&yuml;' ), "entity(255) eq '&yuml;'" );
-
     ok( 1 == do { 1 }, "do block" );
 
     runtesterrorcheck( "Bookloupe",        "textcheck.txt",   "bookloupebaseline.txt" );

--- a/src/lib/Guiguts/TextUnicode.pm
+++ b/src/lib/Guiguts/TextUnicode.pm
@@ -73,20 +73,13 @@ sub SaveUTF {
     my $progress;
     my $fileend = $w->index('end -1c');
     my ($lines) = $fileend =~ /^(\d+)\./;
-    my $unicode = ::currentfileisunicode();
 
-    # No BOM please
-    #if ($unicode) {
-    #	my $bom = "\x{FEFF}";
-    #	utf8::encode($bom);
-    #	print $tempfh $bom;
-    #}
     while ( $w->compare( $index, '<', $fileend ) ) {
         my $end  = $w->index("$index lineend +1c");
         my $line = $w->get( $index, $end );
         $line =~ s/[\t \xA0]+$//;
         $line =~ s/\cM\cJ|\cM|\cJ/\cM\cJ/g if (OS_Win);
-        utf8::encode($line) if $unicode;
+        utf8::encode($line);
         $w->BackTrace("Cannot write to temp file:$!\n") and return
           unless print $tempfh $line;
         $index = $end;

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -16,7 +16,7 @@ BEGIN {
       &natural_sort_length &natural_sort_freq &drag &cut &paste &entrypaste &textcopy &colcut &colcopy &colpaste &showversion
       &checkforupdates &checkforupdatesmonthly &gotobookmark &setbookmark &seeindex &ebookmaker
       &sidenotes &poetrynumbers &get_page_number &externalpopup &add_entry_history &entry_history
-      &xtops &toolbar_toggle &killpopup &expandselection &currentfileisunicode
+      &xtops &toolbar_toggle &killpopup &expandselection
       &getprojectid &setprojectid &viewprojectcomments &viewprojectdiscussion &viewprojectpage
       &scrolldismiss &updatedrecently &hidelinenumbers &restorelinenumbers &displaylinenumbers
       &enable_interrupt &disable_interrupt &set_interrupt &query_interrupt &soundbell &busy &unbusy
@@ -1002,10 +1002,8 @@ sub initialize {
     $::lglobal{htmlimagesizey}     = 0;                           # HTML pixel height of file loaded in image dialog
     $::lglobal{isedited}           = 0;
     $::lglobal{wf_ignore_case}     = 0;
-    $::lglobal{keep_latin1}        = 1;                           # HTML convert - retain Latin1 characters
     $::lglobal{lastmatchindex}     = '1.0';
     $::lglobal{lastsearchterm}     = '';
-    $::lglobal{leave_utf}          = 1;                           # HTML convert - retain utf8 characters
     $::lglobal{longordlabel}       = 0;
     $::lglobal{ordmaxlength}       = 1;
     $::lglobal{pageanch}           = 1;                           # HTML convert - add page anchors
@@ -2247,12 +2245,12 @@ sub ebookmaker {
         my $tstring = $textwindow->get( $tbeg . '+7c', $tend );    # Get whole title/author string
         $tstring =~ s/\s+/ /g;                                     # Join into one line, single spaced
         if (
-            $tstring =~ s/The Project Gutenberg EBook of//i        # Strip PG part - 2 formats
-            or $tstring =~ s/&mdash;A Project Gutenberg eBook//i
+            $tstring =~ s/The Project Gutenberg EBook of//i              # Strip PG part - 2 formats
+            or $tstring =~ s/(--|\x{2014})A Project Gutenberg eBook//i
         ) {
-            HTML::Entities::decode_entities($tstring);             # HTML entities need converting to characters
-            $tstring = deaccentdisplay($tstring);                  # Remove accents since passing as argument in shell
-            $tstring =~ s/[^[:ascii:]]/_/g;                        # Substitute "_" for any remaining non-ASCII characters
+            HTML::Entities::decode_entities($tstring);                   # HTML entities need converting to characters
+            $tstring = deaccentdisplay($tstring);                        # Remove accents since passing as argument in shell
+            $tstring =~ s/[^[:ascii:]]/_/g;                              # Substitute "_" for any remaining non-ASCII characters
 
             # Split into title/author - use last "by" in case "by" is in the book title
             my $byidx = rindex( $tstring, ", by " );
@@ -2749,12 +2747,6 @@ sub columnizeselection {
     for ( my $i = $lsr ; $i <= $ler ; $i++ ) {
         $textwindow->tagAdd( 'sel', "$i.$lsc", "$i.$lec" );
     }
-}
-
-sub currentfileisunicode {
-    return 1 if $::utf8save;    # treat as unicode regardless of contents
-    my $textwindow = $::textwindow;
-    return $textwindow->search( '-regexp', '--', '[\x{100}-\x{FFFE}]', '1.0', 'end' );
 }
 
 #FIXME: doesnt work quite right if multiple volumes held in same directory

--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -390,7 +390,7 @@ sub wordfrequency {
                 if ( defined($name) and length($name) ) {
                     open( my $save, ">", "$name" );
                     my $list = join "\n", $::lglobal{wclistbox}->get( '0', 'end' );
-                    utf8::encode($list) if ::currentfileisunicode();
+                    utf8::encode($list);
                     print $save $list;
                 }
             }
@@ -405,15 +405,14 @@ sub wordfrequency {
                 );
 
                 if ( defined($name) and length($name) ) {
-                    my $unicode = ::currentfileisunicode();
-                    my $count   = $::lglobal{wclistbox}->index('end');
+                    my $count = $::lglobal{wclistbox}->index('end');
                     open( my $save, ">", "$name" );
                     for ( 1 .. $count ) {
                         my $word = $::lglobal{wclistbox}->get($_);
                         if ( ( defined $word ) && ( length $word ) ) {
                             $word =~ s/^\d+\s+//;
                             $word =~ s/\s+\*{4}\s*$//;
-                            utf8::encode($word) if $unicode;
+                            utf8::encode($word);
                             print $save $word, "\n";
                         }
                     }

--- a/src/lib/ppvchecks/pphtml.pl
+++ b/src/lib/ppvchecks/pphtml.pl
@@ -100,10 +100,6 @@ sub runProgram {
             if ( $line =~ /\[Illustration/ ) {
                 printf LOGFILE ( "%d:0 Unconverted illustration: %s\n", $count, $line );
             }
-            if ( $line =~ /<table/
-                and ( ( $line !~ /summary/ ) or ( $line =~ /summary=""/ ) ) ) {
-                printf LOGFILE ( "%d:0 Missing table summary: %s\n", $count, $line );
-            }
             if ( $line =~ /Blank Page/ ) {
                 printf LOGFILE ( "%d:0 Blank page\n", $count );
             }

--- a/tests/testhtml2baseline.html
+++ b/tests/testhtml2baseline.html
@@ -64,10 +64,10 @@ National Herbarium</i>.</p>
 </pre>
 
 <p class="center">For sale by the Superintendent of Documents, U.S. Government Printing Office
-Washington, D.C., 20402&mdash;Price $1.00 (Paper Cover)
+Washington, D.C., 20402—Price $1.00 (Paper Cover)
 </p>
 <p><span class="pagenum" id="Page_iv">[Pg iv]</span></p>
-<p>[Illustration: Frontispiece.&mdash;"Washington as a Surveyor." Engraving reproduced from
+<p>[Illustration: Frontispiece.—"Washington as a Surveyor." Engraving reproduced from
 Washington Irving's <i>Life of George Washington</i> (New York: 1857, vol. 1).]</p>
 <p><span class="pagenum" id="Page_v">[Pg v]</span></p>
 
@@ -221,8 +221,8 @@ the earlier periods of American scientific development, and of their
 tools. At the same time it is essential to have a history of the
 development and distribution and use of scientific instruments by
 others than the practitioners and teachers. The role of the instrument
-maker in the American Colonies was an important one&mdash;as
-it was in each epoch of the history of science in Europe&mdash;and it
+maker in the American Colonies was an important one—as
+it was in each epoch of the history of science in Europe—and it
 deserves to be reported.</p>
 
 <p>To make a comprehensive study of American scientific instruments
@@ -275,7 +275,7 @@ INSTRUMENTS</p>
 <p>Philosophical and Practical Instruments</p>
 
 <p>Development of the sciences in the American Colonies was
-critically dependent upon the available tools&mdash;scientific instruments&mdash;and
+critically dependent upon the available tools—scientific instruments—and
 the men who made and used them. These tools may
 be separated into two groups. The first group consists of philosophical
 instruments and scientific teaching apparatus produced
@@ -356,7 +356,7 @@ can be recovered, it may then be possible to establish whether he
 worked in the Colonies as a mathematical practitioner in the 17th
 century. His name is included on a tentative basis.</p>
 
-<p>[Illustration: Figure 1.&mdash;Dialing rule made of brass and inscribed with the name "Arthur
+<p>[Illustration: Figure 1.—Dialing rule made of brass and inscribed with the name "Arthur
 Willis" and the date "1674." Allegedly used by Nathaniel Footes, surveyor of
 Springfield, Massachusetts. Photo courtesy Newton C. Brainard, Hartford,
 Connecticut, and the Connecticut Historical Society.]</p>
@@ -507,7 +507,7 @@ not likely that the one or two isolated practitioners that had been
 trained in England could have taught so many others who worked
 in the same epoch.</p>
 
-<p>[Illustration: Figure 2.&mdash;Title page of <i>The Surveyor</i> by Aaron Rathborne, published in London
+<p>[Illustration: Figure 2.—Title page of <i>The Surveyor</i> by Aaron Rathborne, published in London
 in 1616. The book was one of the sources of information for American makers
 of mathematical instruments.]</p>
 
@@ -553,12 +553,12 @@ instruments made by four separate members of the Chandlee
 family, whose clockmaking traditions began early in the 17th century
 (see p. 54).</p>
 
-<p>[Illustration: Figure 3.&mdash;Transit telescope made by David Rittenhouse and used by him for
+<p>[Illustration: Figure 3.—Transit telescope made by David Rittenhouse and used by him for
 the observation of the transit of Venus in 1769. Brass, 33-1/2-in. tube on a 25-in.
 axis, with an aperture of 1-3/4 in. and a focal length of 32 in. Photo courtesy
 the American Philosophical Society.]</p>
 <p><span class="pagenum" id="Page_12">[Pg 12]</span></p>
-<p>[Illustration: Figure 4.&mdash;Surveying compass marked "Potts and Rittenhouse." Believed to be
+<p>[Illustration: Figure 4.—Surveying compass marked "Potts and Rittenhouse." Believed to be
 the work of David Rittenhouse in partnership with Thomas Potts. Photo
 courtesy the American Philosophical Society.]</p>
 <p><span class="pagenum" id="Page_13">[Pg 13]</span></p>
@@ -594,7 +594,7 @@ which would ordinarily be deliberately discarded or destroyed, or
 melted down for the recovery of the metal, this small percentage
 of survival presents a puzzle which has not been resolved.</p>
 <p><span class="pagenum" id="Page_14">[Pg 14]</span></p>
-<p>[Illustration: Figure 5.&mdash;David Rittenhouse. Engraving from portrait by Charles Wilson Peale.]</p>
+<p>[Illustration: Figure 5.—David Rittenhouse. Engraving from portrait by Charles Wilson Peale.]</p>
 
 <hr class="chap x-ebookmaker-drop" />
 
@@ -615,8 +615,8 @@ Six years later, in 1769, he successfully calculated the
 transit of Venus and later observed that planet with astronomical
 instruments he had constructed himself. In the following year,
 1770, he built the first American astronomical observatory, in
-Philadelphia. Two orreries that he designed and built&mdash;at the
-University of Pennsylvania and at Princeton University&mdash;survive
+Philadelphia. Two orreries that he designed and built—at the
+University of Pennsylvania and at Princeton University—survive
 as outstanding examples of American craftsmanship.<a id="FNanchor_8" href="#Footnote_8" class="fnanchor">[8]</a> Several of
 his surveying and astronomical instruments are exhibited in the
 collections of the U.S. National Museum. David Rittenhouse
@@ -643,25 +643,25 @@ Mr. David Rittenhouse, in Philadelphia, or at the subscriber's house in
 Worcester township, Montgomery county. Benjamin Rittenhouse.</p>
 </div>
 
-<p>[Illustration: Figure 6.&mdash;Astronomical clock made by David Rittenhouse
+<p>[Illustration: Figure 6.—Astronomical clock made by David Rittenhouse
 <span class="pagenum" id="Page_16">[Pg 16]</span>for his observatory at Norristown, Pa., and used by him for the
 observation of the transit of Venus in 1769. Unembellished
 pine case 83-1/2 in. high, 13-1/4 in. wide at the waist with a
 silvered brass dial 10-5/8 in. diameter. Photo courtesy the
 American Philosophical Society.]</p>
 
-<p>[Illustration: Figure 7.&mdash;Orrery built by David Rittenhouse for the University
+<p>[Illustration: Figure 7.—Orrery built by David Rittenhouse for the University
 of Pennsylvania. The center section shows the
 motions of the planets and their satellites and the right-hand
 section the eclipses of the Sun and Moon. The case,
 considered to be an outstanding example of colonial cabinet-work,
 was made by John Folwell.]</p>
 
-<p>[Illustration: Figure 8.&mdash;Brass surveying compass inscribed "Made by
+<p>[Illustration: Figure 8.—Brass surveying compass inscribed "Made by
 Benjamin Rittenhouse, 1787." Photo courtesy Ohio State
 Museum, Columbus, Ohio.]</p>
 <p><span class="pagenum" id="Page_18">[Pg 18]</span></p>
-<p>[Illustration: Figure 9.&mdash;Portrait of Andrew Ellicott (1754-1820) by unknown artist.]</p>
+<p>[Illustration: Figure 9.—Portrait of Andrew Ellicott (1754-1820) by unknown artist.]</p>
 <p><span class="pagenum" id="Page_19">[Pg 19]</span></p>
 
 <p>Andrew Ellicott</p>
@@ -715,11 +715,11 @@ in 1817 when the Government required his services as astronomer<span class="page
 to locate a portion of the United States-Canadian boundary in
 accordance with the fifth article of the Treaty of Ghent.</p>
 
-<p>[Illustration: Figure 10.&mdash;Transit and equal-altitude instrument (left) made by Ellicott in 1789
+<p>[Illustration: Figure 10.—Transit and equal-altitude instrument (left) made by Ellicott in 1789
 and used by him in the survey of the boundary between the United States and
 Florida and in other surveys. USNM 152080.]</p>
 
-<p>[Illustration: Figure 11.&mdash;Zenith sector with focal length of 6 ft., made by David Rittenhouse
+<p>[Illustration: Figure 11.—Zenith sector with focal length of 6 ft., made by David Rittenhouse
 and revised by Andrew Ellicott. Described in <i>Journal of Andrew Ellicott</i>
 (Philadelphia, 1803). USNM 152078.]</p>
 
@@ -825,7 +825,7 @@ annually until 1802. When he died in 1806 he was eulogized before
 the French Academy by the Marquis de Condorcet, and William
 Pitt placed his name in the records of the English Parliament.<a id="FNanchor_11" href="#Footnote_11" class="fnanchor">[11]</a></p>
 
-<p>[Illustration: Figure 12.&mdash;Letter from Benjamin Banneker to George Ellicott dated October
+<p>[Illustration: Figure 12.—Letter from Benjamin Banneker to George Ellicott dated October
 13, 1789, regarding astronomical data for the compilation of Banneker's
 almanac. Photo courtesy Maryland Historical Society.]</p>
 
@@ -871,7 +871,7 @@ Amherst, and Williams. Among other accomplishments, he
 effected "improvements" on the lucernal microscope and the air
 pump.<a id="FNanchor_13" href="#Footnote_13" class="fnanchor">[13]</a></p>
 
-<p>[Illustration: Figure 13.&mdash;Title page of one of Banneker's almanacs. The portrait of Banneker
+<p>[Illustration: Figure 13.—Title page of one of Banneker's almanacs. The portrait of Banneker
 was made by Timothy Woods in 1793 for the publisher and reproduced by
 woodcut. Banneker's first almanac was published in Philadelphia in 1792.]</p>
 
@@ -883,7 +883,7 @@ woodcut. Banneker's first almanac was published in Philadelphia in 1792.]</p>
 and telescope maker of Southwick, Massachusetts, Holcomb
 became a surveyor in 1808. An autobiographical sketch noted
 that "he manufactured about this time a good many sets of surveyors
-instruments&mdash;compasses, chains, scales, protractors and dividers,
+instruments—compasses, chains, scales, protractors and dividers,
 some for his pupils and some for others."<a id="FNanchor_14" href="#Footnote_14" class="fnanchor">[14]</a></p>
 
 

--- a/tests/testhtml3baseline.html
+++ b/tests/testhtml3baseline.html
@@ -165,88 +165,88 @@ Richard Quarren, Esq<sup>r.</sup>{e.}</i></p>
 <span style="margin-left: 24em;">PAGES</span><br />
 <br />
 <span style="margin-left: 1em;">"She excused the witness and turned her back</span><br />
-<span style="margin-left: 1em;">to the looking-glass"&nbsp; &nbsp; &nbsp; <i>Frontispiece</i></span><br />
+<span style="margin-left: 1em;">to the looking-glass"&#160; &#160; &#160; <i>Frontispiece</i></span><br />
 <br />
 <span style="margin-left: 1em;">"Westguard, colossal in his armour, gazed</span><br />
-<span style="margin-left: 1em;">gloomily around at the gorgeous spectacle"&nbsp; &nbsp; &nbsp; 24-25</span><br />
+<span style="margin-left: 1em;">gloomily around at the gorgeous spectacle"&#160; &#160; &#160; 24-25</span><br />
 <br />
 <span style="margin-left: 1em;">"Jingling, fluttering, gems clashing musically,</span><br />
 <span style="margin-left: 1em;">the Byzantine dancer, besieged by adorers,</span><br />
-<span style="margin-left: 1em;">deftly evaded their pressing gallantries"&nbsp; &nbsp; &nbsp; 30-31</span><br />
+<span style="margin-left: 1em;">deftly evaded their pressing gallantries"&#160; &#160; &#160; 30-31</span><br />
 <br />
 <span style="margin-left: 1em;">"'To our new friendship, Monsieur Harlequin!'</span><br />
-<span style="margin-left: 1em;">she said lightly"&nbsp; &nbsp; &nbsp; 52-53</span><br />
+<span style="margin-left: 1em;">she said lightly"&#160; &#160; &#160; 52-53</span><br />
 <br />
 <span style="margin-left: 1em;">"Strelsa, propped on her pillows, was still intent</span><br />
-<span style="margin-left: 1em;">on her newspapers"&nbsp; &nbsp; &nbsp; 60-61</span><br />
+<span style="margin-left: 1em;">on her newspapers"&#160; &#160; &#160; 60-61</span><br />
 <br />
 <span style="margin-left: 1em;">"'A perfect scandal, child. The suppers those</span><br />
-<span style="margin-left: 1em;">young men give there!'"&nbsp; &nbsp; &nbsp; 78-79</span><br />
+<span style="margin-left: 1em;">young men give there!'"&#160; &#160; &#160; 78-79</span><br />
 <br />
-<span style="margin-left: 1em;">"'Is&mdash;Mrs. Leeds&mdash;well?' he ventured at length,</span><br />
-<span style="margin-left: 1em;">reddening again"&nbsp; &nbsp; &nbsp; 86-87</span><br />
+<span style="margin-left: 1em;">"'Is—Mrs. Leeds—well?' he ventured at length,</span><br />
+<span style="margin-left: 1em;">reddening again"&#160; &#160; &#160; 86-87</span><br />
 <br />
 <span style="margin-left: 1em;">"'I write,' said Westguard, furious, 'because</span><br />
-<span style="margin-left: 1em;">I have a message to deliver&mdash;'"&nbsp; &nbsp; &nbsp; 98-99</span><br />
+<span style="margin-left: 1em;">I have a message to deliver—'"&#160; &#160; &#160; 98-99</span><br />
 <br />
 <span style="margin-left: 1em;">"'Never mind geography, child; tell me about</span><br />
-<span style="margin-left: 1em;">the men!'"&nbsp; &nbsp; &nbsp; 116-117</span><br />
+<span style="margin-left: 1em;">the men!'"&#160; &#160; &#160; 116-117</span><br />
 <span class="pagenum" id="Page_11">[Pg 11]</span><br />
 <span style="margin-left: 1em;">"Strelsa, curled up on a divan ... listened to</span><br />
-<span style="margin-left: 1em;">his departure with quiet satisfaction"&nbsp; &nbsp; &nbsp; 126-127</span><br />
+<span style="margin-left: 1em;">his departure with quiet satisfaction"&#160; &#160; &#160; 126-127</span><br />
 <br />
 <span style="margin-left: 1em;">"'Do you remember our first toast?' he asked,</span><br />
-<span style="margin-left: 1em;">smiling"&nbsp; &nbsp; &nbsp; 128-129</span><br />
+<span style="margin-left: 1em;">smiling"&#160; &#160; &#160; 128-129</span><br />
 <br />
 <span style="margin-left: 1em;">"Once more, according to the newspapers, her</span><br />
 <span style="margin-left: 1em;">engagement to Sir Charles was expected</span><br />
-<span style="margin-left: 1em;">to be announced"&nbsp; &nbsp; &nbsp; 172-173</span><br />
+<span style="margin-left: 1em;">to be announced"&#160; &#160; &#160; 172-173</span><br />
 <br />
 <span style="margin-left: 1em;">"All stacked up pell-mell in the back yard and</span><br />
-<span style="margin-left: 1em;">regarded in amazement by the neighbors"&nbsp; &nbsp; &nbsp; 178-179</span><br />
+<span style="margin-left: 1em;">regarded in amazement by the neighbors"&#160; &#160; &#160; 178-179</span><br />
 <br />
 <span style="margin-left: 1em;">"A fortnight later Strelsa wrote to Quarren for</span><br />
-<span style="margin-left: 1em;">the first time in nearly two months"&nbsp; &nbsp; &nbsp; 190-191</span><br />
+<span style="margin-left: 1em;">the first time in nearly two months"&#160; &#160; &#160; 190-191</span><br />
 <br />
-<span style="margin-left: 1em;">"'I say, Quarren&mdash;does this old lady hang next</span><br />
-<span style="margin-left: 1em;">to the battered party in black?'"&nbsp; &nbsp; &nbsp; 194-195</span><br />
+<span style="margin-left: 1em;">"'I say, Quarren—does this old lady hang next</span><br />
+<span style="margin-left: 1em;">to the battered party in black?'"&#160; &#160; &#160; 194-195</span><br />
 <br />
 <span style="margin-left: 1em;">"'I didn't tell Strelsa that you were coming,'</span><br />
-<span style="margin-left: 1em;">she whispered"&nbsp; &nbsp; &nbsp; 210-211</span><br />
+<span style="margin-left: 1em;">she whispered"&#160; &#160; &#160; 210-211</span><br />
 <br />
 <span style="margin-left: 1em;">"So he took the lake path and presently</span><br />
-<span style="margin-left: 1em;">rounded a sharp curve"&nbsp; &nbsp; &nbsp; 214-215</span><br />
+<span style="margin-left: 1em;">rounded a sharp curve"&#160; &#160; &#160; 214-215</span><br />
 <br />
-<span style="margin-left: 1em;">"'The old ones are the best,' she commented"&nbsp; &nbsp; &nbsp; 228-229</span><br />
+<span style="margin-left: 1em;">"'The old ones are the best,' she commented"&#160; &#160; &#160; 228-229</span><br />
 <br />
 <span style="margin-left: 1em;">"Strelsa in the library, pulling on her gloves,</span><br />
-<span style="margin-left: 1em;">was silent witness to a pantomime unmistakable"&nbsp; &nbsp; &nbsp; 246-247</span><br />
+<span style="margin-left: 1em;">was silent witness to a pantomime unmistakable"&#160; &#160; &#160; 246-247</span><br />
 <br />
 <span style="margin-left: 1em;">"A high and soulful tenor voice was singing</span><br />
-<span style="margin-left: 1em;">'Perfumes of Araby'"&nbsp; &nbsp; &nbsp; 272-273</span><br />
+<span style="margin-left: 1em;">'Perfumes of Araby'"&#160; &#160; &#160; 272-273</span><br />
 <br />
-<span style="margin-left: 1em;">"She came about noon&mdash;a pale young girl, very</span><br />
-<span style="margin-left: 1em;">slim in her limp black gown"&nbsp; &nbsp; &nbsp; 280-281</span><br />
+<span style="margin-left: 1em;">"She came about noon—a pale young girl, very</span><br />
+<span style="margin-left: 1em;">slim in her limp black gown"&#160; &#160; &#160; 280-281</span><br />
 <span class="pagenum" id="Page_12">[Pg 12]</span><br />
-<span style="margin-left: 1em;">Jessie Vining&nbsp; &nbsp; &nbsp; 290-291</span><br />
+<span style="margin-left: 1em;">Jessie Vining&#160; &#160; &#160; 290-291</span><br />
 <br />
 <span style="margin-left: 1em;">"'In the evenings sometimes Miss Vining remains</span><br />
 <span style="margin-left: 1em;">and dines with Dankmere and myself</span><br />
-<span style="margin-left: 1em;">at some near restaurant'"&nbsp; &nbsp; &nbsp; 302-303</span><br />
+<span style="margin-left: 1em;">at some near restaurant'"&#160; &#160; &#160; 302-303</span><br />
 <br />
-<span style="margin-left: 1em;">"'If you'll let me, I'll stand by you, darling'"&nbsp; &nbsp; &nbsp; 328-329</span><br />
+<span style="margin-left: 1em;">"'If you'll let me, I'll stand by you, darling'"&#160; &#160; &#160; 328-329</span><br />
 <br />
 <span style="margin-left: 1em;">"'Is it to be Sir Charles after all, darling?' she</span><br />
-<span style="margin-left: 1em;">asked caressingly"&nbsp; &nbsp; &nbsp; 346-347</span><br />
+<span style="margin-left: 1em;">asked caressingly"&#160; &#160; &#160; 346-347</span><br />
 <br />
-<span style="margin-left: 1em;">"'And it is to be your last breakfast'"&nbsp; &nbsp; &nbsp; 374-375</span><br />
+<span style="margin-left: 1em;">"'And it is to be your last breakfast'"&#160; &#160; &#160; 374-375</span><br />
 <br />
-<span style="margin-left: 1em;">Strelsa Leeds&nbsp; &nbsp; &nbsp; 380-381</span><br />
+<span style="margin-left: 1em;">Strelsa Leeds&#160; &#160; &#160; 380-381</span><br />
 <br />
-<span style="margin-left: 1em;">"'Let him loose, Quarren,' said Sprowl"&nbsp; &nbsp; &nbsp; 416-417</span><br />
+<span style="margin-left: 1em;">"'Let him loose, Quarren,' said Sprowl"&#160; &#160; &#160; 416-417</span><br />
 <br />
 <span style="margin-left: 1em;">"'I wanted to surprise you,' he explained</span><br />
-<span style="margin-left: 1em;">feebly"&nbsp; &nbsp; &nbsp; 424-425</span><br />
+<span style="margin-left: 1em;">feebly"&#160; &#160; &#160; 424-425</span><br />
 </p>
 
 <p><span class="pagenum" id="Page_13">[Pg 13]</span></p>
@@ -313,10 +313,10 @@ my instinct is to be friends with you?</p>
 <p>"It was from the very beginning.</p>
 
 <p>"And please don't be absurd enough to think that I am going to
-forget you&mdash;or our jolly escapade at the Wycherly ball. You behaved
+forget you—or our jolly escapade at the Wycherly ball. You behaved
 very handsomely once. I know I can count on your kindness to me.</p>
 
-<p>"Good-bye, and many many thanks&mdash;as Jack Lacy says&mdash;'f'r the manny
+<p>"Good-bye, and many many thanks—as Jack Lacy says—'f'r the manny
 booggy-rides, an' th' goom-candy, an' the boonches av malagy
 grrapes'!</p>
 </div>
@@ -333,7 +333,7 @@ grrapes'!</p>
 to Mrs. Sprowl's house. Their interview was rather brief but loudly
 cordial on the old lady's part:</p>
 
-<p>"How's my sister and Foxy?" she asked&mdash;meaning Sir Renard and Lady
+<p>"How's my sister and Foxy?" she asked—meaning Sir Renard and Lady
 Spinney.</p>
 
 <p>Sir Charles regretted he had not seen them.</p>
@@ -354,7 +354,7 @@ profane might consider more like a grin.</p>
 
 <p>"Was it four years ago when you saw her in Egypt?"</p>
 
-<p>"Four years&mdash;last month&mdash;the tenth."</p>
+<p>"Four years—last month—the tenth."</p>
 
 <p>"And never saw her again?"</p>
 
@@ -375,7 +375,7 @@ with the rest of 'em? Dawdle away your time?"</p>
 
 <p><span class="pagenum" id="Page_119">[Pg 119]</span></p>
 
-<p>[Illustration: "'Is&mdash;Mrs. Leeds&mdash;well?' he ventured at length, reddening
+<p>[Illustration: "'Is—Mrs. Leeds—well?' he ventured at length, reddening
 again."]</p>
 
 <p><span class="pagenum" id="Page_122">[Pg 122]</span></p>
@@ -391,8 +391,8 @@ She's at Palm Beach for the next three weeks."</p>
 <p>She looked up at him, her little opaque green eyes a trifle softened.</p>
 
 <p>"I am trying to get you the prettiest woman in America," she said. "I'm
-ready to fight off everybody else&mdash;beat 'em to death," she added, her
-eyes snapping, then suddenly kind again&mdash;"because, Sir Charles, I like
+ready to fight off everybody else—beat 'em to death," she added, her
+eyes snapping, then suddenly kind again—"because, Sir Charles, I like
 you. And for no other reason on earth!"</p>
 
 <p>Which was not the exact truth. It was for another man's sake she was
@@ -401,16 +401,16 @@ kind to him. And the other man had been dead many years.</p>
 <p>Sir Charles thanked her, awkwardly, and fell silent again, pulling his
 moustache.</p>
 
-<p>"Is&mdash;Mrs. Leeds&mdash;well?" he ventured, at length, reddening again.</p>
+<p>"Is—Mrs. Leeds—well?" he ventured, at length, reddening again.</p>
 
-<p>"Perfectly. She's a bit wiry just now&mdash;thin&mdash;leggy, y' know. Some
+<p>"Perfectly. She's a bit wiry just now—thin—leggy, y' know. Some
 fanciers prefer 'em weedy. But she'll plump up. I know the breed."</p>
 
 <p>He shrank from her loud voice and the vulgarity of her comments, and she
 was aware of it and didn't care a rap. There were plenty of noble ladies
-as vulgar as she, and more so&mdash;and anyway it was not this well-built,
+as vulgar as she, and more so—and anyway it was not this well-built,
 sober-faced man of forty-five whom she was serving with all the craft
-and insolence and brutality and generosity that was in her&mdash;it was the
+and insolence and brutality and generosity that was in her—it was the
 son of a dead man who had been much to her. How much nobody in these
 days gossiped about any longer, for it was a long time ago, a long, long
 time ago that she had made her curtsey to<span class="pagenum" id="Page_123">[Pg 123]</span> a young queen and a prince
@@ -429,7 +429,7 @@ no fear.... When do you go South?"</p>
 <p>"To-morrow," he said, so honestly that she grinned again.</p>
 
 <p>"Then I'll give you a letter to Molly Wycherly. Her husband is Jim
-Wycherly&mdash;one of your sort&mdash;eternally lumbering after something to kill.
+Wycherly—one of your sort—eternally lumbering after something to kill.
 He has a bungalow on some lagoon where he murders ducks, and no doubt
 he'll go there. But his wife will be stopping at Palm Beach. I'll send
 you a letter to her in the morning."</p>
@@ -454,21 +454,21 @@ the end of the third week Quarren wrote her.</p>
 <p>"Will you accept from me a copy of Karl's new book? And are you
 ever coming back? You are missing an unusually diverting winter;
 the opera is exceptional, there are some really interesting plays
-in town and several new and amusing people&mdash;Prince and Princess
+in town and several new and amusing people—Prince and Princess
 Sarnoff for example; and the Earl of Dankmere, an anxious, and
 perplexed little man, sadly hard up, and simple-minded enough to
 say so; which amuses everybody immensely.</p>
 
 <p>"He's pathetically original; plebeian on his mother's side; very
 good-natured; nothing at all of a sportsman; and painfully short of
-both intellect and cash&mdash;a funny, harmless, distracted little man
+both intellect and cash—a funny, harmless, distracted little man
 who runs about asking everybody the best and quickest methods of
 amassing a comfortable fortune in America. And I must say that
 people have jollied him rather cruelly.</p>
 
-<p>"The Sarnoffs on the other hand are modest and nice people&mdash;the
+<p>"The Sarnoffs on the other hand are modest and nice people—the
 Prince is a yellow, dried-up Asiatic who is making a collection of
-parasites&mdash;a shrewd, kindly, and clever little scientist. His wife
+parasites—a shrewd, kindly, and clever little scientist. His wife
 is a charming girl, intellectual but deliciously feminine. She was<span class="pagenum" id="Page_125">[Pg 125]</span>
 Cynthia Challis before her marriage, and always a most attractive
 and engaging personality. They dined with us at the Legation on
@@ -477,8 +477,8 @@ Thursday.</p>
 <p>"Afterward there was a dance at Mrs. Sprowl's. I led from one end,
 Lester Caldera from the other. One or two newspapers criticised the
 decorations and favours as vulgarly expensive; spoke of a 'monkey
-figure'&mdash;purely imaginary&mdash;which they said I introduced into the
-cotillion, and that the favours were marmosets!&mdash;who probably were
+figure'—purely imaginary—which they said I introduced into the
+cotillion, and that the favours were marmosets!—who probably were
 the intellectual peers of anybody present.</p>
 
 <p>"The old lady is in a terrific temper. I'm afraid some poor
@@ -503,7 +503,7 @@ washes her fat and gem-laden hands of him henceforth.</p>
 <p>"Poor Karl! He's already thirty-seven; he's written fifteen books,
 no one of which, he tells me, ever before<span class="pagenum" id="Page_126">[Pg 126]</span> stirred up anybody's
 interest. But this newest novel, 'The Real Thing,' has already gone
-into three editions in two weeks&mdash;whatever that actually means&mdash;and
+into three editions in two weeks—whatever that actually means—and
 still the re-orders are pouring in, and his publishers are madly
 booming it, and several indignant people are threatening Karl with
 the law of libel, and Karl is partly furious, partly amused, and
@@ -511,7 +511,7 @@ entirely astonished at the whole affair.</p>
 
 <p>"Because you see, the people who think they recognise portraits of
 themselves or their friends in several of the unattractive
-characters in the story&mdash;are as usual, in error. Karl's people are
+characters in the story—are as usual, in error. Karl's people are
 always purely and synthetically composite. Besides everybody who
 knows Karl Westguard ought to know that he's too decent a fellow,
 and too good a workman to use models stupidly. Anybody can copy;
@@ -533,7 +533,7 @@ entirely self-persuaded that the novelist has offered to them.</p>
 
 <p>"And these phases of 'The Real Thing' are fretting and mortifying
 Karl to the verge of distraction. He<span class="pagenum" id="Page_127">[Pg 127]</span> awakes to find himself not
-famous but notorious&mdash;not criticised for his workmanship, good or
+famous but notorious—not criticised for his workmanship, good or
 bad, but gabbled about because some ludicrous old Uncle Foozle
 pretends to discover a similarity between Karl's episodes and
 characters and certain doings of which Uncle F. is personally
@@ -549,8 +549,8 @@ for hidden meanings preoccupies the majority of mankind.</p>
 why I also should have presumed to write you a treatise in several
 volumes.</p>
 
-<p>"But I miss you, oddly enough&mdash;miss everything I never had of
-you&mdash;your opinions on what interests us both; the delightful
+<p>"But I miss you, oddly enough—miss everything I never had of
+you—your opinions on what interests us both; the delightful
 discussions of things important, which have never taken place
 between us. It's odd, isn't it, Mrs. Leeds, that I miss, long for,
 and even remember so much that has never been?</p>
@@ -589,13 +589,13 @@ are not invariably all of these things at the same time.</p>
 <p>"<span class="smcap">My dear Mr. Quarren</span>:</p>
 
 <p>"Your letter interested me, but there was all through it an
-undertone of cynicism which rang false&mdash;almost a dissonance to an
+undertone of cynicism which rang false—almost a dissonance to an
 ear which has heard you strike a truer chord.</p>
 
 <p>"I do not like what you say of yourself, or of your life. I have
 talked very seriously with Molly, who adores you; and she evidently
 thinks you capable of achieving anything you care to undertake.
-Which is my own opinion&mdash;based on twenty-four hours of
+Which is my own opinion—based on twenty-four hours of
 acquaintance.</p>
 
 <p>"I have read Mr. Westguard's novel. Everybody here is reading it.
@@ -603,12 +603,12 @@ I'd like to talk to you about it, some day. Mr. Westguard's intense
 bitterness confuses me a little, and seems almost to paralyse any
 critical judgment I may possess. A crusade in fiction has always
 seemed to me but a sterile effort. To do a thing is fine;<span class="pagenum" id="Page_129">[Pg 129]</span> to talk
-about it in fiction a far less admirable performance&mdash;like the
+about it in fiction a far less admirable performance—like the
 small boy, safe in the window, who defies his enemy with out-thrust
 tongue.</p>
 
-<p>"When I was young&mdash;a somewhat lonely child, with only a very few
-books to companion me&mdash;I pored over Carlyle's 'French Revolution,'
+<p>"When I was young—a somewhat lonely child, with only a very few
+books to companion me—I pored over Carlyle's 'French Revolution,'
 and hated Philip Egalité. But that youthful hatred was a little
 modified because Egalité did actually become personally active. If
 he had only talked, my hatred would have become contempt for a
@@ -620,7 +620,7 @@ he also acted.</p>
 sanguinary French iconoclast. Mr. Westguard, also, has the courage
 of his convictions; he lives, I understand, the life which he
 considers a proper one. It is the life which he preaches in 'The
-Real Thing'&mdash;a somewhat solemn, self-respecting, self-supporting
+Real Thing'—a somewhat solemn, self-respecting, self-supporting
 existence, devoted to self-development; a life of upright thinking,
 and the fulfilment of duty, civil and religious, incident to
 dignified citizenship. Such a life may be a blameless one; I don't
@@ -667,14 +667,14 @@ time you write to me. You seek my society mentally. Do you really
 believe that my mind is so easily satisfied with intellectual
 rubbish, or that I am flattered by letters from a nobody?</p>
 
-<p>"What do you suppose there is attractive about you, Mr. Quarren&mdash;if
+<p>"What do you suppose there is attractive about you, Mr. Quarren—if
 you really do amount to as little as you pretend? I've seen
 handsomer men, monsieur,<span class="pagenum" id="Page_131">[Pg 131]</span> wealthier men, more intelligent men; men
 more experienced, men of far greater talents and attainments.</p>
 
 <p>"Why do you suppose that I sit here in the Southern sunshine
 writing to you when there are dozens of men perfectly ready to
-amuse me?&mdash;and qualified to do it, too!</p>
+amuse me?—and qualified to do it, too!</p>
 
 <p>"For the sake of your <i>beaux-yeux</i>? <i>Non pas!</i></p>
 
@@ -723,7 +723,7 @@ with him.</p>
 
 <p>"He is middle-aged, and, I imagine, very wise. Perhaps his
 reticence makes me think so. He and Mr. Wycherly shoot ducks on the
-lagoon&mdash;and politics into each other.</p>
+lagoon—and politics into each other.</p>
 
 <p>"I must go. You are not here to persuade me to stay and talk
 nonsense to you against my better judgment. You're quite helpless,
@@ -783,7 +783,7 @@ faïence pipe which he always did when angry, and which had become known
 as "The Weather-breeder."</p>
 
 <p>[Illustration: "'I write,' said Westguard, furious, 'because I have a
-message to deliv&mdash;'"]</p>
+message to deliv—'"]</p>
 
 <p>"Jetzt geht das Wetter los!" quoted Quarren, dropping into a seat by the
 fire. "Where is this particular area of low depression centred, Karl?"</p>
@@ -793,7 +793,7 @@ certain the thing is selling on that account! I tell you it's
 humiliating. I've done my best as honestly as I know how, and not one
 critic even mentions the philosophy of the thing; all they notice is the
 mere story and the supposed resemblance between my characters and living
-people! I'm cursed if I ever&mdash;&mdash;"</p>
+people! I'm cursed if I ever——"</p>
 
 <p>"Oh, shut up!" said Quarren tranquilly. "If you're a novelist you write
 to amuse people, and you ought to be thankful that you've succeeded."</p>
@@ -801,14 +801,14 @@ to amuse people, and you ought to be thankful that you've succeeded."</p>
 <p>"Confound it!" roared Westguard, "I write to <i>instruct</i> people! not to
 keep 'em from yawning!"</p>
 
-<p>"Then you've made a jolly fluke of it, that's all&mdash;because you have
-accidentally written a corking good story&mdash;good enough and interesting
+<p>"Then you've made a jolly fluke of it, that's all—because you have
+accidentally written a corking good story—good enough and interesting
 enough to make people stand for the cold chunks of philosophical
-admonition with which you've spread your sandwich&mdash;thinly, Heaven be
+admonition with which you've spread your sandwich—thinly, Heaven be
 praised!"</p>
 
 <p>"I write," said Westguard, furious, "because I've a message to
-deliv&mdash;&mdash;"</p>
+deliv——"</p>
 
 <p>"Help!" moaned Quarren. "You write because it's in you to do it; because
 you've nothing more interesting to do; and because it enables you to
@@ -824,11 +824,11 @@ believed you had a message to deliver. You've written some fifteen
 novels, and fifteen times you have smothered your story with your
 message. This time, by accident, the story got its second breath, and
 romped home, with 'Message' a bad second, and that selling plater,
-'Philosophy,' left at the post&mdash;&mdash;"</p>
+'Philosophy,' left at the post——"</p>
 
-<p>"Go on!&mdash;you irreverent tout!" growled Westguard; "I want my novels
+<p>"Go on!—you irreverent tout!" growled Westguard; "I want my novels
 read, of course. Any author does. But I wish to Heaven somebody would
-try to interpret the important lessons which I&mdash;&mdash;"</p>
+try to interpret the important lessons which I——"</p>
 
 <p>"Oh, preciousness and splash! Tell your story as well as you can, and if
 it's well done there'll be latent lessons enough in it."</p>
@@ -836,13 +836,13 @@ it's well done there'll be latent lessons enough in it."</p>
 <p>"Are you perhaps instructing me in my own profession?" asked the other,
 smiling.</p>
 
-<p>"Heaven knows I'm not venturing&mdash;&mdash;"</p>
+<p>"Heaven knows I'm not venturing——"</p>
 
-<p>"Heaven knows you <i>are</i>! Also there is something In what you say&mdash;" He
-sat smoking, thoughtfully, eyes narrowing in the fire&mdash;"if I only
-<i>could</i> manage that!&mdash;to arrest the public's attention by the rather
+<p>"Heaven knows you <i>are</i>! Also there is something In what you say—" He
+sat smoking, thoughtfully, eyes narrowing in the fire—"if I only
+<i>could</i> manage that!—to arrest the public's attention by the rather
 cheap medium of the story, and then, cleverly, shoot a few moral pills
-into 'em.... That's one way, of course&mdash;&mdash;"</p>
+into 'em.... That's one way, of course——"</p>
 
 <p>"Like the drums of the Salvation Army."</p>
 
@@ -871,9 +871,9 @@ from the immemorial but immobile battlements of righteousness. Truth
 <i>is</i> a citadel, old fellow; but its garrison should be raiders, not
 defenders. And they should ride far afield to carry its message. For few
 journey to that far citadel; you must go to them. And does it make any
-difference what vehicle you employ in the cause of Truth&mdash;so that the
+difference what vehicle you employ in the cause of Truth—so that the
 message arrives somewhere before your vehicle breaks down of its own
-heaviness? Novel or poem, sermon or holy writ&mdash;it's all one, Karl, so
+heaviness? Novel or poem, sermon or holy writ—it's all one, Karl, so
 that they get there with their burden."</p>
 
 <p>Westguard sat silent a moment, then thumped the table, emphatically.</p>
@@ -882,13 +882,13 @@ that they get there with their burden."</p>
 
 <p>"Rot!"</p>
 
-<p>"As you please. You use your ability rottenly&mdash;that's true enough."</p>
+<p>"As you please. You use your ability rottenly—that's true enough."</p>
 
 <p>"My ability," mimicked Quarren.</p>
 
 <p>"Yes, your many, many talents, Rix. God knows why He gave them to you; I
-don't&mdash;for you use them ignobly, when you do not utterly neglect
-them&mdash;&mdash;"</p>
+don't—for you use them ignobly, when you do not utterly neglect
+them——"</p>
 
 <p>"I've a light and superficial talent for entertaining<span class="pagenum" id="Page_139">[Pg 139]</span> people; I've
 nimble legs, and possess a low order of intelligence known as 'tact.'
@@ -899,7 +899,7 @@ What more have I?"</p>
 <p>"An <i>amateur</i>," sneered Quarren. "That is to say, a man who has the
 inclinations, but neither the courage, the self-respect, nor the
 ambition of the professional.... Well, I admit that. I lack
-something&mdash;courage, I think. I prefer what is easy. And I'm doing it."</p>
+something—courage, I think. I prefer what is easy. And I'm doing it."</p>
 
 <p>"What's your reward?" said Westguard bluntly.</p>
 
@@ -907,7 +907,7 @@ something&mdash;courage, I think. I prefer what is easy. And I'm doing it."</p>
 premises. People like me, trust me, depend upon me more or less. The
 intrigues and politics of my little world amuse me; now and then I act
 as ambassador, as envoy of peace, as herald, as secret diplomatic
-agent.... Reward? Oh, yes&mdash;you didn't suppose that my real-estate
+agent.... Reward? Oh, yes—you didn't suppose that my real-estate
 operations clothed and fed me, did you, Karl?"</p>
 
 <p>"What does?"</p>
@@ -920,14 +920,14 @@ elegantiarum.... There are, perhaps, fewer separations and divorces on
 account of me; fewer scandals.</p>
 
 <p>"I am sometimes called into consultation, <i>in extremis</i>; I listen, I
-advise&mdash;sometimes I plan and execute; even take the initiative and
-interfere&mdash;as when a foolish boy at the Cataract Club, last week, locked
+advise—sometimes I plan and execute; even take the initiative and
+interfere—as when a foolish boy at the Cataract Club, last week, locked
 himself into the bath-room with an automatic revolver and a case of
 half-drunken fright. I had to be very careful;<span class="pagenum" id="Page_140">[Pg 140]</span> I expected to hear that
 drumming fusillade at any moment.</p>
 
 <p>"But I talked to him, through the keyhole: and at last he opened the
-door&mdash;to take a shot at me, first."</p>
+door—to take a shot at me, first."</p>
 
 <p>Quarren shrugged and lighted a cigarette.</p>
 
@@ -942,7 +942,7 @@ women."</p>
 <p>"Somebody must. I seem better fitted to do it than the next man."</p>
 
 <p>"Yes," said Westguard with a wry face, "I fancy somebody must do
-unpleasant things&mdash;even among the lepers of Molokai. But I'd prefer real
+unpleasant things—even among the lepers of Molokai. But I'd prefer real
 lepers."</p>
 
 <p>"The social sort are sometimes sicker," laughed Quarren.</p>
@@ -950,14 +950,14 @@ lepers."</p>
 <p>"I don't agree with you.... By the way, it's all off between my aunt and
 me."</p>
 
-<p>"I'm sorry, Karl&mdash;&mdash;"</p>
+<p>"I'm sorry, Karl——"</p>
 
 <p>"I'm not! I don't want her money. She told me to go to the devil, and I
 said something similar. Do you know what she wants me to do?" he added
 angrily. "Give up writing, live on an allowance from her, and marry
 Chrysos Lacy! What do you think of that for a cold-blooded and
 impertinent proposition! We had a fearful family row," he continued with
-satisfaction&mdash;"my aunt bellowing so that her footmen actually fled, and
+satisfaction—"my aunt bellowing so that her footmen actually fled, and
 I doing the cool and haughty, and letting her bellow her bally head
 off."</p>
 
@@ -973,7 +973,7 @@ off."</p>
 spoken a dozen words to her, either. And I'll pick out my own wife. What
 does my aunt think I am? I wish I were in love with somebody's
 parlour-maid. B'jinks! I'd marry her, just to see my aunt's
-expression&mdash;&mdash;"</p>
+expression——"</p>
 
 <p>"Oh, stop your fulminations," said Quarren, laughing. "That's the way
 with you artistic people; you're a passionate pack of pups!"</p>
@@ -993,18 +993,18 @@ Weather-breeder."</p>
 and this time it's all off for keeps. I told her if she sent me another
 check I'd send it back. That settles it, doesn't it?"</p>
 
-<p>"You're foolish, Karl&mdash;&mdash;"</p>
+<p>"You're foolish, Karl——"</p>
 
 <p>"Never mind. If I can't keep myself alive in an untrammelled and
-self-respecting exercise of my profession&mdash;" His voice ended in a
+self-respecting exercise of my profession—" His voice ended in a
 gurgling growl. Then, as though the recollections of his injuries at the
 hands of his aunt still stung him, he reared up in his chair:</p>
 
 <p><span class="pagenum" id="Page_142">[Pg 142]</span></p>
 
-<p>"Chrysos Lacy," he roared, "is a sweet, innocent girl&mdash;not a bale of
+<p>"Chrysos Lacy," he roared, "is a sweet, innocent girl—not a bale of
 fashionable merchandise! Besides," he added in a modified tone, "I was
-rather taken by&mdash;by Mrs. Leeds."</p>
+rather taken by—by Mrs. Leeds."</p>
 
 <p>Quarren slowly raised his eyes.</p>
 
@@ -1017,11 +1017,11 @@ delighted that she'd give me several tons of helpful advice."</p>
 
 <p>"<i>Did</i> she! She came back at me with Chrysos Lacy, I tell you! And when
 I merely smiled and attempted to waive away the suggestion, she flew
-into a passion, called me down, cursed me out&mdash;you know her language
-isn't always in good taste&mdash;and then she ordered me to keep away from
-Mrs. Leeds&mdash;as though I ever hung around any woman's skirts! I'm no
+into a passion, called me down, cursed me out—you know her language
+isn't always in good taste—and then she ordered me to keep away from
+Mrs. Leeds—as though I ever hung around any woman's skirts! I'm no
 Squire of Dames. I tell you, Rix, I was mad clear through. So I told her
-that I'd marry Mrs. Leeds the first chance I got&mdash;&mdash;"</p>
+that I'd marry Mrs. Leeds the first chance I got——"</p>
 
 <p>"Don't talk about her that way," remonstrated Quarren pleasantly.</p>
 
@@ -1030,9 +1030,9 @@ that I'd marry Mrs. Leeds the first chance I got&mdash;&mdash;"</p>
 <p>"I didn't mean your aunt?"</p>
 
 <p>"Oh. About Mrs. Leeds. Why not? She's the most attractive woman I ever
-met&mdash;&mdash;"</p>
+met——"</p>
 
-<p>"Very well. But don't talk about marrying her&mdash;as though you had merely
+<p>"Very well. But don't talk about marrying her—as though you had merely
 to suggest it to her. You know, after all, Mrs. Leeds may have ideas of
 her own."</p>
 
@@ -1062,7 +1062,7 @@ aboard the <i>Yulan</i>."</p>
 
 <p>"She swore like a trooper, and called Langly all kinds of impolite
 names. Said she'd trim him if he ever tried any of his tricks around
-Mrs. Leeds&mdash;&mdash;"</p>
+Mrs. Leeds——"</p>
 
 <p>"What tricks? What does she mean by tricks?"</p>
 
@@ -1086,13 +1086,13 @@ and his boots and spurs were shockingly muddy.</p>
 <p>"Who is this Sir Charles Mallison, anyway?" he asked, using the decanter
 and then squirting his glass full of carbonic. "Is it true that he's
 goin' to marry that charmin' Mrs. Leeds? I'll break his bally Sassenach
-head for him! I'll&mdash;&mdash;"</p>
+head for him! I'll——"</p>
 
 <p>"The rumour was contradicted in this morning's paper," said Quarren
 coldly.</p>
 
 <p>O'Hara drank pensively: "I see that Langly Sprowl is messin' about, too.
-Mrs. Ledwith had better hurry up out there in Reno&mdash;or wherever she's
+Mrs. Ledwith had better hurry up out there in Reno—or wherever she's
 gettin' her divorce. I saw Chet Ledwith ridin' in the Park. Dankmere was
 with him. Funny he doesn't seem to lose any caste by sellin' his wife to
 Sprowl."</p>
@@ -1104,7 +1104,7 @@ Sprowl."</p>
 <p>"Because, you dub! I don't use real episodes or living people!" roared
 Westguard; "newspapers and a few chumps to the contrary!"</p>
 
-<p>"So!&mdash;so-o!" said O'Hara, soothingly&mdash;"whoa&mdash;steady, boy!" And he
+<p>"So!—so-o!" said O'Hara, soothingly—"whoa—steady, boy!" And he
 pretended to rub down Westguard, hissing the while as do grooms when
 currying.</p>
 
@@ -1116,7 +1116,7 @@ with social conditions in any fashionable set, I'd be disbelieved."</p>
 <p>"You would be if you devoted your attention to fashionable scandals
 only," said Quarren.</p>
 
-<p>"Why? Aren't there plenty of scandalous&mdash;&mdash;"</p>
+<p>"Why? Aren't there plenty of scandalous——"</p>
 
 <p><span class="pagenum" id="Page_145">[Pg 145]</span></p>
 
@@ -1131,11 +1131,11 @@ aunt in fiction. Nobody would believe her possible."</p>
 <p>"I sometimes doubt her even now," observed O'Hara, grinning.</p>
 
 <p>Quarren said: "Count up the unpleasant characters in your own social
-vicinity, Karl&mdash;just to prove to yourself that there are really very
+vicinity, Karl—just to prove to yourself that there are really very
 few."</p>
 
-<p>"There is Langly&mdash;and my aunt&mdash;and the Lester Calderas&mdash;and the
-Ledwiths&mdash;&mdash;"</p>
+<p>"There is Langly—and my aunt—and the Lester Calderas—and the
+Ledwiths——"</p>
 
 <p>"Go on!"</p>
 
@@ -1153,7 +1153,7 @@ Ledwiths&mdash;&mdash;"</p>
 
 <p>"Divorce is a dirty business."</p>
 
-<p>"Oh. You'd rather she put up with Chester?&mdash;the sort of man who was weak
+<p>"Oh. You'd rather she put up with Chester?—the sort of man who was weak
 enough to let her go?"</p>
 
 <p>"Yes!"</p>
@@ -1180,7 +1180,7 @@ Beach to Havana; the perpetual social activity, the unbroken fever of
 change and excitement had already made firmer the soft lineaments of the
 girl's features, had slightly altered the expression of the mouth.</p>
 
-<p>By daylight the fatigues of pleasure were faintly visible&mdash;that
+<p>By daylight the fatigues of pleasure were faintly visible—that
 unmistakable imprint which may perhaps leave the eyes clear and calm,
 but which edges the hardened contour of the cheek under them with deeper
 violet shadow.</p>
@@ -1197,8 +1197,8 @@ features showed it.</p>
 
 <p>But nervous exhaustion alone could not account for the subtle change in
 her expression. Eyes and lips were still sweet, even in repose, but
-there was now a jaded charm about them&mdash;something unspoiled had
-disappeared<span class="pagenum" id="Page_148">[Pg 148]</span> from them&mdash;something of that fearlessness which vanishes
+there was now a jaded charm about them—something unspoiled had
+disappeared<span class="pagenum" id="Page_148">[Pg 148]</span> from them—something of that fearlessness which vanishes
 after too close and too constant contact with the world of men.</p>
 
 <p>Evidently her mind was quite as weary as her body, though even to
@@ -1207,12 +1207,12 @@ itself. Hers had not; and the defence had been, day by day,
 imperceptibly weakening. So that things to which once she had been able
 at will to close her mind, and, mentally deaf, let pass unheard, she had
 heard, and had even thought about. And the effort to defend her ears and
-mind became less vigorous, less instinctive&mdash;partly through sheer
+mind became less vigorous, less instinctive—partly through sheer
 weariness.</p>
 
 <p>The wisdom of woman and of man, and of what is called the world, the
-girl was now learning&mdash;unconsciously in the beginning and then with a
-kind of shamed indifference&mdash;but the creation of an artificial interest
+girl was now learning—unconsciously in the beginning and then with a
+kind of shamed indifference—but the creation of an artificial interest
 in anything is a subtle matter; and the ceaseless repetition of things
 unworthy at last awake that ignoble curiosity always latent in man.
 Because intelligence was born with it; and unwearied intelligence alone
@@ -1221,12 +1221,12 @@ completely suppresses it.</p>
 <p>At first she had kept her head fairly level in the whirlwind of
 adulation. To glimpses of laxity she closed her eyes. Sir Charles was
 always refreshing to her; but she could see little more of him than of
-other men&mdash;less than she saw of Langly Sprowl, however that
-happened&mdash;and it probably happened through the cleverness of Langly
+other men—less than she saw of Langly Sprowl, however that
+happened—and it probably happened through the cleverness of Langly
 Sprowl.</p>
 
 <p>Again and again she found herself with him separated from the
-others&mdash;sometimes alone with him on deck&mdash;and never quite understood how
+others—sometimes alone with him on deck—and never quite understood how
 it came about so constantly.</p>
 
 <p><span class="pagenum" id="Page_149">[Pg 149]</span></p>
@@ -1243,7 +1243,7 @@ adjusted or over-strained.</p>
 <p>At first Strelsa found the young fellow fascinating. He had been
 everywhere and had seen everything; his mind was kaleidoscopic; his
 thought shifted, flashed, jerked, leaped like erratic lightning from one
-subject to another&mdash;from Japanese aeroplanes to a scheme for filling in
+subject to another—from Japanese aeroplanes to a scheme for filling in
 the East River; from a plan to reconcile church and state in France to
 an idea for indefinitely prolonging human life. He had written several
 books about all kinds of things. Nobody read them.</p>
@@ -1279,45 +1279,45 @@ while Mary Ledwith is in Reno?"</p>
 is perfectly frank to me. I can't believe that scandal. Besides he is
 quite open and manly about his unsavoury reputation; makes no excuses;
 simply says that there's good in every man, and that there is always one
-woman in the world who can bring it out&mdash;&mdash;"</p>
+woman in the world who can bring it out——"</p>
 
 <p>"Oh, mushy! What an out-of-date whine! He's bad all through I tell
-you&mdash;&mdash;"</p>
+you——"</p>
 
 <p>"No man is!" insisted Strelsa.</p>
 
 <p>"What?"</p>
 
 <p>"No man is. The great masters of fiction always ascribe at least one
-virtue to their most infamous creations&mdash;&mdash;"</p>
+virtue to their most infamous creations——"</p>
 
 <p>"Oh, Strelsa, you talk like a pan of fudge! <i>I</i> tell you that Langly
 Sprowl is no good at all. I hope you won't have to marry him to find
 out."</p>
 
-<p>"I don't intend to.... How inconsistent you are, Molly. You&mdash;and
-everybody else&mdash;believe him to be the most magnificent match in&mdash;&mdash;"</p>
+<p>"I don't intend to.... How inconsistent you are, Molly. You—and
+everybody else—believe him to be the most magnificent match in——"</p>
 
 <p><span class="pagenum" id="Page_151">[Pg 151]</span></p>
 
 <p>"If position and wealth is all you care for, yes. I didn't suppose you'd
 come to that."</p>
 
-<p>Strelsa said candidly: "I care for both&mdash;I don't know how much."</p>
+<p>Strelsa said candidly: "I care for both—I don't know how much."</p>
 
 <p>"As much as that?"</p>
 
 <p>"No; not enough to marry him. And if he is what you say, it's hopeless
 of course.... I don't think he is. Be decent, Molly; everybody is very
-horrid about him, and&mdash;and that is always a matter of sympathetic
+horrid about him, and—and that is always a matter of sympathetic
 interest to a generous woman. When the whole world condemns a man it
 makes him interesting!"</p>
 
 <p>"That's a piffling and emotional thing to say! He may be attractive in
 an uncanny way, because he's agreeable to look at, amusing, and very
-dangerous&mdash;a perfectly cold-blooded, and I think, slightly unbalanced
+dangerous—a perfectly cold-blooded, and I think, slightly unbalanced
 social marauder. And that's the fact about Langly Sprowl. And I wish we
-were on land, the <i>Yulan</i> and her owner in&mdash;well, in the Erie Basin,
+were on land, the <i>Yulan</i> and her owner in—well, in the Erie Basin,
 perhaps."</p>
 
 <p>Whether or not Strelsa believed these things, there still remained in
@@ -1341,20 +1341,20 @@ narrow world with which she was already identified; and few realised how
 fast she was learning. Laxity of precept, easy morals, looseness of
 thought, idle and good-natured acquiescence in social conditions where
 all standards seemed alike, all ideals merely a matter of personal
-taste&mdash;this was the atmosphere into which she had stepped from two years
+taste—this was the atmosphere into which she had stepped from two years
 of Western solitude after a nightmare of violence, cruelty, and
 depravity unutterable. And naturally it seemed heavenly to her; and each
 revelation inconsistent with her own fastidious instincts left her less
 and less surprised, less and less uneasy. And after a while she began to
 assimilate all that she saw and heard.</p>
 
-<p>A few unworldly instincts remained in her&mdash;gratitude for and quick
+<p>A few unworldly instincts remained in her—gratitude for and quick
 response to any kindness offered from anybody; an inclination to make
 friends with stray wanderers into her circle, and to cultivate the
 socially useless.</p>
 
 <p>Taking four o'clock tea alone with Mrs. Sprowl the afternoon of her
-return to town&mdash;an honour vouchsafed to few&mdash;Strelsa was relating, at
+return to town—an honour vouchsafed to few—Strelsa was relating, at
 that masterful woman's request, her various exotic experiences. Mrs.
 Sprowl had commanded her attendance early. There were reasons. And now
 partly vexed, partly in unwilling admiration, the old lady sat smiling
@@ -1367,11 +1367,11 @@ green eyes shining in the expanse of powdered and painted fat.</p>
 <p>After a while she could endure it no longer, and she said with a wheeze
 of good-natured disdain:</p>
 
-<p>"It's like a school-girl's diary&mdash;all those rhapsodies over volcanoes,
+<p>"It's like a school-girl's diary—all those rhapsodies over volcanoes,
 palm trees, and the colour of the Spanish Main. Never mind geography,
 child; tell me about the men!"</p>
 
-<p>"Men?" repeated Strelsa, laughingly&mdash;"why there were shoals and shoals
+<p>"Men?" repeated Strelsa, laughingly—"why there were shoals and shoals
 of them, of every description!"</p>
 
 <p>"I mean the <i>one</i> man?" insisted Mrs. Sprowl encouragingly.</p>
@@ -1381,7 +1381,7 @@ of them, of every description!"</p>
 <p>"Nonsense! There <i>was</i> one, I suppose."</p>
 
 <p>"Oh, I don't think so.... Your nephew, Langly, was exceedingly
-amiable&mdash;&mdash;"</p>
+amiable——"</p>
 
 <p>"He's a plain beast," said his aunt, bluntly. "I didn't mean him."</p>
 
@@ -1389,10 +1389,10 @@ amiable&mdash;&mdash;"</p>
 
 <p>"Probably he didn't have a chance to be otherwise. He's a rotter, child.
 Ask anybody. I know perfectly well what he's been up to. I'm sorry you
-went on the <i>Yulan</i>. He had no business to ask you&mdash;or any other nice
-girl&mdash;or anybody at all until that Reno scandal is officially made
-respectable. If it were not for his money&mdash;" She stopped a moment,
-adding cynically&mdash;"and if it were not for mine&mdash;certain people wouldn't
+went on the <i>Yulan</i>. He had no business to ask you—or any other nice
+girl—or anybody at all until that Reno scandal is officially made
+respectable. If it were not for his money—" She stopped a moment,
+adding cynically—"and if it were not for mine—certain people wouldn't
 be tolerated anywhere, I suppose.... How did you like Sir Charles?"</p>
 
 <p>"Oh, he is charming!" she said warmly.</p>
@@ -1411,7 +1411,7 @@ men!'"]</p>
 <p><span class="pagenum" id="Page_158">[Pg 158]</span></p>
 
 <p>Strelsa laughed frankly: "He hasn't asked me to, for one reason.
-Besides&mdash;&mdash;"</p>
+Besides——"</p>
 
 <p>"No doubt he'll do it."</p>
 
@@ -1439,7 +1439,7 @@ she thought; but her smile remained bland and calmly patronising.</p>
 
 <p>For a second or two longer she studied the girl cautiously, trying to
 make up her mind whether there was really any character in Strelsa's
-soft beauty&mdash;anything firmer than material fastidiousness; anything more
+soft beauty—anything firmer than material fastidiousness; anything more
 real than a natural and dainty reticence. Mrs. Sprowl could ride
 rough-shod over such details. But she was too wise to ride if there was
 any chance of a check from higher sources.</p>
@@ -1458,56 +1458,56 @@ Don't you see I can't, dear Mrs. Sprowl?"</p>
 <p>"Pooh! Rubbish! Anybody can discuss anything," rejoined the old lady
 with impersonal and boisterous informality. "I'm fond of you. Everybody
 knows it. I'm fond of Sir Charles. He's a fine figure of a man. You
-match him in everything, except wealth. It's an ideal marriage&mdash;&mdash;"</p>
+match him in everything, except wealth. It's an ideal marriage——"</p>
 
-<p>"Please don't!&mdash;I simply cannot&mdash;&mdash;"</p>
+<p>"Please don't!—I simply cannot——"</p>
 
-<p>"Ideal," repeated Mrs. Sprowl loudly&mdash;"an ideal marriage&mdash;&mdash;"</p>
+<p>"Ideal," repeated Mrs. Sprowl loudly—"an ideal marriage——"</p>
 
-<p>"But when there is no love&mdash;&mdash;"</p>
+<p>"But when there is no love——"</p>
 
-<p>"Plenty! Loads of it! He's mad about you&mdash;crazy!&mdash;&mdash;"</p>
+<p>"Plenty! Loads of it! He's mad about you—crazy!——"</p>
 
-<p>"I&mdash;meant&mdash;on my part&mdash;&mdash;"</p>
+<p>"I—meant—on my part——"</p>
 
 <p>"Good God!" shouted the old lady, beating the air with pudgy
-hands&mdash;"isn't it luck enough to have love on one side? What does the
+hands—"isn't it luck enough to have love on one side? What does the
 present generation want! I tell you it's ideal, perfect. He's a good man
-as men go, and a devilish handsome&mdash;&mdash;"</p>
+as men go, and a devilish handsome——"</p>
 
-<p>"I know&mdash;but&mdash;&mdash;"</p>
+<p>"I know—but——"</p>
 
-<p>"And he's got money!" shouted the old lady&mdash;"plenty of it I tell you!
-And he has the entrée everywhere on the Continent&mdash;in
-England&mdash;everywhere!&mdash;which Dankmere has not!&mdash;if you're considering
+<p>"And he's got money!" shouted the old lady—"plenty of it I tell you!
+And he has the entrée everywhere on the Continent—in
+England—everywhere!—which Dankmere has not!—if you're considering
 that little whelp!"</p>
 
 <p>Stunned, shrinking from the dreadful asthmatic noises in Mrs. Sprowl's
 voice, Strelsa sat dumb, wincing under the blows of sound, not knowing
 how to escape.</p>
 
-<p>"I'm fond of you!" shrieked the old lady&mdash;"I can<span class="pagenum" id="Page_160">[Pg 160]</span> be of use to you and I
-want to be. That's why I asked you to tea! I want to make you happy&mdash;and
+<p>"I'm fond of you!" shrieked the old lady—"I can<span class="pagenum" id="Page_160">[Pg 160]</span> be of use to you and I
+want to be. That's why I asked you to tea! I want to make you happy—and
 Sir Charles, too! What the devil do you suppose there is in it for me
-except to oblige hi&mdash;you both?"</p>
+except to oblige hi—you both?"</p>
 
-<p>"Th-thank you, but&mdash;&mdash;"</p>
+<p>"Th-thank you, but——"</p>
 
 <p>"I'll bet a shilling that Molly Wycherly let you go about with any
-little spindle-shanked pill who came hanging around!&mdash;And I told her
-what were my wishes&mdash;&mdash;"</p>
+little spindle-shanked pill who came hanging around!—And I told her
+what were my wishes——"</p>
 
-<p>"Please&mdash;oh, <i>please</i>, Mrs. Sprowl&mdash;&mdash;"</p>
+<p>"Please—oh, <i>please</i>, Mrs. Sprowl——"</p>
 
-<p>"Yes, I did! It's a good match! I want you to consider it!&mdash;I insist
-that&mdash;&mdash;"</p>
+<p>"Yes, I did! It's a good match! I want you to consider it!—I insist
+that——"</p>
 
 <p>"Mrs. Sprowl!" exclaimed Strelsa, pink with confusion and resentment, "I
-am obliged to you for the interest you display, but it is a matter&mdash;&mdash;"</p>
+am obliged to you for the interest you display, but it is a matter——"</p>
 
 <p>"What!"</p>
 
-<p>"I am really&mdash;grateful&mdash;but&mdash;&mdash;"</p>
+<p>"I am really—grateful—but——"</p>
 
 <p>"Answer me, child. Has that cursed nephew of mine made any impression on
 you? Answer me!"</p>
@@ -1520,7 +1520,7 @@ you? Answer me!"</p>
 tried to be gentle; tried to remember the age, and the excellent
 intentions of this excited old lady; and she answered in a low voice:</p>
 
-<p>"I care for no man in particular, unless it be Sir Charles&mdash;and&mdash;&mdash;"</p>
+<p>"I care for no man in particular, unless it be Sir Charles—and——"</p>
 
 <p>"And who?"</p>
 
@@ -1528,22 +1528,22 @@ intentions of this excited old lady; and she answered in a low voice:</p>
 
 <p>Mrs. Sprowl's jowl grew purple with fury:</p>
 
-<p>"You&mdash;has that boy had the impudence&mdash;damn him&mdash;&mdash;"</p>
+<p>"You—has that boy had the impudence—damn him——"</p>
 
 <p><span class="pagenum" id="Page_161">[Pg 161]</span></p>
 
 <p>Strelsa sprang to her feet.</p>
 
-<p>"I really cannot remain&mdash;" she said with decision, but the old lady only
+<p>"I really cannot remain—" she said with decision, but the old lady only
 bawled:</p>
 
 <p>"Sit down! Sit down!"</p>
 
 <p>"I will not!"</p>
 
-<p>"Sit <i>down</i>!" she roared in a passion. "What the devil&mdash;&mdash;"</p>
+<p>"Sit <i>down</i>!" she roared in a passion. "What the devil——"</p>
 
-<p>Strelsa, a little pale, started to pass her&mdash;then halted, astounded: for
+<p>Strelsa, a little pale, started to pass her—then halted, astounded: for
 the old lady had burst into a passion of choking gasps. Whether the
 terrible sounds she made were due to impotent rage or asthma, Strelsa,
 confused, shocked, embarrassed, but still angry, had no notion; and
@@ -1551,7 +1551,7 @@ while Mrs. Sprowl coughed fatly, she stood still, catching muffled
 fragments of reproaches directed at people who flouted friendship; who
 had no consideration for age, and no gratitude, no tenderness, no pity.</p>
 
-<p>"I&mdash;I <i>am</i> grateful," faltered Strelsa, "only I cannot&mdash;&mdash;"</p>
+<p>"I—I <i>am</i> grateful," faltered Strelsa, "only I cannot——"</p>
 
 <p>"I wanted to be a mother to you! I've tried to be," wheezed the old lady
 in a fresh paroxysm; and beat the air.</p>
@@ -1571,31 +1571,31 @@ the handkerchief.</p>
 panting.</p>
 
 <p>"I only wanted to be good to you, Strelsa. I'm just an old fool I
-suppose&mdash;&mdash;"</p>
+suppose——"</p>
 
 <p><span class="pagenum" id="Page_162">[Pg 162]</span></p>
 
-<p>"Oh, please don't&mdash;&mdash;"</p>
+<p>"Oh, please don't——"</p>
 
 <p>"That's all I am, child, just a sentimental old fool. The poor man's
-adoration of you touched my heart&mdash;and you do like him a little, don't
+adoration of you touched my heart—and you do like him a little, don't
 you?"</p>
 
-<p>"Very much.... Thank you for&mdash;for wishing happiness to me. I really
+<p>"Very much.... Thank you for—for wishing happiness to me. I really
 don't mean to be ungrateful; I have a horror of ingratitude. It's only
-that&mdash;the idea never occurred to me; and I am incapable of doing such a
-thing for material reasons, unless&mdash;I also really cared for a man&mdash;&mdash;"</p>
+that—the idea never occurred to me; and I am incapable of doing such a
+thing for material reasons, unless—I also really cared for a man——"</p>
 
 <p>"Of course, child. Maybe you will care for him some day. I won't
-interfere any more.... Only&mdash;don't lose your heart to any of these young
+interfere any more.... Only—don't lose your heart to any of these young
 jackals fawning around your skirts. Every set is full of 'em. They're
-nothing but the capering chorus in this comic opera.... And&mdash;don't be
-angry&mdash;but I am an older and wiser woman than you, and I am fond of you,
-and it's my duty to tell you that any of the lesser breed&mdash;take young
-Quarren for example&mdash;are of no real account, even in the society which
+nothing but the capering chorus in this comic opera.... And—don't be
+angry—but I am an older and wiser woman than you, and I am fond of you,
+and it's my duty to tell you that any of the lesser breed—take young
+Quarren for example—are of no real account, even in the society which
 they amuse."</p>
 
-<p>"I would scarcely class Mr. Quarren with the sort you mention&mdash;&mdash;"</p>
+<p>"I would scarcely class Mr. Quarren with the sort you mention——"</p>
 
 <p>"Why not? He's of no importance."</p>
 
@@ -1613,7 +1613,7 @@ one, who evolved us. He's dead. We have another. He's still talking.
 When he ultimately evaporates into infinity Ricky will be his natural
 successor. Do you want that kind of a husband?"</p>
 
-<p>"Did you suppose&mdash;&mdash;"</p>
+<p>"Did you suppose——"</p>
 
 <p>"Don't get angry, Strelsa? I didn't suppose anything. Ricky, like every
 other man, dangles his good-looking, good-humoured self in your
@@ -1651,7 +1651,7 @@ moustache.</p>
 
 <p>He looked up in slight surprise, recognised a condition of things which,
 on second thought, surprised him still more. Because his aunt had never
-before noticed his affairs&mdash;had not even commented on the Ledwith matter
+before noticed his affairs—had not even commented on the Ledwith matter
 to him. He had always felt that she disliked him too thoroughly to care.</p>
 
 <p>"I don't think I understood you," he said, watching her out of shifting
@@ -1660,12 +1660,12 @@ eyes which protruded a trifle.</p>
 <p>"I think you will understand me before I've done with you," returned his
 aunt, grimly. "It's a perfectly plain matter; you've the rest of the
 female community to chase if you choose. Go and chase 'em for all I
-care&mdash;hunt from here to Reno if you like!&mdash;but I have other plans for
+care—hunt from here to Reno if you like!—but I have other plans for
 Strelsa Leeds. Do you understand? I've put my private mark on her.
 There's no room for yours."</p>
 
-<p>Langly's gaze which had not met hers&mdash;and never met anybody's for more
-than a fraction of a second&mdash;shifted. He continued his attentions to his
+<p>Langly's gaze which had not met hers—and never met anybody's for more
+than a fraction of a second—shifted. He continued his attentions to his
 moustache; his eyes roved; he looked at but did not see a hundred things
 in a second.</p>
 
@@ -1693,7 +1693,7 @@ Charles."</p>
 
 <p>Mrs. Sprowl turned red:</p>
 
-<p>"Suppose what you like, you cold-blooded cad! But by God!&mdash;if you annoy
+<p>"Suppose what you like, you cold-blooded cad! But by God!—if you annoy
 that child I'll empty the family wash all over the sidewalk! And let the
 public pick it over!"</p>
 
@@ -1728,7 +1728,7 @@ another, disrobed her mistress and got her into bed.</p>
 
 <p>Their offices accomplished, they were ordered to withdraw but to leave
 one light burning. It glimmered over an old-fashioned photograph on the
-wall&mdash;the portrait of a British officer taken in the days when whiskers,
+wall—the portrait of a British officer taken in the days when whiskers,
 "pill-box," and frogged frock-tunic were cultivated in Her British
 Majesty's Service.</p>
 
@@ -1769,7 +1769,7 @@ second-year gown; dinner was announced; she descended the stairway in
 solitary state, still smiling to herself at Quarren's forgotten remark,
 and passed by the library just as the telephone rang there.</p>
 
-<p>It may have been a flash of clairvoyance&mdash;afterward she wondered exactly
+<p>It may have been a flash of clairvoyance—afterward she wondered exactly
 what it was that made her say to her maid very confidently:</p>
 
 <p>"That is Mr. Quarren. I'll speak to him."</p>
@@ -1804,14 +1804,14 @@ departure with quiet satisfaction."]</p>
 
 <p>"I said something aloud to you about eight o'clock."</p>
 
-<p>"How odd! Did you know I was asleep? But you couldn't&mdash;&mdash;"</p>
+<p>"How odd! Did you know I was asleep? But you couldn't——"</p>
 
 <p>"No, of course not. I was merely thinking of you."</p>
 
-<p>"You were&mdash;you happened to be thinking of <i>me</i>? And you said something
+<p>"You were—you happened to be thinking of <i>me</i>? And you said something
 aloud about me?"</p>
 
-<p>"About you&mdash;and <i>to</i> you."</p>
+<p>"About you—and <i>to</i> you."</p>
 
 <p>"How delightfully interesting! What was it, please?"</p>
 
@@ -1834,11 +1834,11 @@ simply cannot recollect what it was you said."</p>
 <p>"That's true. I'm not at home to anybody. So you can't drop in, can
 you?"</p>
 
-<p>"You are not logical; I could drop in because I'm not anybody&mdash;&mdash;"</p>
+<p>"You are not logical; I could drop in because I'm not anybody——"</p>
 
 <p>"What!"</p>
 
-<p>"I'm not anybody in particular&mdash;&mdash;"</p>
+<p>"I'm not anybody in particular——"</p>
 
 <p>"You know if you begin to talk that way, after all these days, I'll ring
 off in a rage. You are the only man in the world to whom I'm at home
@@ -1854,10 +1854,10 @@ what does?... Are you well, Mr. Quarren?"</p>
 <p>"Oh, we are all that. Nothing more serious threatens you than impending
 slumber?"</p>
 
-<p>"I said I was tired, not sleepy. I'm wide awake but horribly lazy&mdash;and
+<p>"I said I was tired, not sleepy. I'm wide awake but horribly lazy—and
 inclined to slump. Where are you; at the Legation?"</p>
 
-<p>"At the Founders' Club&mdash;foundered."</p>
+<p>"At the Founders' Club—foundered."</p>
 
 <p>"What are you doing there?"</p>
 
@@ -1872,7 +1872,7 @@ inclined to slump. Where are you; at the Legation?"</p>
 <p>"Oh, yes; I'm trying to think whether I want you to come around and
 share a solitary dinner with me. Do I want you?"</p>
 
-<p>"Just a little&mdash;don't you?"</p>
+<p>"Just a little—don't you?"</p>
 
 <p>"Do you want to come?"</p>
 
@@ -1880,19 +1880,19 @@ share a solitary dinner with me. Do I want you?"</p>
 
 <p>"Very much?"</p>
 
-<p>"I can't tell you how much&mdash;over the telephone."</p>
+<p>"I can't tell you how much—over the telephone."</p>
 
 <p>"That sounds both humble and dangerous. Which do you mean to be?"</p>
 
-<p>"Humble&mdash;and very, very grateful, dear lady. May I come?"</p>
+<p>"Humble—and very, very grateful, dear lady. May I come?"</p>
 
-<p>"I&mdash;don't know. Dinner was announced a quarter of an hour ago."</p>
+<p>"I—don't know. Dinner was announced a quarter of an hour ago."</p>
 
-<p>"It won't take me three minutes&mdash;&mdash;"</p>
+<p>"It won't take me three minutes——"</p>
 
 <p>"If it takes you more you'll ring my door-bell in vain, young man."</p>
 
-<p>"I'll start now! Good&mdash;&mdash;"</p>
+<p>"I'll start now! Good——"</p>
 
 <p><span class="pagenum" id="Page_173">[Pg 173]</span></p>
 
@@ -1904,7 +1904,7 @@ smiling."]</p>
 <p>"Wait! I haven't decided. Really I'm simply stupid with the accumulated
 fatigues of two months' frivolity. Do you mind my being stupid?"</p>
 
-<p>"You know I don't&mdash;&mdash;"</p>
+<p>"You know I don't——"</p>
 
 <p>"Shame on you! That was not the answer. Think out the right one on your
 way over. <i>À bien tôt!</i>"</p>
@@ -1939,7 +1939,7 @@ dinner. Here is your cocktail."</p>
 After a moment she raised her eyes, met his gaze, returned it with one
 quite as audacious:</p>
 
-<p>"I am drinking that same toast again&mdash;after many days," she said.</p>
+<p>"I am drinking that same toast again—after many days," she said.</p>
 
 <p><span class="pagenum" id="Page_177">[Pg 177]</span></p>
 
@@ -1974,7 +1974,7 @@ view of Quarren.</p>
 
 <p>"You look rather tired, Mrs. Leeds."</p>
 
-<p>"I know I do. By daylight it's particularly visible.... But&mdash;do <i>you</i>
+<p>"I know I do. By daylight it's particularly visible.... But—do <i>you</i>
 mind?"</p>
 
 <p>Her charming head was bent over her grapefruit: she lifted her gray eyes
@@ -1982,7 +1982,7 @@ under level brows, looking across the table at him.</p>
 
 <p>"I mind anything that concerns you," he said.</p>
 
-<p>"I mean&mdash;are you disappointed because I'm growing old and haggard?"</p>
+<p>"I mean—are you disappointed because I'm growing old and haggard?"</p>
 
 <p>"I think you are even more beautiful than you were."</p>
 
@@ -2005,8 +2005,8 @@ as a declared suitor?"</p>
 
 <p>"You <i>have</i> changed."</p>
 
-<p>"What a perfect pill you are!" she exclaimed, vexed&mdash;"you're casting
-yourself for the rôle of the honest friend&mdash;and I simply hate it! Young
+<p>"What a perfect pill you are!" she exclaimed, vexed—"you're casting
+yourself for the rôle of the honest friend—and I simply hate it! Young
 sir, do you not understand that I've breakfasted, lunched and dined too
 long on flattery to endure anything more wholesome? If you can't lie to
 me like a gentleman and a suitor your usefulness in my entourage is
@@ -2032,9 +2032,9 @@ in the mirror.</p>
 affably to him in the glass:</p>
 
 <p>"I'm quite changed; you are right. I'm not as nice as I was when I first
-knew you.... I'm not as contented; I'm restless&mdash;I wasn't then....
+knew you.... I'm not as contented; I'm restless—I wasn't then....
 Amusement is becoming a necessity to me; and I'm not particular about
-the kind&mdash;as long as it does amuse me. Tell me something exciting."</p>
+the kind—as long as it does amuse me. Tell me something exciting."</p>
 
 <p>"A cradle song is what you require."</p>
 
@@ -2043,7 +2043,7 @@ cradle. I'm dreadfully cross, too. Do you realise that?"</p>
 
 <p>"I realise how tired you are."</p>
 
-<p>"And&mdash;I'll never again be rested," she said thoughtfully, looking at her
+<p>"And—I'll never again be rested," she said thoughtfully, looking at her
 mirrored self. "I seem to understand that, now, for the first time....
 Something in me will always remain a little tired. I wonder what. Do you
 know?"</p>
@@ -2076,9 +2076,9 @@ only a few weeks ago. But the world has whirled very swiftly. Each day
 was a little lifetime in itself; a week a century condensed; Time became
 only a concentrated essence, one drop of which contained eons of
 experience.... I wonder whether my silly head <i>was</i> turned a little....
-People said too much to me: there were too many of them&mdash;and they came
-too near.... And do you know&mdash;looking back at it now as I sit here
-talking to you&mdash;I&mdash;it seems absurd&mdash;but I believe that I was really a
+People said too much to me: there were too many of them—and they came
+too near.... And do you know—looking back at it now as I sit here
+talking to you—I—it seems absurd—but I believe that I was really a
 trifle lonely at times."</p>
 
 <p>She interlaced her fingers and rested her chin on the back of them.</p>
@@ -2092,19 +2092,19 @@ fixed on his face which was shadowed by his hand as though to shield his
 eyes from the bracket light.</p>
 
 <p>For a time she sat motionless, considering him, interested in his
-silence and abstraction&mdash;in the set of his shoulders, and the
+silence and abstraction—in the set of his shoulders, and the
 unconscious grace of him. Light, touching his short blond hair, made it
 glossy like a boy's where his hand had disarranged it above the
-forehead. Certainly it was very pleasant to see him again&mdash;agreeable to
-be with him&mdash;not exactly restful, perhaps, but distinctly agreeable&mdash;for
+forehead. Certainly it was very pleasant to see him again—agreeable to
+be with him—not exactly restful, perhaps, but distinctly agreeable—for
 even in the frequent silences that had crept in between them there was
 no invitation to repose of mind. On the contrary, she was perfectly
-conscious of a reserve force now awaking&mdash;of <span class="pagenum" id="Page_181">[Pg 181]</span> a growing sense of
+conscious of a reserve force now awaking—of <span class="pagenum" id="Page_181">[Pg 181]</span> a growing sense of
 freshness within her; of physical renewal, of unsuspected latent vigour.</p>
 
 <p>"Are you attempting to go to sleep, Mr. Quarren?" she inquired at last.</p>
 
-<p>He dropped his hand, smiling: she made an instinctive move&mdash;scarcely an
+<p>He dropped his hand, smiling: she made an instinctive move—scarcely an
 invitation, scarcely even perceptible. But he came over and seated
 himself on the arm of the lounge beside her.</p>
 
@@ -2121,14 +2121,14 @@ door of Eternity."</p>
 
 <p>"How do you mean?"</p>
 
-<p>"Otherwise he would never have stirred a step&mdash;until to-night."</p>
+<p>"Otherwise he would never have stirred a step—until to-night."</p>
 
-<p>"That is very gallant of you, Mr. Quarren&mdash;but a little
-sentimental&mdash;isn't it?"</p>
+<p>"That is very gallant of you, Mr. Quarren—but a little
+sentimental—isn't it?"</p>
 
 <p>"Do you think so?"</p>
 
-<p>"I don't know. I'm a poor judge of real sentiment&mdash;being unaccustomed to
+<p>"I don't know. I'm a poor judge of real sentiment—being unaccustomed to
 it."</p>
 
 <p>"How many men made you declarations?"</p>
@@ -2148,7 +2148,7 @@ think so?"</p>
 <p>"Do you, Mrs. Leeds?"</p>
 
 <p>"I think so.... A woman might as well know the worst truths about
-life&mdash;and about men."</p>
+life—and about men."</p>
 
 <p>"Not about men."</p>
 
@@ -2161,7 +2161,7 @@ probably prefer your women screened and veiled."</p>
 
 <p>"We are all born veiled. God knows why we ever tear the film."</p>
 
-<p>"Mr. Quarren&mdash;are you becoming misanthropic?" she exclaimed, laughing.
+<p>"Mr. Quarren—are you becoming misanthropic?" she exclaimed, laughing.
 But under his marred eyes of a boy she saw shadows, and the pale
 induration already stamped on the flesh over the cheek-bones.</p>
 
@@ -2175,17 +2175,17 @@ curiously.</p>
 <p>"Fewer crumbs have fallen from the banquet, perhaps. I keep Lent when I
 must."</p>
 
-<p>"You are beginning to speak in a way that you know I dislike&mdash;aren't
+<p>"You are beginning to speak in a way that you know I dislike—aren't
 you?" she asked, turning around in her seat to face him.</p>
 
 <p>He laughed.</p>
 
-<p>"You make me very angry," she said; "I like you&mdash;I'm quite happy with
-you&mdash;and suddenly you try to tell me that my friendship is lavished on
+<p>"You make me very angry," she said; "I like you—I'm quite happy with
+you—and suddenly you try to tell me that my friendship is lavished on
 an unworthy man; that my taste is low, and that you're a kind of a
-social jackal&mdash;an upper servant&mdash;&mdash;</p>
+social jackal—an upper servant——</p>
 
-<p>"I feed on what the pack leaves&mdash;and I wash their fragile plates for
+<p>"I feed on what the pack leaves—and I wash their fragile plates for
 them," he said lightly.</p>
 
 <p>"What else?" she asked, furious.</p>
@@ -2204,23 +2204,23 @@ manager, principals, chorus, prompter, and carpenter."</p>
 control of herself and her fingers closed tight.</p>
 
 <p>"What are you saying!" she said, fiercely. "Are you telling me that this
-is the kind of a man I care enough for to write to&mdash;to think
-about&mdash;think about a great deal&mdash;care enough about to dine with in my
+is the kind of a man I care enough for to write to—to think
+about—think about a great deal—care enough about to dine with in my
 own house when I denied myself to everybody else! Is that all you are
 after all? And am I finding my level by liking you?"</p>
 
-<p>He said, slowly: "I could have been anything&mdash;I could be yet&mdash;if
-you&mdash;&mdash;"</p>
+<p>He said, slowly: "I could have been anything—I could be yet—if
+you——"</p>
 
 <p>"If you are not anything for your own sake you will never be for
 anybody's!" she retorted.... "I refuse to believe that you are what you
-say, anyway. It hurts&mdash;it hurts&mdash;&mdash;"</p>
+say, anyway. It hurts—it hurts——"</p>
 
-<p>"It only hurts me, Mrs. Leeds&mdash;&mdash;"</p>
+<p>"It only hurts me, Mrs. Leeds——"</p>
 
-<p>"It hurts <i>me!</i> I <i>do</i> like you. I was glad to see you&mdash;you don't know
-how glad. Your letters to me were&mdash;were interesting. <i>You</i> have always
-been interesting, from the very first&mdash;more so than many men&mdash;more than
+<p>"It hurts <i>me!</i> I <i>do</i> like you. I was glad to see you—you don't know
+how glad. Your letters to me were—were interesting. <i>You</i> have always
+been interesting, from the very first—more so than many men—more than
 most men. And now you admit to me what kind of a man you really are. If
 I believe it, what am I to think of myself? Can you tell me?"</p>
 
@@ -2231,23 +2231,23 @@ every moment, she leaned forward looking at him, her right hand
 tightening on the arm of the sofa, the other clenched over her twisted
 handkerchief.</p>
 
-<p>"I could stand anything!&mdash;my friendship for you could stand almost
-anything except what you pretend you are&mdash;and what other malicious
-tongues will say if you continue to repeat it!&mdash;And it <i>has</i> been said
+<p>"I could stand anything!—my friendship for you could stand almost
+anything except what you pretend you are—and what other malicious
+tongues will say if you continue to repeat it!—And it <i>has</i> been said
 already about you! Do you know that? People <i>do</i> say that of you. People
-even say so to me&mdash;tell me you are worthless&mdash;warn me
-against&mdash;against&mdash;&mdash;"</p>
+even say so to me—tell me you are worthless—warn me
+against—against——"</p>
 
 <p>"What?"</p>
 
-<p>"Caring&mdash;taking you seriously! And it's because you deliberately exhibit
-disrespect for yourself! A man&mdash;<i>any</i> man is what he chooses to be, and
+<p>"Caring—taking you seriously! And it's because you deliberately exhibit
+disrespect for yourself! A man—<i>any</i> man is what he chooses to be, and
 people always believe him what he pretends to be. Is there any harm in
-pretending to dignity and worth when&mdash;when you can be the peer of any
+pretending to dignity and worth when—when you can be the peer of any
 man? What's the use of inviting contempt? This very day a woman spoke of
 you with contempt. I denied what she said.... I'd rather they'd say
-anything else about you&mdash;that you had vices&mdash;a vigorous, wilful,
-unmanageable man's vices!&mdash;than to say <i>that</i> of you!"</p>
+anything else about you—that you had vices—a vigorous, wilful,
+unmanageable man's vices!—than to say <i>that</i> of you!"</p>
 
 <p>"What?"</p>
 
@@ -2257,9 +2257,9 @@ unmanageable man's vices!&mdash;than to say <i>that</i> of you!"</p>
 
 <p>"Of course! It strikes at my own self-respect!"</p>
 
-<p>"Do you care&mdash;otherwise?"</p>
+<p>"Do you care—otherwise?"</p>
 
-<p>"I care&mdash;as a friend, naturally&mdash;&mdash;"</p>
+<p>"I care—as a friend, naturally——"</p>
 
 <p>"Otherwise still?"</p>
 
@@ -2298,13 +2298,13 @@ with him in silence.</p>
 
 <p>"Did you wish me to remain a little longer?"</p>
 
-<p>"I&mdash;don't know what I wish...."</p>
+<p>"I—don't know what I wish...."</p>
 
 <p>Her cheeks were deeply flushed; the hand he took into his again seemed
 burning.</p>
 
 <p>"It's fearfully hot in here," she said. "Please muffle up warmly because
-it's bitter weather out doors"&mdash;and she lifted the other hand as though
+it's bitter weather out doors"—and she lifted the other hand as though
 unconsciously and passed her finger tips over his fur collar.</p>
 
 <p>"Do you feel feverish?"</p>
@@ -2314,7 +2314,7 @@ unconsciously and passed her finger tips over his fur collar.</p>
 <p>"You haven't caught malaria in the tropics, have you?"</p>
 
 <p>"No, you funny man. I'm never ill. But it's odd how burning hot I seem
-to be&mdash;&mdash;"</p>
+to be——"</p>
 
 <p><span class="pagenum" id="Page_186">[Pg 186]</span></p>
 
@@ -2322,16 +2322,16 @@ to be&mdash;&mdash;"</p>
 
 <p>They were silent for a while. And, little by little it seemed to her as
 though within her a curious stillness was growing, responsive to the
-quiet around her&mdash;a serenity stealing over her, invading her mind like a
-delicate mist&mdash;a dreamy mental lethargy, soothing, obscuring sense and
+quiet around her—a serenity stealing over her, invading her mind like a
+delicate mist—a dreamy mental lethargy, soothing, obscuring sense and
 thought.</p>
 
 <p>Vaguely she was aware of their contact. He neither spoke nor stirred;
 and her palm burned softly, meltingly against his.</p>
 
 <p>At last he lifted her hand and laid his lips to it in silence. Small
-head lowered, she dreamily endured his touch&mdash;a slight caress over her
-forehead&mdash;the very ghost of contact; suffered his cheek against hers,
+head lowered, she dreamily endured his touch—a slight caress over her
+forehead—the very ghost of contact; suffered his cheek against hers,
 closer, never stirring.</p>
 
 <p>Thought drifted, almost dormant, lulled by infinite and rhythmical
@@ -2342,7 +2342,7 @@ the sorcery.</p>
 <p>Then, like a shaft of sunlight slanting through a dream and tearing its
 fabric into tatters, his kiss on her lips awoke her.</p>
 
-<p>She strove to turn her mouth from his&mdash;twisted away from him, straining,
+<p>She strove to turn her mouth from his—twisted away from him, straining,
 tearing her body from his arms; and leaned back against the stair-rail,
 gray eyes expressionless as though dazed. He would have spoken, but she
 shook her head and closed both ears with her hands; nor would she even
@@ -2359,7 +2359,7 @@ locked the door against her maid.</p>
 <p>Thought dragged, then halted with her steps as she dropped onto the seat
 before the dresser and took her throbbing head in her hands. Cheeks and
 lips grew hotter; she was aware of strange senses dawning; of strange
-nerves signalling; stranger responses&mdash;of a subtle fragrance in her
+nerves signalling; stranger responses—of a subtle fragrance in her
 breath so strange that she became conscious of it.</p>
 
 <p>She straightened up staring at her flushed reflection in the glass while
@@ -2367,12 +2367,12 @@ through and through her shot new pulses, and every breath grew
 tremulously sweet to the verge of pain as she recoiled dismayed from the
 unknown.</p>
 
-<p>Unknown still!&mdash;for she crouched there shrinking from the
-revelation&mdash;from the restless wonder of the awakening, wilfully deaf,
+<p>Unknown still!—for she crouched there shrinking from the
+revelation—from the restless wonder of the awakening, wilfully deaf,
 blind, ignorant, defying her other self with pallid flashes of
 self-contempt.</p>
 
-<p>Then fear came&mdash;fear of him, fear of herself, defiance of him, and
+<p>Then fear came—fear of him, fear of herself, defiance of him, and
 defiance of this other self, glimpsed only as yet, and yet already
 dreaded with every instinct. But it was a losing battle. Truth is very
 patient. And at last she looked Truth in the eyes.</p>
@@ -2380,20 +2380,20 @@ patient. And at last she looked Truth in the eyes.</p>
 <p>So, after all, she was what she had understood others were or must one
 day become. Unawakened, pure in her inherent contempt for the lesser
 passion; incredulous that it could ever touch her; out of nothing had
-sprung the lower menace, full armed, threatening her&mdash;out of a moment's
+sprung the lower menace, full armed, threatening her—out of a moment's
 lassitude, a touch of a man's hand, and his lips on hers! And now all
-her life was already behind her&mdash;childhood, girlhood, wifehood&mdash;all,
+her life was already behind her—childhood, girlhood, wifehood—all,
 all<span class="pagenum" id="Page_188">[Pg 188]</span> behind her now; and she, a stranger even to herself, alone on an
 unknown road; an unknown world before her.</p>
 
 <p>With every instinct inherent and self-inculcated, instincts of modesty,
 of reticence, of self-control, of pride, she quivered under this fierce
-humiliation born of self-knowledge&mdash;knowledge scornfully admitted and
-defied with every breath&mdash;but no longer denied.</p>
+humiliation born of self-knowledge—knowledge scornfully admitted and
+defied with every breath—but no longer denied.</p>
 
-<p>She <i>was</i> as others were&mdash;fashioned of that same and common clay,
+<p>She <i>was</i> as others were—fashioned of that same and common clay,
 capable of the lesser emotions, shamefully and incredibly conscious of
-them&mdash;so keenly, so incomprehensibly, that, at one unthinkable instant,
+them—so keenly, so incomprehensibly, that, at one unthinkable instant,
 they had obscured and were actually threatening to obliterate the things
 of the mind.</p>
 
@@ -2403,7 +2403,7 @@ strange moment, at the door, the moment that man's enemy had been
 awaiting, to find her unprepared?</p>
 
 <p>Wretched, humiliated, she bowed her head above the flowers and silver on
-her dresser&mdash;the fairest among the Philistines who had so long
+her dresser—the fairest among the Philistines who had so long
 unconsciously thanked God that she was not like other women in the homes
 of Gath and in the sinful streets of Ascalon.</p>
 <hr class="chap x-ebookmaker-drop" />
@@ -2429,7 +2429,7 @@ members of that important diplomatic body found his door locked, after
 dinner, though his light sometimes brightened the transom until morning.</p>
 
 <p>Westguard, after the final rupture with his aunt, had become a soured
-hermit&mdash;sourer because of the low motives of the public which was buying
+hermit—sourer because of the low motives of the public which was buying
 his book by the thousands and reading it for the story, exclusively.</p>
 
 <p>His aunt had cast him off; to him she was the overfed embodiment of
@@ -2444,7 +2444,7 @@ declining years.</p>
 
 <p>So, after dinner, he, too, retired to seclusion behind bolted doors,
 pondering darkly on a philosophic novel which should be no novel at all
-but a dignified and crushing rebuke to mankind&mdash;a solid slice of moral
+but a dignified and crushing rebuke to mankind—a solid slice of moral
 cake thickly frosted with social economics, heavy with ethical plums,
 and without any story to it whatever.</p>
 
@@ -2456,8 +2456,8 @@ accustomed to embellish and splash in. O'Hara, inclining more toward
 sporting circles, noticed Quarren's absence less; but Lacy, after the
 first week, demanded an explanation at the dinner-table.</p>
 
-<p>"You spoiled a party for Mrs. Lannis," he said&mdash;"and Winnifred Miller
-was almost in tears over the charity tableaux&mdash;&mdash;"</p>
+<p>"You spoiled a party for Mrs. Lannis," he said—"and Winnifred Miller
+was almost in tears over the charity tableaux——"</p>
 
 <p>"I wrote them both in plenty of time, Jack."</p>
 
@@ -2485,20 +2485,20 @@ sicken you and the public make you ill. Solitude is the only remedy."</p>
 <p>"Not for me," said Quarren; "I could breakfast, lunch, and dine with and
 on the public; and I'm laying plans to do it."</p>
 
-<p>"They'll turn your stomach&mdash;&mdash;"</p>
+<p>"They'll turn your stomach——"</p>
 
 <p>"Oh, dry up, Karl!" said O'Hara; "there's a medium between extremes
-where you can get a good sportin' chance at anythin'&mdash;horse, dog,
-girl&mdash;anythin' you fancy. You'd like some of my friends, now,
-Ricky!&mdash;they're a good sort, all game, all jolly, all interestin' as
-hell&mdash;&mdash;"</p>
+where you can get a good sportin' chance at anythin'—horse, dog,
+girl—anythin' you fancy. You'd like some of my friends, now,
+Ricky!—they're a good sort, all game, all jolly, all interestin' as
+hell——"</p>
 
 <p>"<i>I</i> don't want to meet any cock-fighters," growled Westguard.</p>
 
-<p>"They're all right, too&mdash;but there are all kinds of interestin' people
-in my circles&mdash;writers like Karl, huntin' people, a professional here
-and there&mdash;and then there's that fascinatin' Mrs. Wyland-Baily, the best
-trap-shot&mdash;&mdash;"</p>
+<p>"They're all right, too—but there are all kinds of interestin' people
+in my circles—writers like Karl, huntin' people, a professional here
+and there—and then there's that fascinatin' Mrs. Wyland-Baily, the best
+trap-shot——"</p>
 
 <p>"Trap-shot," repeated Westguard in disgust, and took his cigar and
 himself into seclusion.</p>
@@ -2513,7 +2513,7 @@ added persuasively.</p>
 
 <hr class="tb" />
 
-<p>He wrote them&mdash;all the business letters he could think of, concentrating
+<p>He wrote them—all the business letters he could think of, concentrating
 his thoughts as much as possible. Afterward he lay down on the lounge
 with a book, and remained there for an hour, although he changed books
 every few minutes. This was becoming a bad habit. But it was difficult
@@ -2523,7 +2523,7 @@ cushions.</p>
 
 <p>This wouldn't do either: he racked his brain for further employment,
 found excuses for other business letters, wrote them, then attacked a
-pile of social matters&mdash;notes and letters heretofore deliberately
+pile of social matters—notes and letters heretofore deliberately
 neglected to the ragged edge of decency.</p>
 
 <p>He replied to them all, and invariably in the negative.</p>
@@ -2539,7 +2539,7 @@ endurance now. And at last he weakened, and wrote to her once more:</p>
 <hr class="tb" />
 
 <p>
-"<span class="smcap">My dear Mrs. Leeds</span>&mdash;<br />
+"<span class="smcap">My dear Mrs. Leeds</span>—<br />
 </p>
 
 <div class="blockquot">
@@ -2567,7 +2567,7 @@ Mrs. Leeds was not at home and he had left the note as directed.</p>
 
 <p>The night was a white one. He did not feel very well when he sat
 scanning the morning paper over his coffee. Recently he had formed the
-custom of reading two columns only in the paper&mdash;Real Estate News and
+custom of reading two columns only in the paper—Real Estate News and
 Society. In the latter column Strelsa usually figured.</p>
 
 <p>She figured as usual this morning; and he read the fulsome stuff
@@ -2590,13 +2590,13 @@ Strelsa Leeds face to face. She said, coolly amiable:</p>
 <p>"Is it good policy for a young man to drop out of sight? Our world
 forgets over-night."</p>
 
-<p>He laughed: "Something similar has been intimated<span class="pagenum" id="Page_194">[Pg 194]</span> to me by others&mdash;but
+<p>He laughed: "Something similar has been intimated<span class="pagenum" id="Page_194">[Pg 194]</span> to me by others—but
 less gently. I'm afraid I've offended some people."</p>
 
 <p>"Oh, so you have already been disciplined?"</p>
 
 <p>"Verbally trounced, admonished, and still smarting under the displeasure
-of the powers that reign. They seem to resent my Sunday out&mdash;yet even
+of the powers that reign. They seem to resent my Sunday out—yet even
 their other domestics have that. And it's the first I've taken in three
 years. I think I'll have to give notice to my Missus."</p>
 
@@ -2606,7 +2606,7 @@ observed indifferently.</p>
 <p>"I <i>am</i> that spectre, Mrs. Leeds."</p>
 
 <p>"You certainly look pallid enough for any disembodied rôle. You have not
-been ill, by any chance?"&mdash;carelessly.</p>
+been ill, by any chance?"—carelessly.</p>
 
 <p>"Not at all, thank you. Rude health and I continue to link arms."</p>
 
@@ -2618,7 +2618,7 @@ explained gravely.</p>
 
 <p>She lifted her eyebrows: "Yet you are here this afternoon."</p>
 
-<p>"Oh, yes. Charity has not yet palled on my palate&mdash;perhaps because I
+<p>"Oh, yes. Charity has not yet palled on my palate—perhaps because I
 need so much myself."</p>
 
 <p>"I have never considered you an object of charity."</p>
@@ -2636,11 +2636,11 @@ with decision.</p>
 
 <p>"Certainly."</p>
 
-<p>"I scarcely know how to take your&mdash;generosity."</p>
+<p>"I scarcely know how to take your—generosity."</p>
 
 <p>"I offer none. There is no occasion for generosity or for the exercise
 of any virtue, cardinal or otherwise. You have not offended me, nor I
-you&mdash;I trust.... Have I?"</p>
+you—I trust.... Have I?"</p>
 
 <p>"No," he said.</p>
 
@@ -2649,7 +2649,7 @@ groups which presently mingled, definitely separating her from Quarren
 unless either he or she chose to evade the natural trend of things.
 Neither made the effort. Then Sir Charles Mallison joined her, and
 Quarren, smilingly accepting that gentleman's advent as his own congé,
-took his leave of Strelsa and went his way&mdash;which chanced, also, to be
+took his leave of Strelsa and went his way—which chanced, also, to be
 the way of Mrs. Lester Caldera, very fetching in lilac gown and hat.</p>
 
 <p>Susanne Lannis, lips slightly curling, looked after them, touching
@@ -2672,7 +2672,7 @@ going to behave."</p>
 <p>"Such scandal!" laughed Chrysos Lacy. "How<span class="pagenum" id="Page_196">[Pg 196]</span> many of us can afford to
 turn our backs to the rest of the cage even for an instant? Sir Charles,
 I simply don't dare to go away. Otherwise I'd purchase several of those
-glittering articles yonder&mdash;whatever they are. Do you happen to know?"</p>
+glittering articles yonder—whatever they are. Do you happen to know?"</p>
 
 <p>"Automatic revolvers. The cartridges are charged with Japanese perfumes.
 Did you never see one?" he asked, turning to Strelsa. But she was not
@@ -2699,7 +2699,7 @@ gloved hand. "Is it really for me? And why?"</p>
 
 <p>"Are you timid about firearms?" he asked, jestingly.</p>
 
-<p>"No.... I don't know anything about them&mdash;except to keep my finger away
+<p>"No.... I don't know anything about them—except to keep my finger away
 from the trigger. I know enough to do that."</p>
 
 <p>He supposed that she also was jesting, and her fastidious handling of
@@ -2730,7 +2730,7 @@ herself.</p>
 of her unusual brilliancy and beauty, surprised and interested in the
 sudden revelation of powers within her still unexercised, she felt
 herself, for the first time in her life, in contact with things
-heretofore impalpable&mdash;and, in spirit, with delicate fingers, she
+heretofore impalpable—and, in spirit, with delicate fingers, she
 gathered up instinctively those intangible threads with which man is
 guided as surely as though driven in chains of steel.</p>
 
@@ -2738,29 +2738,29 @@ guided as surely as though driven in chains of steel.</p>
 
 <p>And all the while she was aware of Quarren's boyish head bending almost
 too near to Cyrille Caldera's over the trays of antique jewels; and all
-the while she was conscious of the transfiguration in process&mdash;that not
+the while she was conscious of the transfiguration in process—that not
 only a new self was being evolved for her out of the débris of the old,
-but that the world itself was changing around her&mdash;and a new Heaven and
-a new earth were being born&mdash;and a new hell.</p>
+but that the world itself was changing around her—and a new Heaven and
+a new earth were being born—and a new hell.</p>
 
 <p>That evening she fought it out with herself with a sort of deadly
 intelligence. Alone in her room, seated, and facing her mirrored gaze
 unflinchingly, she stated her case, minutely, to herself from beginning
-to end; then called the only witness for the prosecution&mdash;herself&mdash;and
+to end; then called the only witness for the prosecution—herself—and
 questioned that witness without mercy.</p>
 
 <p>Did she care for Quarren? Apparently. How much? A great deal. Was she in
 love with him? She could not answer. Wherein did he differ from other
-men she knew&mdash;Sir Charles, for example? She only knew that he <i>was</i>
+men she knew—Sir Charles, for example? She only knew that he <i>was</i>
 different. Perhaps he was nobler? No. More intelligent? No. Kinder? No.
 More admirable? No. More gentle, more sincere, less selfish? No. Did he,
-as a man, compare favorably with other men&mdash;Sir Charles for example? The
+as a man, compare favorably with other men—Sir Charles for example? The
 comparison was not in Quarren's favor.</p>
 
 <p>Wherein, then, lay her interest in him? She could not answer. Was she
 perhaps sorry for him? Very. Why? Because she believed him capable of
 better things. Then the basis of her regard for him was founded on pity.
-No; because from the beginning&mdash;even before he had unmasked&mdash;she had
+No; because from the beginning—even before he had unmasked—she had
 been sensible of an interest in him different from any interest she had
 ever before felt for any man.</p>
 
@@ -2785,14 +2785,14 @@ When?</p>
 own face grew pink: but she answered, looking the shadowy witness
 steadily in the eyes:</p>
 
-<p>"When he took my hand at the door&mdash;and during&mdash;whatever
-happened&mdash;afterward."</p>
+<p>"When he took my hand at the door—and during—whatever
+happened—afterward."</p>
 
 <p>And she excused the witness and turned her back to the looking-glass.</p>
 
-<p>The only witness for the defence was the accused&mdash;unless her own heart
-were permitted to testify. Or&mdash;and there seemed to be some slight
-confusion here&mdash;<i>was</i> Quarren on trial? Or was she herself?</p>
+<p>The only witness for the defence was the accused—unless her own heart
+were permitted to testify. Or—and there seemed to be some slight
+confusion here—<i>was</i> Quarren on trial? Or was she herself?</p>
 
 <p>This threatened to become a serious question; she strove to think
 clearly, to reason; but only evoked the pale, amused face of Quarren
@@ -2803,47 +2803,47 @@ the witness box.</p>
 <p>"Ricky," she said, "do you really love me?"</p>
 
 <p>But the clear-cut, amused face seemed to mock her question with the
-smile she knew so well&mdash;so well, alas!</p>
+smile she knew so well—so well, alas!</p>
 
-<p>"Why are you unworthy?" she said again&mdash;"you who surely are equipped for
+<p>"Why are you unworthy?" she said again—"you who surely are equipped for
 a nobler life. What is it in you that I have responded to? If a woman is
 so colourless as to respond merely to love in the abstract, she is worth
 nothing better, nothing higher, than what she has evoked. For you are no
 better than other men, Ricky; indeed you are less admirable than many;
 and to compare you to Sir Charles is not advantageous to you, poor
-boy&mdash;poor boy."</p>
+boy—poor boy."</p>
 
 <p>In vain she strove to visualise Sir Charles; she could not. All she
 could do was to mentally enumerate his qualities; and she did so, the
 amused face of Quarren looking on at her from out of empty space.</p>
 
-<p>"Ricky, Ricky," she said, "am I no better than that?&mdash;am I fit only for
-such a response?&mdash;to find the contact of your hand so wonderful?&mdash;to
-thrill with the consciousness of your nearness&mdash;to let my senses drift,
-contented merely by your touch&mdash;yielding to the charm of it&mdash;suffering
-even your lips' embrace&mdash;&mdash;"</p>
+<p>"Ricky, Ricky," she said, "am I no better than that?—am I fit only for
+such a response?—to find the contact of your hand so wonderful?—to
+thrill with the consciousness of your nearness—to let my senses drift,
+contented merely by your touch—yielding to the charm of it—suffering
+even your lips' embrace——"</p>
 
 <p>She shuddered slightly, drawing one hand across her eyes, then sitting
 straight, she faced his smiling phantom, resolute to end it now forever.</p>
 
 <p>"If I am such a woman," she said, "and you are the kind of man I know
-you to be&mdash;then is it time for me to fast and pray, lest I enter into
+you to be—then is it time for me to fast and pray, lest I enter into
 temptation.... Into the one temptation I have never before known,
-Ricky&mdash;and which, in my complacency and pride I never dreamed that I
+Ricky—and which, in my complacency and pride I never dreamed that I
 should encounter.</p>
 
 <p><span class="pagenum" id="Page_201">[Pg 201]</span></p>
 
 <p>"And it is coming to that!... A girl must be honest with herself or all
 life is only the same smiling lie. I'm ashamed to be honest, Ricky; but
-I must be. You are not very much of a man&mdash;otherwise I might find some
-reason for caring: and now there is none; and yet&mdash;I care&mdash;God knows
-why&mdash;or what it is in you that I care for!&mdash;But I do&mdash;I am beginning to
-care&mdash;and I don't know why; I&mdash;don't&mdash;know why&mdash;&mdash;".</p>
+I must be. You are not very much of a man—otherwise I might find some
+reason for caring: and now there is none; and yet—I care—God knows
+why—or what it is in you that I care for!—But I do—I am beginning to
+care—and I don't know why; I—don't—know why——".</p>
 
 <p>She dropped her face in her hands, sitting there bowed low over her
 knees. And there, hour after hour she fought it out with herself and
-with the amused spectre ever at her elbow&mdash;so close at moments that some
+with the amused spectre ever at her elbow—so close at moments that some
 unaroused nerve fell a-trembling in its sleep, threatening to awaken
 those quiet senses that she already feared for their unknown powers.</p>
 
@@ -2872,7 +2872,7 @@ from her pillows; and for one moment he felt seriously inclined to run.</p>
 
 <p>"Where have you been?" she wheezed.</p>
 
-<p>"Nowhere in particu&mdash;&mdash;"</p>
+<p>"Nowhere in particu——"</p>
 
 <p>"I know damn well you've been nowhere," she burst out. "Molly Wycherly's
 dance went to pieces because she was fool enough to trust things to you.
@@ -2882,9 +2882,9 @@ trick elephant, too!"</p>
 <p>Quarren looked politely distressed.</p>
 
 <p>"And there are a dozen hostesses perfectly furious with you," continued
-the old lady, pounding the pillows with a fat arm&mdash;"parties of all sorts
+the old lady, pounding the pillows with a fat arm—"parties of all sorts
 spoiled, idiocies committed, dinners either commonplace or blank
-failures&mdash;what the devil possesses you to behave this way?"</p>
+failures—what the devil possesses you to behave this way?"</p>
 
 <p>"I'm tired," he said, politely.</p>
 
@@ -2893,13 +2893,13 @@ failures&mdash;what the devil possesses you to behave this way?"</p>
 <p>He smiled:</p>
 
 <p>"Oh, the place suits, Mrs. Sprowl; I haven't any complaint; and the work
-and wages are easy; and it's comfortable below-stairs. But&mdash;I'm just
+and wages are easy; and it's comfortable below-stairs. But—I'm just
 tired."</p>
 
 <p>"What are you talking about?"</p>
 
 <p>"I'm talking <i>about</i> my employers, and I'm talking <i>like</i> the social
-upper-servant that I am&mdash;or was. I'm merely giving a respectable
+upper-servant that I am—or was. I'm merely giving a respectable
 warning; that is the airy purport of my discourse, Mrs. Sprowl."</p>
 
 <p>"Do you know what you're saying?"</p>
@@ -2927,11 +2927,11 @@ anything?"</p>
 <p>"That also is why," he said pleasantly. "I am ambitious to be out of
 livery and see what my own kind will do to me."</p>
 
-<p>"Well, you'll see!" she threatened&mdash;"you'll see what we'll do to
-you&mdash;&mdash;"</p>
+<p>"Well, you'll see!" she threatened—"you'll see what we'll do to
+you——"</p>
 
 <p>"<i>You're</i> not my kind. I always supposed you were, but you all knew
-better from the day I took service with you&mdash;&mdash;"</p>
+better from the day I took service with you——"</p>
 
 <p>"Ricky!"</p>
 
@@ -2941,7 +2941,7 @@ family affiliations with the very amiable people who found me useful.
 Only, in common with them, I had the inherent taste for idleness and the
 genius for making it endurable to you all. So you welcomed me very
 warmly; and you have been very kind to me.... But, somewhere or
-other&mdash;in some forgotten corner of me&mdash;an odd and old-fashioned idea
+other—in some forgotten corner of me—an odd and old-fashioned idea
 awoke the other day.... I think perhaps it awoke when you reminded me
 that to serve<span class="pagenum" id="Page_204">[Pg 204]</span> you was one thing and to marry among you something very
 different."</p>
@@ -2951,30 +2951,30 @@ didn't say or intimate or dream any such thing! You know perfectly well
 you're not only with us but <i>of</i> us. Nobody ever imagined otherwise. But
 you can't marry any girl you pick out. Sometimes she won't; sometimes
 her family won't. It's the same everywhere. You have no money. Of course
-I intend that you shall eventually marry money&mdash;What the devil are you
+I intend that you shall eventually marry money—What the devil are you
 laughing at?"</p>
 
-<p>"I beg your pardon&mdash;&mdash;"</p>
+<p>"I beg your pardon——"</p>
 
 <p>"I said that you would marry well. Was that funny? I also said,
-once&mdash;and I repeat it now, that I have my own plans for one or two
-girls&mdash;Strelsa Leeds included. I merely asked you to respect my wishes
+once—and I repeat it now, that I have my own plans for one or two
+girls—Strelsa Leeds included. I merely asked you to respect my wishes
 in that single matter; and bang! you go off and blow up and maroon
 yourself and sulk until nobody knows what's the matter with you. Don't
-be a fool. Everybody likes you; every girl <i>can't</i> love you&mdash;but I'll
-bet many of 'em do.... Pick one out and come to me&mdash;if that's your
+be a fool. Everybody likes you; every girl <i>can't</i> love you—but I'll
+bet many of 'em do.... Pick one out and come to me—if that's your
 trouble. Go ahead and pick out what you fancy; and ten to one it will be
 all right, and between you and me we'll land the little lady!"</p>
 
-<p>"You're tremendously kind&mdash;&mdash;"</p>
+<p>"You're tremendously kind——"</p>
 
-<p>"I know I am. I'm always doing kindnesses&mdash;and nobody likes me, and
-they'd bite my head off, every one of 'em&mdash;if they weren't afraid it
+<p>"I know I am. I'm always doing kindnesses—and nobody likes me, and
+they'd bite my head off, every one of 'em—if they weren't afraid it
 would disagree with them," she added grimly.</p>
 
 <p>Quarren rose and came over to the bedside.</p>
 
-<p>"Good-bye, Mrs. Sprowl," he said. "And&mdash;I like you&mdash;somehow&mdash;I really
+<p>"Good-bye, Mrs. Sprowl," he said. "And—I like you—somehow—I really
 do."</p>
 
 <p>"The devil you do," said the old lady.</p>
@@ -2983,9 +2983,9 @@ do."</p>
 
 <p>"It's a curious fact," he insisted, smiling.</p>
 
-<p>"Get out with you, Ricky! And I want you to come&mdash;&mdash;"</p>
+<p>"Get out with you, Ricky! And I want you to come——"</p>
 
-<p>"No&mdash;please."</p>
+<p>"No—please."</p>
 
 <p>"What?"</p>
 
@@ -2999,12 +2999,12 @@ resemble."</p>
 <p>"That's a damned insolent remark!" she gasped.</p>
 
 <p>"Not meant to be. <i>You</i> are real enough, Heaven knows. But," and his
-smile faded&mdash;"I've taken a month off to think it out. And, do you know,
+smile faded—"I've taken a month off to think it out. And, do you know,
 thinking being an unaccustomed luxury, I've enjoyed it. Imagine my
 delight and surprise, Mrs. Sprowl, when I discovered that my leisurely
-reflections resulted in the discovery that I had a mind&mdash;a real
-one&mdash;capable of reason and conclusions. And so when I actually came to a
-conclusion my joy knew no bounds&mdash;&mdash;"</p>
+reflections resulted in the discovery that I had a mind—a real
+one—capable of reason and conclusions. And so when I actually came to a
+conclusion my joy knew no bounds——"</p>
 
 <p>"Ricky! Stop those mental athletics! Do you hear? I've a toothache and a
 backache and I can't stand 'em!"</p>
@@ -3053,14 +3053,14 @@ over night and all Philistia is smitten by the sun.</p>
 <p>And all the meanness and shabbiness and effrontery of the monstrous
 city, all its civic pretence and tarnished ostentation are suddenly
 revealed when the summer sun blazes over Ascalon. Wherefore the daintier
-among the Philistines flee&mdash;idler, courtier, dangler and squire of
-dames&mdash;not to return until the first snow-flakes fall and the gray veil
+among the Philistines flee—idler, courtier, dangler and squire of
+dames—not to return until the first snow-flakes fall and the gray veil
 of November descends once more over the sorry sham of Ascalon.</p>
 
 <p>Out of the inner temple, his ears still ringing with the noise of the
 drones, Quarren had gone forth. And already, far away in the outer
 sunshine, he could see real people at work and at play, millions and
-millions of them&mdash;and a real sky overhead edging far horizons.</p>
+millions of them—and a real sky overhead edging far horizons.</p>
 
 <p>He began real life once more in a bad way, financially; his money being
 hopelessly locked up in Tappan-Zee Park, a wooded and worthless tract of
@@ -3071,7 +3071,7 @@ Caldera was to finance for him.</p>
 such promise to anybody; which surprised and disconcerted Quarren who
 had no money with which to build sewers, roads, and electric<span class="pagenum" id="Page_208">[Pg 208]</span> plants.
 And he began to realise how carelessly he had drifted into the
-enterprise&mdash;how carelessly he had drifted into everything and past
+enterprise—how carelessly he had drifted into everything and past
 everything for the last five years.</p>
 
 <p>After a hunt for a capitalist among and outside his circle of friends
@@ -3097,7 +3097,7 @@ grief of the diplomats domiciled there, and established himself in the
 back parlour and extension of the Lexington Avenue house, ready at all
 moments now for business or for sleep. Neither bothered him excessively.</p>
 
-<p>He wrote no more notes to Strelsa Leeds&mdash;that is, he posted no more,
+<p>He wrote no more notes to Strelsa Leeds—that is, he posted no more,
 however many he may have composed. Rumours from the inner temple
 concerning her and Langly Sprowl and Sir Charles Mallison drifted out
 into the real world every day or so. But he<span class="pagenum" id="Page_209">[Pg 209]</span> never went back to the
@@ -3114,33 +3114,33 @@ now she wore the gaunt mask of poverty, but Quarren continued to ignore
 her, because to him, there was no real menace in her skinny grin, no
 real tragedy in what she threatened.</p>
 
-<p>Real tragedy lay in something very different&mdash;perhaps in manhood awaking
+<p>Real tragedy lay in something very different—perhaps in manhood awaking
 from ignoble lethargy to learn its own degeneracy in a young girl's
 scornful eyes.</p>
 
 <p>All day long he sat in his office attending to the trivial business that
-came into it&mdash;not enough so far to give him a living.</p>
+came into it—not enough so far to give him a living.</p>
 
 <p>In the still spring evenings he retired to his quarters in the back
 parlour, bathed, dressed, looking out at the cats on the back fences.
 Then he went forth to dine either at the Legation or with some one of
 the few friends he had cared to retain in that magic-lantern world which
-he at last had found uninhabitable&mdash;a world in which few virile men
-remain very long&mdash;fewer and fewer as the years pass on. For the gilding
+he at last had found uninhabitable—a world in which few virile men
+remain very long—fewer and fewer as the years pass on. For the gilding
 on the temple dome is peeling off; and the laughter is dying out, and
 the hum of the drones sounds drowsy like unreal voices heard in summer
 dreams.</p>
 
-<p>"It is the passing of an imbecile society," declaimed<span class="pagenum" id="Page_210">[Pg 210]</span> Westguard&mdash;"the
-dying sounds of its meaningless noise&mdash;the first omens of a silence
+<p>"It is the passing of an imbecile society," declaimed<span class="pagenum" id="Page_210">[Pg 210]</span> Westguard—"the
+dying sounds of its meaningless noise—the first omens of a silence
 which foretells annihilation. Out of chaos will gradually emerge the
-elements of a real society&mdash;the splendid social and intellectual
-brotherhood of the future&mdash;&mdash;"</p>
+elements of a real society—the splendid social and intellectual
+brotherhood of the future——"</p>
 
 <p>"See my forthcoming novel," added Lacy, "$1.35 net, for sale at all
-booksellers or sent post-paid on receipt of&mdash;&mdash;"</p>
+booksellers or sent post-paid on receipt of——"</p>
 
-<p>"You little fashionable fop!" growled Westguard&mdash;"there's a winter
+<p>"You little fashionable fop!" growled Westguard—"there's a winter
 coming for all butterflies!"</p>
 
 <p>"I've seen 'em dancing over the snow on a mild and sunny day," retorted
@@ -3157,10 +3157,10 @@ solidity.</p>
 <p>"Every annual wave pushes the flotsam of the year before toward the
 solid land. The acquaintance with sordid things is the first real
 impulse toward education. Some day there will be no squalor in the
-land&mdash;neither the physical conditions in our slums nor the arid
+land—neither the physical conditions in our slums nor the arid
 intellectual deserts within the social frontiers."</p>
 
-<p>"But the waves will accomplish that&mdash;not your very worthy novels," said
+<p>"But the waves will accomplish that—not your very worthy novels," said
 Lacy, impudently.</p>
 
 <p>"If you call me 'worthy' I'll bat you on the head," roared Westguard,
@@ -3184,18 +3184,18 @@ philosopher, Karl, but you really could write a good story if you tried.
 Get your people into action. That's the game."</p>
 
 <p>O'Hara nodded. "Interestin' people, in books and outside, are always
-doin' things, not talkin'," he said&mdash;"like Sir Charles quietly drawin'
+doin' things, not talkin'," he said—"like Sir Charles quietly drawin'
 four cards to a kicker and sayin' nothin'."</p>
 
-<p>"&mdash;Like old Dankmere, yonder, playing 'Madame Sherry' and not trying to
+<p>"—Like old Dankmere, yonder, playing 'Madame Sherry' and not trying to
 tell us why human beings enjoy certain sounds known as harmonies, but
-just keeping busy beating the box&mdash;&mdash;"</p>
+just keeping busy beating the box——"</p>
 
-<p>"&mdash;Like a pretty woman who is contented to be as attractive and cunnin'
+<p>"—Like a pretty woman who is contented to be as attractive and cunnin'
 as she can be, and not stoppin' to explain the anatomy of romantic love
 and personal beauty," added O'Hara.</p>
 
-<p>"&mdash;Like&mdash;&mdash;"</p>
+<p>"—Like——"</p>
 
 <p>"For Heaven's sake give me a stack of chips and shut up!" shouted
 Westguard, jumping to his feet and striding to the table. "Everybody on
@@ -3276,7 +3276,7 @@ musical comedy of sorts? Didn't I even do a turn in it myself?"</p>
 
 <p>"Dankmere ought to have filled his show full of flossy flappers,"
 insisted Lacy. "Who wants to see an Earl dance and sing? Next time I'll
-manage the company for you, Dankmere&mdash;&mdash;"</p>
+manage the company for you, Dankmere——"</p>
 
 <p>"There'll be no next time," said Dankmere, scanning his cards. "I'm done
 for," he added, dramatically, letting his own ante go.</p>
@@ -3292,7 +3292,7 @@ sympathetically.</p>
 
 <p>"The matter is that I don't want the sort that want me. Somebody's
 ruined the business in the States. I suppose I might possibly induce a
-Broadway show-girl&mdash;&mdash;"</p>
+Broadway show-girl——"</p>
 
 <p>The little Earl got up and began to wander around, hands in his pockets,
 repeating:</p>
@@ -3308,11 +3308,11 @@ accompaniment:</p>
 <div class="poetry">
   <div class="stanza">
     <div class="verse indent0">"I sigh for the maiden I never have seen,</div>
-    <div class="verse indent0">I'll make her my countess whatever she's been&mdash;</div>
+    <div class="verse indent0">I'll make her my countess whatever she's been—</div>
     <div class="verse indent0">Typewriter, manicure, heiress or queen,</div>
     <div class="verse indent0">Aged fifty or thirty or lovely eighteen,</div>
     <div class="verse indent0">Redundant and squatty, or scraggy and lean,</div>
-    <div class="verse indent0">Generous spendthrift or miserly mean&mdash;</div>
+    <div class="verse indent0">Generous spendthrift or miserly mean—</div>
     <div class="verse indent0">I sigh for the maiden I never have seen</div>
     <div class="verse indent0">Provided she's padded with wads of Long Green!"</div>
   </div>
@@ -3321,7 +3321,7 @@ accompaniment:</p>
 
 <p>Still singing the air he picked up a silk hat and walking-stick and
 began to dance, rather lightly and gracefully, his sunken, heavy-lidded
-eyes fixed nonchalantly on space&mdash;his nimble little feet making no sound
+eyes fixed nonchalantly on space—his nimble little feet making no sound
 on the floor as he swung, swayed, and capered under the electric light
 timing his agile steps to his own singing.</p>
 
@@ -3340,8 +3340,8 @@ vaudeville and let my creditors howl."</p>
 lordship made no bones about it.</p>
 
 <p>"They certainly did. And a fine mess I've made of it, haven't I? No
-decent girl wants me&mdash;though why, I don't know, because I'm decent
-enough as men go. But your newspapers make fun of me and my title&mdash;and I
+decent girl wants me—though why, I don't know, because I'm decent
+enough as men go. But your newspapers make fun of me and my title—and I
 might as well cut away to Dankmere Tarns and let 'em pick my carcass
 clean."</p>
 
@@ -3369,15 +3369,15 @@ anything about pictures."</p>
 
 <p>"Don't you know their value?"</p>
 
-<p>"No, I don't. But I fancy the good ones were sold off long ago&mdash;twenty
-years ago I believe. There was<span class="pagenum" id="Page_216">[Pg 216]</span> a sale&mdash;a lot of rubbish of sorts. I
+<p>"No, I don't. But I fancy the good ones were sold off long ago—twenty
+years ago I believe. There was<span class="pagenum" id="Page_216">[Pg 216]</span> a sale—a lot of rubbish of sorts. I
 took it for granted that Lister's people cleaned out everything worth
 taking."</p>
 
 <p>"When you go back," said Sir Charles, "inspect that rubbish again.
 Perhaps Lister's people overlooked enough to get you out of your
 financial difficulties. Pictures that sold for £100 twenty years ago
-might bring £1,000 to-day. It's merely a suggestion, Dankmere&mdash;if you'll
+might bring £1,000 to-day. It's merely a suggestion, Dankmere—if you'll
 pardon it."</p>
 
 <p>"And a good one," added O'Hara. "I know a lot of interestin' people and
@@ -3387,7 +3387,7 @@ amount of money. Sting 'em, Dankmere. Get to 'em!"</p>
 <p>"You might send for some of your pictures," said Lacy, "and have a shot
 at the auction-mad amateur. He's too easy."</p>
 
-<p>"And pay duty and storage and gallery hire and auction fees!&mdash;no,
+<p>"And pay duty and storage and gallery hire and auction fees!—no,
 thanks," replied the little Earl, cautiously. "I've burnt my bally
 fingers too often in schemes."</p>
 
@@ -3450,7 +3450,7 @@ Karl, that I'll make it ten more to draw cards. Are you all staying in?"</p>
 
 <hr class="tb" />
 
-<p>Before the party broke up&mdash;and it was an early one&mdash;Lord Dankmere turned
+<p>Before the party broke up—and it was an early one—Lord Dankmere turned
 to Quarren.</p>
 
 <p>"I'll drop in at your office, if I may, some morning," he said. "May I?"</p>
@@ -3461,24 +3461,24 @@ you are welcome to send for those pictures and store them in my back
 parlour until you can find a purchaser."</p>
 
 <p>"It's an idea, isn't it?" mused his lordship. "Now I don't suppose you
-happen to know anything about such rubbish, do you?&mdash;pictures and that
+happen to know anything about such rubbish, do you?—pictures and that
 sort. What?"</p>
 
-<p>"Why&mdash;yes&mdash;I do, in a way."</p>
+<p>"Why—yes—I do, in a way."</p>
 
 <p>"The devil you do! But then I've always been told that you know
-something about everything&mdash;&mdash;"</p>
+something about everything——"</p>
 
 <p>"Very, very little," said Quarren, laughing. "In an ignorant world
 smatterings are reverenced. But the fashionable Philistine of yesterday,
 who used to boast of his ignorance regarding things artistic and
-intellectual, is becoming a little ashamed of his ignorance&mdash;&mdash;"</p>
+intellectual, is becoming a little ashamed of his ignorance——"</p>
 
 <p>Dankmere, reddening, said bluntly:</p>
 
 <p>"That applies to me; doesn't it?"</p>
 
-<p>"I beg your pardon!&mdash;I didn't mean it that way&mdash;&mdash;"</p>
+<p>"I beg your pardon!—I didn't mean it that way——"</p>
 
 <p>"You're right, anyway. I'm damnably ignorant.... See here, Quarren, if I
 send over for some of those pictures of mine, will you give me your
@@ -3490,7 +3490,7 @@ mean," said Quarren, much amused.</p>
 
 <p>They shook hands as Sir Charles came up to make his adieux.</p>
 
-<p>"Good-bye," he said to Quarren. "I'm off to Newport to-morrow. And&mdash;I&mdash;I
+<p>"Good-bye," he said to Quarren. "I'm off to Newport to-morrow. And—I—I
 promised to ask you to come with me."</p>
 
 <p>"Where?"</p>
@@ -3530,13 +3530,13 @@ according to the newspapers, her engagement to Sir Charles was expected
 to be announced at any moment.</p>
 
 <p>When Quarren picked up the newspapers from his office desk next morning
-he found the whole story there&mdash;a story to which he had become
+he found the whole story there—a story to which he had become
 accustomed.</p>
 
 <p>But the next day, the papers repeated the news. And it remained, for the
 first time, uncontradicted by<span class="pagenum" id="Page_222">[Pg 222]</span> anybody. All that morning he sat at his
 desk staring at her picture, reproduced in half-tones on the first page
-of every newspaper in town&mdash;stared at it, and at the neighbouring
+of every newspaper in town—stared at it, and at the neighbouring
 likeness of Sir Charles in the uniform of his late regiment; read once
 more of Strelsa's first marriage with all its sequence of misery and
 degradation; read fulsome columns celebrating her beauty, her
@@ -3546,7 +3546,7 @@ in the world.</p>
 <p>[Illustration: "Once more, according to the newspapers, her engagement
 to Sir Charles was expected to be announced."]</p>
 
-<p>He read, also, all about Sir Charles Mallison, V.C.&mdash;the long record of
+<p>He read, also, all about Sir Charles Mallison, V.C.—the long record of
 his military service, his wealth and the dignified simplicity of his
 life. He read about his immense popularity in England, his vast but
 unostentatious charities, his political and social status.</p>
@@ -3554,15 +3554,15 @@ unostentatious charities, his political and social status.</p>
 <p>To Quarren it all meant nothing more definite than a stupid sequence of
 printed words; and he dropped his blond head into both hands and gazed
 out into the sunshine. And presently he remembered the golden dancer
-laughing at him from under her dainty mask&mdash;years and years ago: and
+laughing at him from under her dainty mask—years and years ago: and
 then he thought of the woman whose smooth young hands once seemed to
-melt so sweetly against his&mdash;thought of her gray eyes tinged with
-violet, and her hair and mouth and throat&mdash;and her cheek faintly
-fragrant against his&mdash;a moment's miracle&mdash;and then, the end&mdash;&mdash;</p>
+melt so sweetly against his—thought of her gray eyes tinged with
+violet, and her hair and mouth and throat—and her cheek faintly
+fragrant against his—a moment's miracle—and then, the end——</p>
 
 <p>He made a quick, aimless movement as though impatiently escaping sudden
 pain; cleared his sun-dazzled eyes and began, half blindly, to turn over
-his morning's letters&mdash;circulars, bills, business matters&mdash;and suddenly
+his morning's letters—circulars, bills, business matters—and suddenly
 came upon a letter from her.</p>
 
 <p>For a while he merely gazed at it, incredulous of its reality.</p>
@@ -3583,13 +3583,13 @@ be kind enough to bring you with him when he came to 'Skyland.'</p>
 and if this is so, I am sorry. We have been such good friends that
 I supposed I might venture to send you such a message.</p>
 
-<p>"But perhaps I ought to have written it to you instead&mdash;I don't
+<p>"But perhaps I ought to have written it to you instead—I don't
 know. Lately it seems as though many things that I have done have
 been entirely misunderstood.</p>
 
 <p>"It's gray weather here, and the sea looks as though it were
 bad-tempered; and I've been rather discontented, too, this
-morning&mdash;&mdash;</p>
+morning——</p>
 
 <p>"I don't really mean that. There is a very jolly party here.... I
 believe that I'm growing a little tired of parties.</p>
@@ -3599,25 +3599,25 @@ I'm going. She would ask you if I suggested it. Shall I? Because,
 since we last met, once or twice the thought has occurred to me
 that perhaps an explanation was overdue. Not that I should make any
 to you if you and I meet at Witch-Hollow. There isn't any to
-make&mdash;except by my saying that I hope to see you again. Will you be
+make—except by my saying that I hope to see you again. Will you be
 content with that admission of guilt?</p>
 
 <p>"I meant to speak to you again that day at the Charity affair, only
-there were so many people bothering&mdash;and<span class="pagenum" id="Page_224">[Pg 224]</span> you seemed to be so
+there were so many people bothering—and<span class="pagenum" id="Page_224">[Pg 224]</span> you seemed to be so
 delightfully preoccupied with that pretty Cyrille Caldera. I really
 had no decent opportunity to speak to you again without making her
-my mortal enemy&mdash;and you, too, perhaps.</p>
+my mortal enemy—and you, too, perhaps.</p>
 
 <p>"May I dare to be a little friendly now and say that I would like
 to see you? Somehow I feel that even still I may venture to talk to
 you on a different plane and footing from any which exists between
 other men and me. You were once so friendly, so kind, so nice to
-me. You have been nice&mdash;<i>always</i>. And if I seem to have acquired
+me. You have been nice—<i>always</i>. And if I seem to have acquired
 any of the hardness, any of the cynical veneer, any of the
 fashionable scepticism and unbelief which, perhaps, no woman
 entirely escapes in my environment, it all softens and relaxes and
 fades and seems to slip away as soon as I begin to talk to
-you&mdash;even on this note-paper. Which is only one way of saying,
+you—even on this note-paper. Which is only one way of saying,
 'Please be my friend again!'</p>
 
 <p>"I sometimes hear about you from others. I am impressively informed
@@ -3633,7 +3633,7 @@ country. Don't you know that?</p>
 <p>"Would you care to write to me and tell me a little about yourself?
 Do you think it odd or capricious of me to write to you? And are
 you perhaps irritated because of my manners which must have seemed
-to you discourteous&mdash;perhaps rude?</p>
+to you discourteous—perhaps rude?</p>
 
 <p>"I know of course that you called on me; that you<span class="pagenum" id="Page_225">[Pg 225]</span> telephoned; that
 you wrote to me; and that I made no response.</p>
@@ -3648,7 +3648,7 @@ that a Harlequin and a golden dancer met in the noisy halls of old
 King Carnival.... Only, the girl who writes you this was younger
 and happier then than I think she ever will be again.</p>
 
-<p>"Your friend&mdash;if you wish&mdash;</p>
+<p>"Your friend—if you wish—</p>
 
 <p>"<span class="smcap">Strelsa Leeds.</span>"</p>
 </div>
@@ -3684,24 +3684,24 @@ this time for good and all.</p>
 <div class="blockquot">
 
 <p>"Can you not care for me and still be kind to me, Mr. Quarren? If
-what you say about your regard for me is true&mdash;but it is certainly
-exaggerated, anyway&mdash;should not your attitude toward me include a
+what you say about your regard for me is true—but it is certainly
+exaggerated, anyway—should not your attitude toward me include a
 nobler sentiment? I mean friendship. And I know whereof I speak,
-because I am conscious of a capacity for it&mdash;a desire for it&mdash;and
+because I am conscious of a capacity for it—a desire for it—and
 for you as the object of it. I believe that, if you cared for it, I
 could give you the very best of me in a friendship of the highest
 type.</p>
 
-<p>"It is in me to give it&mdash;a pure, devoted, lofty, untroubled
+<p>"It is in me to give it—a pure, devoted, lofty, untroubled
 friendship, absolutely free of lesser and material sentiments. Am I
 sufficiently frank? I want such a friendship. I need it. I have
-never before offered it to any man&mdash;the kind I mean to give you if
+never before offered it to any man—the kind I mean to give you if
 you wish.</p>
 
 <p>"I believe it would satisfy you; I am convinced that yours would
 satisfy me. You don't know how I have missed such a friendship in
 you. I have wanted it from the very beginning of our acquaintance.
-But I had&mdash;problems&mdash;to solve, first; and I had to let our
+But I had—problems—to solve, first; and I had to let our
 friendship lie dormant. Now I have solved my perplexities, and all
 my leisure is for you again, if you will. Do you want it?</p>
 
@@ -3713,7 +3713,7 @@ drown.</p>
 
 <p>"<span class="smcap">Strelsa Leeds.</span></p>
 
-<p>"P. S.&mdash;Lord Dankmere is here. He is insufferable. He told Mrs.
+<p>"P. S.—Lord Dankmere is here. He is insufferable. He told Mrs.
 Sprowl that you and he were going into the antique-picture
 business. You wouldn't think of<span class="pagenum" id="Page_227">[Pg 227]</span> going into anything whatever with
 a man of that sort, would you? Or was it merely a British jest?"</p>
@@ -3724,7 +3724,7 @@ a man of that sort, would you? Or was it merely a British jest?"</p>
 <div class="blockquot">
 
 <p>"I have your letter and will keep it a week before replying.
-But&mdash;are you engaged?"</p>
+But—are you engaged?"</p>
 </div>
 
 <p>She answered:</p>
@@ -3775,12 +3775,12 @@ from its crate, some heavily framed, some merely sagging on their
 ancient un-keyed stretchers.</p>
 
 <p>There were primitives on panels, triptychs, huge canvases in frames
-carved out of solid wood; pictures in battered Italian frames&mdash;some
+carved out of solid wood; pictures in battered Italian frames—some
 floridly Florentine, some exquisitely inlaid on dull azure and
-rose&mdash;pictures in Spanish frames, Dutch frames, English frames, French
+rose—pictures in Spanish frames, Dutch frames, English frames, French
 frames of the last century; portraits, landscapes, genre, still
-life&mdash;battle pictures, religious subjects, allegorical canvases,
-mythological&mdash;all stacked up pell-mell in the backyard and regarded in
+life—battle pictures, religious subjects, allegorical canvases,
+mythological—all stacked up pell-mell in the backyard and regarded in
 amazement by the neighbours, and by two young men who alternately smoked
 and staunched their wounds under the summer sky.</p>
 
@@ -3789,7 +3789,7 @@ collection?"</p>
 
 <p>"No; but I thought it might be as well to have plenty of rubbish on hand
 in case a demand should spring up.... What do they look like to you,
-Quarren&mdash;I mean what's your first impression?"</p>
+Quarren—I mean what's your first impression?"</p>
 
 <p>"They look all right."</p>
 
@@ -3829,101 +3829,101 @@ office to await events.</p>
 
 <p>"Yes. Will you?"</p>
 
-<p>"Why, I have my own business, Dankmere&mdash;&mdash;"</p>
+<p>"Why, I have my own business, Dankmere——"</p>
 
 <p>"Is it enough to keep you busy?"</p>
 
-<p>"No&mdash;not yet&mdash;but I&mdash;&mdash;"</p>
+<p>"No—not yet—but I——"</p>
 
 <p>"Then, like a good fellow, help me sell these damned pictures. I haven't
 any money to offer you, Quarren, but if you'll be willing to hang the
 pictures around your<span class="pagenum" id="Page_232">[Pg 232]</span> office here and in the back parlour and the
 extension, and if you'll talk the merry talk to the lunatics who may
 come in to look at 'em and tell 'em what the bally pictures are and fix
-the proper prices&mdash;why&mdash;why, I'll make any arrangement with you that you
+the proper prices—why—why, I'll make any arrangement with you that you
 please. Say a half interest, now. Would that be fair?"</p>
 
-<p>"Fair? Of course! It's far too liberal an offer&mdash;but I&mdash;&mdash;"</p>
+<p>"Fair? Of course! It's far too liberal an offer—but I——"</p>
 
-<p>"It's worth that to me, Quarren&mdash;if you can see your way to helping me
-out&mdash;&mdash;"</p>
+<p>"It's worth that to me, Quarren—if you can see your way to helping me
+out——"</p>
 
 <p>"But my help isn't worth half what these pictures might very easily
-bring&mdash;even at public auction&mdash;&mdash;"</p>
+bring—even at public auction——"</p>
 
-<p>"Why not? I'd have to pay an auctioneer, an expert to appraise them&mdash;an
-art dealer to hang them in his gallery for a couple of weeks&mdash;either
+<p>"Why not? I'd have to pay an auctioneer, an expert to appraise them—an
+art dealer to hang them in his gallery for a couple of weeks—either
 that or rent a place by the year. The only way I can recompense you for
 your wall space, for talking art talk to visitors, for fixing prices, is
 to offer you half of what we make. Why not? You pay a pretty stiff rent
 here, don't you? You also pay a servant. You pay for heat and light,
 don't you? So if you'll turn this floor into a combination gallery of
-sorts&mdash;art and real estate, you see&mdash;we'll go into business, egad! What?
+sorts—art and real estate, you see—we'll go into business, egad! What?
 The Dankmere galleries! What? By gad I'll have a sign made to hang out
-there beside your shingle&mdash;only I'm afraid you'll have to pay for it,
+there beside your shingle—only I'm afraid you'll have to pay for it,
 Quarren, and recompense yourself after we sell the first picture."</p>
 
 <p>"But, Dankmere," he protested, very much amused, "I don't want to become
 a picture dealer."</p>
 
 <p>"What's the harm? Take a shot at it, old chap! A young man can't collect
-too many kinds of experience. Take me for example!&mdash;I've sold dogs and
+too many kinds of experience. Take me for example!—I've sold dogs and
 hunters on commission, gone shares in about every rotten<span class="pagenum" id="Page_233">[Pg 233]</span> scheme anybody
-ever suggested to me, financed a show, and acted in it&mdash;as you
-know&mdash;and, by gad!&mdash;here I am now a dealer in old masters! Be a good
+ever suggested to me, financed a show, and acted in it—as you
+know—and, by gad!—here I am now a dealer in old masters! Be a good
 fellow and come in with me. What?"</p>
 
-<p>"I don't really know enough about antique pictures to&mdash;&mdash;"</p>
+<p>"I don't really know enough about antique pictures to——"</p>
 
 <p>"What's the odds! Neither do I! My dear sir, we must lie like gentlemen
 for the honour of the Dankmere gallery! What? Along comes a chap walking
-slowly and painfully for the weight of the money in his pockets&mdash;'Ho!'
-says he&mdash;'a genuine Van Dyck!' 'Certainly,' you say, very coldly. And,
+slowly and painfully for the weight of the money in his pockets—'Ho!'
+says he—'a genuine Van Dyck!' 'Certainly,' you say, very coldly. And,
 'How much?' says he, shivering for fear he mayn't get it. 'Three hundred
-thousand dollars,' you say, trying not to yawn in his face&mdash;&mdash;"</p>
+thousand dollars,' you say, trying not to yawn in his face——"</p>
 
 <p>Quarren could no longer control his laughter: Dankmere blinked at him
 amiably.</p>
 
 <p>"We'll hang them anyhow, Dankmere," he said. "As long as there is so
 little business in the office I don't mind looking after your pictures
-for you&mdash;&mdash;"</p>
+for you——"</p>
 
 <p>"Yours, too," urged the Earl.</p>
 
-<p>"No; I can't accept anything&mdash;&mdash;"</p>
+<p>"No; I can't accept anything——"</p>
 
 <p>"Then it's all off!" exclaimed Dankmere, turning a bright red. "I'm
-blessed if I'll accept charity!&mdash;even if I am hunting heiresses. I'll
+blessed if I'll accept charity!—even if I am hunting heiresses. I'll
 marry money if I can, but I'm damned if I hold out a tin cup for
 coppers!"</p>
 
 <p>"If you feel that way," began Quarren, very much embarrassed, "I'll do
-whatever would make you feel comfortable&mdash;&mdash;"</p>
+whatever would make you feel comfortable——"</p>
 
-<p>"Half interest or it's all off! A Dankmere means what he says&mdash;now and
+<p>"Half interest or it's all off! A Dankmere means what he says—now and
 then."</p>
 
-<p>"One-third interest, then&mdash;&mdash;"</p>
+<p>"One-third interest, then——"</p>
 
-<p>"A half!&mdash;by gad! There's a good fellow!"</p>
+<p>"A half!—by gad! There's a good fellow!"</p>
 
 <p><span class="pagenum" id="Page_234">[Pg 234]</span></p>
 
 <p>"No; one-third is all I'll accept."</p>
 
-<p>"Oh, very well. It may amount to ten dollars&mdash;it may amount to ten
-thousand&mdash;and ten times that, perhaps. What?"</p>
+<p>"Oh, very well. It may amount to ten dollars—it may amount to ten
+thousand—and ten times that, perhaps. What?"</p>
 
 <p>"Perhaps," said Quarren, smiling. "And, if you're going out, Dankmere,
-perhaps you had better order a sign painted&mdash;anything you like, of
+perhaps you had better order a sign painted—anything you like, of
 course. Because I'm afraid I couldn't leave these pictures here
 indefinitely and we might as well make plans to get rid of some of them
 as soon as possible."</p>
 
 <p>"Right-o! I'm off to find a painter. Leave it to me, Quarren. And when
-the picture-hangers come, have them hung in a poor light&mdash;I mean the
-pictures&mdash;God knows they need it&mdash;the dimmer the light the better. What?
+the picture-hangers come, have them hung in a poor light—I mean the
+pictures—God knows they need it—the dimmer the light the better. What?
 Take care of yourself, old chap. There's money in sight, believe me!"</p>
 
 <p>And the lively little Earl trotted out, swinging his stick and setting
@@ -3938,10 +3938,10 @@ canvases into the basement, when the office door opened in his very face
 and Molly Wycherly came in, breezily.</p>
 
 <p>"Why, Molly!" he exclaimed, surprised; "this is exceedingly nice of
-you&mdash;&mdash;"</p>
+you——"</p>
 
 <p>"Oh, Ricky, I'm glad to see you! But I don't want to buy a house or sell
-one or anything. I'm very unhappy&mdash;and I'm glad to see you&mdash;&mdash;"</p>
+one or anything. I'm very unhappy—and I'm glad to see you——"</p>
 
 <p><span class="pagenum" id="Page_235">[Pg 235]</span></p>
 
@@ -3951,7 +3951,7 @@ returned to the office; and she seated herself on top of his desk.</p>
 <p>"You dear boy," she said; "you are thin and white and you don't look
 very happy either. Are you?"</p>
 
-<p>"Why, of course I'm happy&mdash;&mdash;"</p>
+<p>"Why, of course I'm happy——"</p>
 
 <p>"I don't believe it! Anyway, I was passing, and I saw your shingle
 swinging, and I made the chauffeur stop on the impulse of the moment....
@@ -3959,10 +3959,10 @@ How are you, Ricky dear?"</p>
 
 <p>"First rate. You are even unusually pretty, Molly."</p>
 
-<p>"I don't feel so. Strelsa and I came into town for the afternoon&mdash;on the
+<p>"I don't feel so. Strelsa and I came into town for the afternoon—on the
 most horrid kind of business, Ricky."</p>
 
-<p>"I'm sorry&mdash;&mdash;"</p>
+<p>"I'm sorry——"</p>
 
 <p>"You will be sorrier when you hear that about all of Strelsa's money was
 in that miserable Adamant Trust Company which is causing so much
@@ -3972,36 +3972,36 @@ scandal. You didn't know Strelsa's money was in it, did you?"</p>
 
 <p>"Isn't it dreadful? The child doesn't know whether she will ever get a
 penny or not. Some of those disgusting men have run away, one shot
-himself&mdash;you read about it!&mdash;and now they are trying to pretend that the
+himself—you read about it!—and now they are trying to pretend that the
 two creatures they have arrested are insane and irresponsible. I don't
 care whether they are or not; I'd like to kill them. How does their
 insanity concern Strelsa? For three weeks she hasn't known what to
-think, what to expect&mdash;and even her lawyers can't tell her. I hate
+think, what to expect—and even her lawyers can't tell her. I hate
 lawyers. But <i>I</i> think the chances are that her pretty house will be for
 sale before long.... Wouldn't it be too tragic if it came into your
-office&mdash;&mdash;"</p>
+office——"</p>
 
 <p><span class="pagenum" id="Page_236">[Pg 236]</span></p>
 
 <p>"Don't say such things, Molly," he said, bending his head over the desk
 and fumbling with his pen.</p>
 
-<p>"Well, I knew you'd be sympathetic. It's a shame&mdash;a crime!&mdash;it's
+<p>"Well, I knew you'd be sympathetic. It's a shame—a crime!—it's
 absolutely disgusting the way that men gamble with other people's money
-and cheat and lie and&mdash;and&mdash;oh, it's a perfectly rotten world and I'm
+and cheat and lie and—and—oh, it's a perfectly rotten world and I'm
 tired of it!"</p>
 
 <p>"Where is Mrs. Leeds?" he asked in a low voice.</p>
 
-<p>"At Witch-Hollow&mdash;in town for this afternoon to see her stupid lawyers.
+<p>"At Witch-Hollow—in town for this afternoon to see her stupid lawyers.
 They don't do anything. They say they can't just yet. They're lazy
-or&mdash;something worse. That's my opinion. We go out on the five-three
-train&mdash;Strelsa and I&mdash;&mdash;"</p>
+or—something worse. That's my opinion. We go out on the five-three
+train—Strelsa and I——"</p>
 
-<p>"Is she&mdash;much affected?"</p>
+<p>"Is she—much affected?"</p>
 
 <p>"No; and that's the silly part of it. It would simply wreck me. But she
-hasn't wept a single tear.... I suppose she'll have to marry, now&mdash;"
+hasn't wept a single tear.... I suppose she'll have to marry, now—"
 Mrs. Wycherly glanced askance at Quarren, but his face remained gravely
 expressionless.</p>
 
@@ -4030,8 +4030,8 @@ same time."</p>
 <p>"What do you mean?" he said, turning a colourless face to hers.</p>
 
 <p>"What I say. Ricky dear, I suppose that Strelsa <i>will</i> have to marry a
-wealthy man, now&mdash;and I believe she realises it, too&mdash;but I&mdash;I <i>wanted</i>
-her to marry you, some day&mdash;&mdash;"</p>
+wealthy man, now—and I believe she realises it, too—but I—I <i>wanted</i>
+her to marry you, some day——"</p>
 
 <p>He swung around again, confronting her.</p>
 
@@ -4041,22 +4041,22 @@ her to marry you, some day&mdash;&mdash;"</p>
 
 <p>"I wish I could express my feelings like Mrs. Sprowl, but I can't," she
 said naïvely. "Sir Charles will marry her, now; I know perfectly well he
-will&mdash;unless Langly Sprowl&mdash;&mdash;"</p>
+will—unless Langly Sprowl——"</p>
 
 <p>Quarren drew his breath sharply.</p>
 
 <p>"Not that man," she said.</p>
 
-<p>"God knows, Ricky. He's after Strelsa every minute&mdash;and he can make
+<p>"God knows, Ricky. He's after Strelsa every minute—and he can make
 himself agreeable. The worst of it is that Strelsa does not believe what
 she hears about him. Women are that way, often. The moment the whole
 world pitches into a man, women are inclined to believe him a
-martyr&mdash;and end by discrediting every unworthy story concerning him....
+martyr—and end by discrediting every unworthy story concerning him....
 I don't know, but I think it is already a little that way with
-Strelsa.... He's a clever brute&mdash;and oh! what a remorseless man!... I
+Strelsa.... He's a clever brute—and oh! what a remorseless man!... I
 said that once to Strelsa, and she said very warmly that I entirely
 misjudged him.... I wish Mary Ledwith would come back and bring things
-to a crisis&mdash;I do, indeed."</p>
+to a crisis—I do, indeed."</p>
 
 <p>Quarren said, calmly;</p>
 
@@ -4072,8 +4072,8 @@ the Adamant Trust? Or was there another reason?</p>
 
 <p>"I suppose," said Molly, dabbing at her eyes, "that Strelsa can't pick
 and choose now. I suppose she's got to marry for sordid and sensible and
-material reasons. But if only she would choose Sir Charles&mdash;I think I
-could be almost reconciled to her losing you&mdash;&mdash;"</p>
+material reasons. But if only she would choose Sir Charles—I think I
+could be almost reconciled to her losing you——"</p>
 
 <p>Quarren laughed harshly.</p>
 
@@ -4081,23 +4081,23 @@ could be almost reconciled to her losing you&mdash;&mdash;"</p>
 survives losing me."</p>
 
 <p>"Ricky! She cares a great deal for you! So do I. And Strelsa <i>does</i> care
-for you&mdash;&mdash;"</p>
+for you——"</p>
 
 <p>"Not too rashly I hope," he said with another disagreeable laugh.</p>
 
 <p>"Oh, that isn't like you, Ricky! You're not the sneering, fleering nasty
-kind. If you are badly hurt, take it better than that&mdash;&mdash;"</p>
+kind. If you are badly hurt, take it better than that——"</p>
 
 <p>"I can't!" he said between set teeth. "I care for her; she knows it. I
 guess she knows, too, that what she once said to me started me into what
-I'm doing now&mdash;working, waiting, living like a dog&mdash;doing my best to
-keep my self-respect and obtain hers&mdash;" He choked, regained his
+I'm doing now—working, waiting, living like a dog—doing my best to
+keep my self-respect and obtain hers—" He choked, regained his
 self-control, and went on quietly:</p>
 
 <p>"Why do you think I dropped out of everything? To try to develop
-whatever may be in me&mdash;so that I could speak to her as an equal and not
+whatever may be in me—so that I could speak to her as an equal and not
 as the court jester and favourite mountebank of the degenerate gang she
-travels with&mdash;&mdash;"</p>
+travels with——"</p>
 
 <p><span class="pagenum" id="Page_239">[Pg 239]</span></p>
 
@@ -4106,12 +4106,12 @@ travels with&mdash;&mdash;"</p>
 <p>"I beg your pardon," he said sullenly.</p>
 
 <p>"I am not offended, you poor boy.... I hadn't realised that you were so
-much in love with her&mdash;so deeply concerned&mdash;&mdash;"</p>
+much in love with her—so deeply concerned——"</p>
 
 <p>"I have always been.... She knows it...." He cleared his eyes and turned
 a dazed gaze on the sunny street once more.</p>
 
-<p>"If I could&mdash;" he stopped; a hopeless look came into his eyes. Then he
+<p>"If I could—" he stopped; a hopeless look came into his eyes. Then he
 slowly shook his head.</p>
 
 <p>"Oh, Ricky! Ricky! Can't you do something? Can't you make a lot of money
@@ -4124,18 +4124,18 @@ don't you?"</p>
 <p>"You know it's true!"</p>
 
 <p>"I don't know what is true. I don't know truth from falsehood. I suppose
-that love requires money to keep it nourished&mdash;as roses require
-manure&mdash;&mdash;"</p>
+that love requires money to keep it nourished—as roses require
+manure——"</p>
 
 <p>"Ricky!"</p>
 
-<p>"I'm speaking of <i>your</i> world&mdash;&mdash;"</p>
+<p>"I'm speaking of <i>your</i> world——"</p>
 
-<p>"My world! The entire world knows that money is necessary&mdash;except
-perhaps a silly sentimentalist here and there&mdash;&mdash;"</p>
+<p>"My world! The entire world knows that money is necessary—except
+perhaps a silly sentimentalist here and there——"</p>
 
-<p>"Yes, there are one or two&mdash;here and there," he said. "But they're all
-poor&mdash;and prejudiced."</p>
+<p>"Yes, there are one or two—here and there," he said. "But they're all
+poor—and prejudiced."</p>
 
 <p>Molly applied her handkerchief to her eyes, viciously.</p>
 
@@ -4149,22 +4149,22 @@ anything."</p>
 
 <p>"Oh, my dear, don't talk slush!"</p>
 
-<p>"&mdash;And&mdash;children&mdash;perhaps."</p>
+<p>"—And—children—perhaps."</p>
 
 <p>"And no money to educate them! You dear boy, there is nothing to
-do&mdash;absolutely nothing&mdash;unless it's based on money. You know it; I know
-it. People without it are intolerable&mdash;a nuisance to everybody and to
+do—absolutely nothing—unless it's based on money. You know it; I know
+it. People without it are intolerable—a nuisance to everybody and to
 themselves. What could Strelsa find in life without the means to enjoy
 it?"</p>
 
-<p>"Nothing&mdash;perhaps.... But I believe I'll ask her."</p>
+<p>"Nothing—perhaps.... But I believe I'll ask her."</p>
 
 <p>"She'll tell you the truth, Ricky. She's an unusually truthful woman....
-I must go downtown. Strelsa and I are lunching"&mdash;she reddened&mdash;"with
+I must go downtown. Strelsa and I are lunching"—she reddened—"with
 Langly.... His aunt would kill me if she heard of it.... I positively do
 not dare ask Langly to Witch-Hollow because I'm so deadly afraid of that
-fat old woman!... Besides, I don't want him there&mdash;although&mdash;if Strelsa
-<i>has</i> to marry him&mdash;&mdash;"</p>
+fat old woman!... Besides, I don't want him there—although—if Strelsa
+<i>has</i> to marry him——"</p>
 
 <p>She fell silent and thoughtful, reflecting, perhaps, that if Strelsa was
 going to take Langly Sprowl, her own country house might as well have
@@ -4178,10 +4178,10 @@ you can! Will you?"</p>
 
 <p>"I'll come to Witch-Hollow if you ask me."</p>
 
-<p>"That's ducky of you. You <i>are</i> a good sport, Ricky&mdash;and always were! Go
+<p>"That's ducky of you. You <i>are</i> a good sport, Ricky—and always were! Go
 on and marry her if you can. Other women have stood it.... And, I know
-it's vulgar and low and catty of me&mdash;but I'd love to see Mrs. Sprowl
-blow up&mdash;and see that hatchet-faced Langly<span class="pagenum" id="Page_241">[Pg 241]</span> disappointed&mdash;yes, I would,
+it's vulgar and low and catty of me—but I'd love to see Mrs. Sprowl
+blow up—and see that hatchet-faced Langly<span class="pagenum" id="Page_241">[Pg 241]</span> disappointed—yes, I would,
 and I don't care what you think! Their ancestors were common people, and
 Heaven knows why a Wycherly of Wycherly should be afraid of the
 descendants of Dutch rum smugglers!"</p>
@@ -4228,38 +4228,38 @@ told you how unexpectedly my worldly affairs have altered since I
 last wrote to you.</p>
 
 <p>"For me, somehow or other, life has been always a sequence of
-abrupt experiences&mdash;a series of extremes&mdash;one grotesque
+abrupt experiences—a series of extremes—one grotesque
 exaggeration after another, and all diametrically opposed. And it
 seems odd that such radically material transformations should so
 ruthlessly disturb and finally, now, end by completely altering the
-character of a girl whose real nature is&mdash;or was&mdash;unaccented and
+character of a girl whose real nature is—or was—unaccented and
 serene to the verge of indifference. For the woman writing this is
 very different from the one you knew as Strelsa Leeds.</p>
 
 <p>"I am not yet sure what the outcome of this Adamant affair will be.
 Neither, apparently, are my attorneys. But it is absolutely certain
 that if I ever recover anything at all, it will not amount to very
-much&mdash;not nearly enough to live on.</p>
+much—not nearly enough to live on.</p>
 
 <p>"When they first brought the unpleasant news to me my instinct was
 to sit down and write you about it. I was horribly scared, and
 wanted you to know it.</p>
 
-<p>"I didn't yield to the impulse as you know&mdash;I cannot<span class="pagenum" id="Page_245">[Pg 245]</span> give you the
+<p>"I didn't yield to the impulse as you know—I cannot<span class="pagenum" id="Page_245">[Pg 245]</span> give you the
 reasons why. They were merely intuitions at first; later they
 became reasons as my financial situation developed in all its
 annoying proportions.</p>
 
 <p>"I can tell you only this: before material disaster threatened me
 out of a clear sky, supposing that matters would always remain with
-me as they were&mdash;that I should never know any serious want, never
-apprehend actual necessity&mdash;I had made up my mind to a course of
+me as they were—that I should never know any serious want, never
+apprehend actual necessity—I had made up my mind to a course of
 life which now has become impossible.</p>
 
 <p>"It was not, perhaps, a very admirable plan of existence that I had
 conceived for myself, nothing radical or original. I meant, merely,
 <i>not</i> to marry, to live well within my income, to divide my time
-between my friends and myself&mdash;that is to give myself more leisure
+between my friends and myself—that is to give myself more leisure
 for self-development, tranquil cultivation, and a wider and more
 serious interest in things worthy.</p>
 
@@ -4270,17 +4270,17 @@ which I live, I had decided on the sacrifice.</p>
 <p>"And that, Mr. Quarren, is how matters stood with me until a month
 ago.</p>
 
-<p>"Now everything is altered&mdash;even my own character I think. There is
-in me very little courage&mdash;and, alas, much of that cowardice which
-shrinks from pain and privation of any kind&mdash;which cringes the more
+<p>"Now everything is altered—even my own character I think. There is
+in me very little courage—and, alas, much of that cowardice which
+shrinks from pain and privation of any kind—which cringes the more
 basely, perhaps, because there has been, in my life, so much of
 sorrow, so little of material ease and tranquility of mind.</p>
 
 <p>"I had been dreaming of a balanced and secure life with leisure to
 develop mental resources hitherto neglected. And your
-friendship&mdash;our new understanding&mdash;meant much of that part of life
-for me&mdash;more<span class="pagenum" id="Page_246">[Pg 246]</span> than I realised&mdash;far more than you do. Can you
-understand how deep the hurt is?&mdash;deeper because now you will learn
+friendship—our new understanding—meant much of that part of life
+for me—more<span class="pagenum" id="Page_246">[Pg 246]</span> than I realised—far more than you do. Can you
+understand how deep the hurt is?—deeper because now you will learn
 what a coward I really am and how selfishly I surrender to the
 menace of material destruction. I am in dire terror of it; I simply
 do not choose to endure it. That I need not submit to it, inspires
@@ -4288,14 +4288,14 @@ in me the low type of equanimity that enables me to face the future
 with apparent courage. My world applauds it as pluck. I have
 confessed to you what it really is.</p>
 
-<p>"Now you know me, Mr. Quarren&mdash;a preacher of lofty ideals while
+<p>"Now you know me, Mr. Quarren—a preacher of lofty ideals while
 prosperous, a recreant in adversity.</p>
 
 <p>"I thought once that the most ignoble sentiments ever entertained
 by man were those lesser and physical emotions which, in the world,
-masquerade as love&mdash;or as an essential part of it. To me they
+masquerade as love—or as an essential part of it. To me they
 always seemed intolerable as any part of love, material, unworthy,
-base. To me love was intellectual&mdash;could be nothing less lofty&mdash;and
+base. To me love was intellectual—could be nothing less lofty—and
 should aspire to the spiritual.</p>
 
 <p>"I say this because you once tried to make me understand that you
@@ -4307,40 +4307,40 @@ way when a marriage tainted with lesser emotions repelled me. And
 now, like all iconoclasts, I end by shattering my own complacent
 image, and the fragments have fallen to the lowest depth of all.</p>
 
-<p>"For I contemplate a mariage de convenance&mdash;and I scarcely care
+<p>"For I contemplate a mariage de convenance—and I scarcely care
 whom I marry as long as he removes from me this terror of a sordid
 and needy future.</p>
 
-<p>"All ideals, all desire for higher and better things&mdash;for a noble
+<p>"All ideals, all desire for higher and better things—for a noble
 leisure and the quiet pleasures of self-development, have
-gone&mdash;vanished utterly. Fear sickens<span class="pagenum" id="Page_247">[Pg 247]</span> me night and day&mdash;the same
-dull dread that I have known so many, many years in my life&mdash;a
+gone—vanished utterly. Fear sickens<span class="pagenum" id="Page_247">[Pg 247]</span> me night and day—the same
+dull dread that I have known so many, many years in my life—a
 blind horror of more unhappiness and pain after two years of
-silence&mdash;that breathless stillness which frightened wounded things
+silence—that breathless stillness which frightened wounded things
 know while they lie, panting, dazed listening for the coming
 footsteps of that remorseless Fate which struck them down from
 afar.</p>
 
 <p>"I tell you this, Mr. Quarren, because it is due to you if you
-really love me&mdash;or if you once did love me&mdash;because when you have
+really love me—or if you once did love me—because when you have
 read this you will no longer care for me.</p>
 
 <p>"One evening you made me understand that you cared for me; and I
 replied to you only by a dazed silence that neither you nor I
-entirely understood at the time. It was not contempt for you&mdash;yet,
+entirely understood at the time. It was not contempt for you—yet,
 perhaps, I could not really have cared very deeply for such a man
 as you then seemed to be. It was not intellectual indifference that
-silenced me.... And I can say no more about it&mdash;except
-that&mdash;something&mdash;changed me radically from that moment&mdash;and ever
-since I have been trying to understand myself&mdash;to learn something
-about myself&mdash;and of the world I live in&mdash;and of men.</p>
+silenced me.... And I can say no more about it—except
+that—something—changed me radically from that moment—and ever
+since I have been trying to understand myself—to learn something
+about myself—and of the world I live in—and of men.</p>
 
 <p>"When a crisis arrives self-revelation comes in a single flash. My
 financial crisis arrived as you know; I suddenly saw myself as I
-am&mdash;a woman astonishingly undeveloped and ignorant in many ways,
-crude, unawakened, stupid&mdash;a woman half-blinded with an unreasoning
-dread of more pain&mdash;pain which she thought had at last been left
-behind her&mdash;and a coward all through; and selfish from head to
+am—a woman astonishingly undeveloped and ignorant in many ways,
+crude, unawakened, stupid—a woman half-blinded with an unreasoning
+dread of more pain—pain which she thought had at last been left
+behind her—and a coward all through; and selfish from head to
 heel.</p>
 
 <p>"This is what I <i>really</i> am. And I shall prove it by marrying for
@@ -4349,7 +4349,7 @@ face adversity and unhappiness.</p>
 
 <p><span class="pagenum" id="Page_249">[Pg 249]</span></p>
 
-<p>[Illustration: "'I say, Quarren&mdash;does this old lady hang next to
+<p>[Illustration: "'I say, Quarren—does this old lady hang next to
 the battered party in black?'"]</p>
 
 <p><span class="pagenum" id="Page_252">[Pg 252]</span></p>
@@ -4358,7 +4358,7 @@ the battered party in black?'"]</p>
 again.</p>
 
 <p>"I am glad you once cared for me. If you should ever reply to this
-letter, don't be very unkind to me. I know what I am&mdash;and I vaguely
+letter, don't be very unkind to me. I know what I am—and I vaguely
 surmise what I shall lose by being so. But I have no courage for
 anything else.</p>
 
@@ -4372,7 +4372,7 @@ whistling a lively air, trotted about superintending everything with all
 the cheerful self-confidence of a family dog regulating everything that
 goes on in his vicinity.</p>
 
-<p>"I say, Quarren&mdash;does this old lady hang next to the battered party in
+<p>"I say, Quarren—does this old lady hang next to the battered party in
 black?" he demanded briskly.</p>
 
 <p>Quarren looked around; "Yes," he said, "they're both by Nicholas Maas
@@ -4384,15 +4384,15 @@ according to your list."</p>
 
 <p>Dankmere puffed away on his cigar and consulted his list: "Reynolds (Sir
 Joshua). Portrait of Lady Dankmere," he read; "portrait of Sir Boggs
-Dankmere!&mdash;string 'em up aloft over that jolly little lady with no frock
-on!&mdash;Rembrandt (Van Rijn). Born near Leyden, July 15th, 1607&mdash;Oh, who
-cares as long as it <i>is</i> a Rembrandt!&mdash;Is it, Quarren? It isn't a copy,
+Dankmere!—string 'em up aloft over that jolly little lady with no frock
+on!—Rembrandt (Van Rijn). Born near Leyden, July 15th, 1607—Oh, who
+cares as long as it <i>is</i> a Rembrandt!—Is it, Quarren? It isn't a copy,
 is it?"</p>
 
 <p>"I hope not," said the young fellow absently.</p>
 
-<p>"Egad! So do I." And to the workmen&mdash;"Philemon<span class="pagenum" id="Page_253">[Pg 253]</span> and Baucis by Rembrandt!
-Hang 'em up next to that Romney&mdash;over the Jan Steen ... Quarren?"</p>
+<p>"Egad! So do I." And to the workmen—"Philemon<span class="pagenum" id="Page_253">[Pg 253]</span> and Baucis by Rembrandt!
+Hang 'em up next to that Romney—over the Jan Steen ... Quarren?"</p>
 
 <p>"Yes?"</p>
 
@@ -4403,7 +4403,7 @@ Hang 'em up next to that Romney&mdash;over the Jan Steen ... Quarren?"</p>
 <p>"I can," said the little Earl; "and I say that if that <i>is</i> a Turner I
 can beat it myself working with tomato catsup, an underdone omelette,
 and a clothes-brush.... Hello! I like this picture. The list calls it a
-Watteau&mdash;'The Fête Champêtre.' What do you know about it, Quarren?"</p>
+Watteau—'The Fête Champêtre.' What do you know about it, Quarren?"</p>
 
 <p>"Nothing yet. It seems to be genuine enough."</p>
 
@@ -4411,10 +4411,10 @@ Watteau&mdash;'The Fête Champêtre.' What do you know about it, Quarren?"</p>
 
 <p>"I tell you, Dankmere, that I don't know. They all appear to be genuine,
 after a superficial examination. It takes time to be sure about any
-picture&mdash;and if we're going to be certain it will require confabs with
-authorities&mdash;restorers, dealers, experts, curators from various
-museums&mdash;all sorts and conditions of people must be approached and
-warily consulted&mdash;and paid," he added smiling. "And that has to be done
+picture—and if we're going to be certain it will require confabs with
+authorities—restorers, dealers, experts, curators from various
+museums—all sorts and conditions of people must be approached and
+warily consulted—and paid," he added smiling. "And that has to be done
 with circumspection because some are not honest and we don't want
 anybody to get the impression that we are attempting to bribe anybody
 for a favourable verdict."</p>
@@ -4436,22 +4436,22 @@ Avenue house.</p>
 
 <p>The transformation was complete; all woodwork had been painted white, a
 gray-green paper hung on the walls, the floor stained dark brown and
-covered with several antique rugs which had come with the pictures&mdash;a
+covered with several antique rugs which had come with the pictures—a
 Fereghan, a Ladik, and an ancient Herez with rose and sapphire lights in
 it.</p>
 
-<p>At the end of the suite hung another relic of Dankmere Tarns&mdash;a Gobelins
+<p>At the end of the suite hung another relic of Dankmere Tarns—a Gobelins
 tapestry about ten by twelve, signed by Audran, the subject of which was
 Boucher's "Venus, Mars, and Vulcan" from the picture in the Wallace
 Collection. Opposite it was suspended an old Persian carpet of the
-sixteenth century&mdash;a magnificent Dankmere heirloom woven in the golden
+sixteenth century—a magnificent Dankmere heirloom woven in the golden
 age of ancient Eastern art and displaying amid the soft splendour of its
 matchless hues the strange and exquisitely arched cloud-forms traced in
 forgotten dyes amid a wilderness of delicate flowers and vines.</p>
 
 <p>Between these two fabrics, filling the walls from base-board to ceiling,
 were ranged Dankmere's pictures. Few traces of the real-estate office
-remained&mdash;merely a desk, letter-file, a shelf piled up with maps, and
+remained—merely a desk, letter-file, a shelf piled up with maps, and
 Quarren's shingle outside; but this was now overshadowed by the severely
 magnificent sign:</p>
 
@@ -4478,20 +4478,20 @@ easy-chair, "that you have almost put me out of business?"</p>
 <p>"No; but last week I went to bed a broker in real estate; and this week
 I wake up a picture dealer and your partner. It's going to take most of
 my time. I can't sell a picture unless I know what it is. I've got to
-find out&mdash;or try to. Do you know what that means?"</p>
+find out—or try to. Do you know what that means?"</p>
 
 <p>"I fancy it means chucking your real estate," said Dankmere,
 imperturbably. "Why not? This is a better gamble. And if we make
 anything we ought to make something worth while."</p>
 
-<p>"Do you propose that I shall simply drop my entire business&mdash;close up
+<p>"Do you propose that I shall simply drop my entire business—close up
 everything and go into this thing permanently?" demanded Quarren.</p>
 
 <p>"It will come to that, ultimately. Don't you want to?"</p>
 
 <p>From the beginning Quarren had felt, vaguely, that it would come to
-that&mdash;realised instinctively that in such an enterprise he would be on
-solid ground&mdash;that the idea was pleasant to him&mdash;that his tastes fitted
+that—realised instinctively that in such an enterprise he would be on
+solid ground—that the idea was pleasant to him—that his tastes fitted
 him for such an occupation. Experience was lacking, but, somehow, his
 ignorance did not dismay him.</p>
 
@@ -4515,8 +4515,8 @@ assimilated knowledge acquired from the sheer love of the subject.</p>
 in his heart lies the unconscious contentment of certainty.</p>
 
 <p>And somehow, with the advent of Dankmere's pictures, into Quarren's
-troubled heart had come a vague sensation of ease&mdash;a cessation of the
-old anxiety and unrest&mdash;a quiet that he had never before known.</p>
+troubled heart had come a vague sensation of ease—a cessation of the
+old anxiety and unrest—a quiet that he had never before known.</p>
 
 <p>To learn what his wares really were seemed no formidable task; to
 appreciate and appraise each one only little labours of love. Every
@@ -4526,13 +4526,13 @@ certain of what he dealt in.</p>
 
 <p>Then, too, his mind had long since invaded a future which day by day
 grew more alluring in its suggestions. He himself would learn the
-practical and manual art of restoration&mdash;learn how to clean, reline,
+practical and manual art of restoration—learn how to clean, reline,
 revarnish; how to identify, how to dissect. Every thread of an<span class="pagenum" id="Page_257">[Pg 257]</span> ancient
 canvas should tell him a true story; every grain in an old panel. He
 would be chief surgeon in his hospital for old and decrepit
-masterpieces; he would "cradle" with his own hands&mdash;clear the opacity
+masterpieces; he would "cradle" with his own hands—clear the opacity
 from time-dimmed beauty with savant touch, knit up tenderly the wounds
-of ages&mdash;&mdash;</p>
+of ages——</p>
 
 <p>"Dankmere," he said, throwing away his cigarette, "I'm going into this
 business from this minute; and I would like to die in harness, at the
@@ -4553,14 +4553,14 @@ in the world. You've done it, too; do you realise it, Dankmere?"</p>
 <p>"Very glad I'm sure."</p>
 
 <p>"So am I!" said Quarren with sudden emphasis. "I believe I'm on the
-right track now. I believe it's in me&mdash;in my heart&mdash;to work&mdash;to
-<i>work</i>!"&mdash;he laughed&mdash;"as the old chronicles say, 'To the glory of God
+right track now. I believe it's in me—in my heart—to work—to
+<i>work</i>!"—he laughed—"as the old chronicles say, 'To the glory of God
 and the happiness of self and mankind.' ... I'm grateful to you; do you
 understand?"</p>
 
 <p>"Awf'lly glad, old chap."</p>
 
-<p>"You funny Englishman&mdash;I believe you are.... And we'll make this thing
+<p>"You funny Englishman—I believe you are.... And we'll make this thing
 go. Down comes my real-estate shingle; I'm a part of the Dankmere
 Galleries now. I'll rent the basement after our first sale and there
 you<span class="pagenum" id="Page_258">[Pg 258]</span> and I will fuss and tinker and doctor and nurse any poor old
@@ -4573,7 +4573,7 @@ to count me out."</p>
 
 <p>"Don't you care for pictures?"</p>
 
-<p>"I prefer horses," said the Earl drily&mdash;"and, after the stable and
+<p>"I prefer horses," said the Earl drily—"and, after the stable and
 kennel, my taste inclines toward Vaudeville." And he cocked up one
 little leg over the other and whistled industriously at a waltz which he
 was attempting to compose. He possessed a high, maddening, soprano
@@ -4606,16 +4606,16 @@ exercise of their professional duties.</p>
 
 <p>"Don't whistle, don't do abrupt skirt-dances, don't sing comic songs,
 don't obscure the air with cigar smoke, don't go to sleep on the sofa
-and snore, don't drink fizzes and rattle the ice in your glass&mdash;&mdash;"</p>
+and snore, don't drink fizzes and rattle the ice in your glass——"</p>
 
 <p>"My God!" faltered his lordship, "do you mind if I breathe now and
 then?"</p>
 
-<p>"I'll be away a few days&mdash;Valasco is slow, and the others take their
+<p>"I'll be away a few days—Valasco is slow, and the others take their
 time. Let anybody come in who wants to, but don't sell anything until
-the experts report to me in writing&mdash;&mdash;"</p>
+the experts report to me in writing——"</p>
 
-<p>"Suppose some chap rushes in with ten thousand&mdash;&mdash;"</p>
+<p>"Suppose some chap rushes in with ten thousand——"</p>
 
 <p>"No!"</p>
 
@@ -4623,17 +4623,17 @@ the experts report to me in writing&mdash;&mdash;"</p>
 
 <p>"Certainly not. Chaps who rush in with any serious money at all will
 rush in again all the faster if you make them wait. Don't sell a
-picture&mdash;not even to Valasco or any of the experts&mdash;&mdash;"</p>
+picture—not even to Valasco or any of the experts——"</p>
 
-<p>"Suppose a charming lady&mdash;&mdash;"</p>
+<p>"Suppose a charming lady——"</p>
 
 <p>"Now you understand, don't you? I wouldn't think of selling a single
 canvas until I have their reports and have made up my own mind that
 they're as nearly right as any expert can be who didn't actually see the
 artist paint the picture. The only trustworthy expert is the man who saw
-the picture painted&mdash;if you can believe his word."</p>
+the picture painted—if you can believe his word."</p>
 
-<p>"But my dear Quarren," protested Dankmere, seriously bewildered&mdash;"how
+<p>"But my dear Quarren," protested Dankmere, seriously bewildered—"how
 could any living expert ever have seen an artist, who died two hundred
 years ago, paint anything?"</p>
 
@@ -4647,16 +4647,16 @@ here?"</p>
 
 <p>"You'd better, I think. But don't have rowdy parties here, will you? And
 don't wander away and leave the door open. By George! I believe I'd
-better stay&mdash;&mdash;"</p>
+better stay——"</p>
 
 <p>"Rot! Go on and take your vacation, old chap! Back in a week?"</p>
 
-<p>"Yes; or any time you wire me&mdash;&mdash;"</p>
+<p>"Yes; or any time you wire me——"</p>
 
 <p>"Not I. I'll have a jolly time by myself."</p>
 
 <p>"Don't have too many men here in the evening. The smoke will get into
-those new curtains&mdash;&mdash;"</p>
+those new curtains——"</p>
 
 <p>Dankmere, in his trousers and undershirt, stretched on the divan,
 laughed and blew a cloud of smoke at the ceiling. Then, reaching forth
@@ -4665,7 +4665,7 @@ and applied both in a manner from which he could extract the most
 benefit.</p>
 
 <p>"Bon voyage!" he nodded to Quarren. "My duties and compliments and all
-that&mdash;and pick me out an heiress of sorts&mdash;there's a good fellow&mdash;&mdash;"</p>
+that—and pick me out an heiress of sorts—there's a good fellow——"</p>
 
 <p>As Quarren went out he heard his lordship burst forth into his
 distressing whistle; and he left him searching piercingly for
@@ -4693,7 +4693,7 @@ AMONG THE BRITISH ARISTOCRACY</p>
 <p>"GAMBLING SPIRIT BLAMED</p>
 
 <p>"OBSERVERS ASCRIBE POVERTY OF OLD BRITISH FAMILIES
-TO THIS CAUSE&mdash;MANY RENT ROLLS DECLARED
+TO THIS CAUSE—MANY RENT ROLLS DECLARED
 TO BE MORTGAGED</p>
 
 <p>"The opening of the so-called Dankmere galleries on Lexington
@@ -4741,9 +4741,9 @@ the sale of some of his treasures.</p>
 <p>"Such cases may be justified by circumstances. The general public
 hears, however, of only a few isolated cases. The number of private
 deals that are executed, week in, week out, between impoverished
-members of the highest nobility&mdash;some of them bound, like Lord
+members of the highest nobility—some of them bound, like Lord
 Blitherington<span class="pagenum" id="Page_263">[Pg 263]</span> and the Duke of Putney by close official ties to the
-Court&mdash;and the agents of either new-rich Britishers or wealthy
+Court—and the agents of either new-rich Britishers or wealthy
 Americans has reached its maximum, and by degrees unentailed
 treasures and heirlooms are passing from owners of many centuries
 to families that were unheard of a dozen years ago.</p>
@@ -4773,7 +4773,7 @@ society. The desire to acquire riches quickly seems to have taken
 hold of the erstwhile staid and conventional upper ten, just as it
 has seized upon the smart set. The recent booms in oil and rubber
 have had the effect of transferring many a comfortable rent roll
-from its owner's<span class="pagenum" id="Page_264">[Pg 264]</span> bankers&mdash;milady's just as often as milord's&mdash;to
+from its owner's<span class="pagenum" id="Page_264">[Pg 264]</span> bankers—milady's just as often as milord's—to
 the chartered mortgagors of the financial world. The panic in
 America in 1907 showed to what extent the English nobility was
 interested, not only in gilt-edged securities, but also to what
@@ -4803,7 +4803,7 @@ a fashionable architect had made the large house "colonially" endurable
 with furnaces and electricity as well as with fan-lights and fluted
 pilasters.</p>
 
-<p>Most of the land remained wild&mdash;weed-grown pastures, hard-wood ridges,
+<p>Most of the land remained wild—weed-grown pastures, hard-wood ridges,
 neglected orchards planted seventy years ago. Molly Wycherly had ordered
 a brand<span class="pagenum" id="Page_265">[Pg 265]</span> new old-time garden to be made for her overlooking the wide,
 unruffled river; also a series of sylvan paths along the wooded shores
@@ -4813,7 +4813,7 @@ of her husband.</p>
 <p>"For Heaven's sake," he said to his wife, "don't try to knock any
 antiquity into the place; I'm sick of fine old ancestral halls put up by
 building-loan associations. Plenty of paint and varnish for mine, Molly,
-and a few durable iron fountains and bronze stags on the lawn&mdash;&mdash;"</p>
+and a few durable iron fountains and bronze stags on the lawn——"</p>
 
 <p>"No, Jim," she said firmly.</p>
 
@@ -4831,11 +4831,11 @@ points of interest.</p>
 why anybody picked out this silly country for estates, but Langly Sprowl
 started a stud farm over yonder, and then poor Chester Ledwith built a
 house for his wife in the middle of a thousand acres, over there where
-you see those maple woods!&mdash;and then people began to come and pick up
-worn-out farms and make 'em into fine old family places&mdash;Lester
+you see those maple woods!—and then people began to come and pick up
+worn-out farms and make 'em into fine old family places—Lester
 Caldera's model dairies are behind that hill; and that leather-headed
-O'Hara has a bungalow somewhere&mdash;and there's a sort of Hunt Club, too,
-and a bum pack of Kiyi's&mdash;&mdash;"</p>
+O'Hara has a bungalow somewhere—and there's a sort of Hunt Club, too,
+and a bum pack of Kiyi's——"</p>
 
 <p><span class="pagenum" id="Page_266">[Pg 266]</span></p>
 
@@ -4845,7 +4845,7 @@ also interested him to observe how Wycherly shaved annihilation at every
 turn of the road.</p>
 
 <p>"I've asked some men to bring up their biplanes and have a few flies on
-me," continued his host&mdash;"I've a 'Stinger' monoplane and a Kent biplane
+me," continued his host—"I've a 'Stinger' monoplane and a Kent biplane
 myself. I can't get any more sensation out of motoring. I'd as soon
 wheel twins in a go-cart."</p>
 
@@ -4853,12 +4853,12 @@ wheel twins in a go-cart."</p>
 
 <p>"Who is stopping with you up here?" he shouted close to Wycherly's ear.</p>
 
-<p>"Nobody&mdash;Mrs. Leeds, Chrysos Lacy, and Sir Charles. There are some few
-neighbours, too&mdash;Langly is mousing and prowling about; and that poor
-Ledwith man is all alone in his big house&mdash;fixing to get out of it so
+<p>"Nobody—Mrs. Leeds, Chrysos Lacy, and Sir Charles. There are some few
+neighbours, too—Langly is mousing and prowling about; and that poor
+Ledwith man is all alone in his big house—fixing to get out of it so
 his wife can move in from Reno when she's ready for more mischief....
 Here we are, Quarren! Your stuff will be in your rooms in a few minutes.
-There's my wife, now&mdash;&mdash;"</p>
+There's my wife, now——"</p>
 
 <p>He waved his hand to Molly but let Quarren go forward alone while he
 started across the fields toward his hangar where, in grotesque and
@@ -4884,17 +4884,17 @@ suppose the child could possibly object."</p>
 
 <p>"Does she?"</p>
 
-<p>"Why&mdash;this morning I said carelessly to Jim that I meant to ask you, and
+<p>"Why—this morning I said carelessly to Jim that I meant to ask you, and
 Strelsa came into my room later and begged me not to ask you until she
 had left."</p>
 
 <p>"Why?" inquired the boy, grimly.</p>
 
-<p>"I really don't know, Ricky&mdash;&mdash;"</p>
+<p>"I really don't know, Ricky——"</p>
 
 <p>"Yes, you do. What has happened?"</p>
 
-<p>"You're certainly rude enough&mdash;&mdash;"</p>
+<p>"You're certainly rude enough——"</p>
 
 <p>"What has happened, Molly?"</p>
 
@@ -4910,9 +4910,9 @@ nearly every day."</p>
 
 <p>"Frankly, no. I'm much more afraid that Langly<span class="pagenum" id="Page_270">[Pg 270]</span> has persuaded her into
 some sort of a tacit engagement.... I don't know what the child can be
-thinking of&mdash;unless the universal criticism of Langly Sprowl has
+thinking of—unless the universal criticism of Langly Sprowl has
 convinced her of his martyrdom.... There'll be a pretty situation when
-Mary Ledwith returns.... I could kill Langly&mdash;" She doubled both pretty
+Mary Ledwith returns.... I could kill Langly—" She doubled both pretty
 hands and frowned at Quarren, then her swift smile broke out and she
 placed the tips of her fingers on his shoulders and stooping from the
 top step deliberately kissed him.</p>
@@ -4922,8 +4922,8 @@ whispered."]</p>
 
 <p>"You dear fellow," she said; "I don't care what Strelsa thinks; I'm glad
 you've come. And, oh, Ricky! The papers are full of you and Dankmere and
-your new enterprise!&mdash;I laughed and laughed!&mdash;forgive me, but the papers
-were so funny&mdash;and I couldn't help laughing&mdash;&mdash;"</p>
+your new enterprise!—I laughed and laughed!—forgive me, but the papers
+were so funny—and I couldn't help laughing——"</p>
 
 <p>Quarren forced a smile.</p>
 
@@ -4952,15 +4952,15 @@ her."</p>
 
 <p>"She is. Why, Ricky, the City had half a million on deposit there, and
 even that foxy young man Langly was caught for twice as much more. It's
-a ghastly scandal&mdash;the entire affair. How many cents on a dollar do you
+a ghastly scandal—the entire affair. How many cents on a dollar do you
 suppose poor little Strelsa is going to recover? Not two!"</p>
 
 <p>They paused at the door of his quarters. His luggage had already arrived
 and a valet was busy unpacking for him.</p>
 
 <p>"Sir Charles, Chrysos Lacy, Jim and I are motoring. We'll be back for
-tea. Prowl about, Ricky; the place is yours and everything in it&mdash;except
-that little girl over there"&mdash;pointing along the corridor to a distant
+tea. Prowl about, Ricky; the place is yours and everything in it—except
+that little girl over there"—pointing along the corridor to a distant
 door.</p>
 
 <p>He smiled. "She may be, yet," he said lightly. "Don't come back too
@@ -4978,13 +4978,13 @@ lie down on the lawn, dead beat, and Quarren resumed his toilet.</p>
 
 <p>Half an hour later he emerged from his quarters wearing tennis flannels
 and screwing the stem into a new pipe which he had decided to break
-in&mdash;a tall, well-built, pleasant-eyed young fellow with the city pallor<span class="pagenum" id="Page_272">[Pg 272]</span>
+in—a tall, well-built, pleasant-eyed young fellow with the city pallor<span class="pagenum" id="Page_272">[Pg 272]</span>
 blanching his skin and the breeze stirring his short blond hair.</p>
 
 <p>"Hello, old man!" he said affably to the fat setter, who thumped his
 tail on the grass and looked up at Quarren with mild, deerlike eyes.</p>
 
-<p>"We're out of the running, we two&mdash;aren't we?" he added. "You try very
+<p>"We're out of the running, we two—aren't we?" he added. "You try very
 pluckily to keep up with your master's devil-wagon; I run a more
 hopeless race.... For the golden chariot is too swift for me, and the
 race is to the swift; and the prize, doggy, is a young girl's unhappy
@@ -4996,7 +4996,7 @@ was in the air; the odour of June peonies, and young leaves and clear
 waters; of grasses and hedges and distant hemlocks.</p>
 
 <p>Leisurely, the fat dog waddling at his heels, he sauntered about the
-Wycherly place inspecting its renovated attractions&mdash;among others the
+Wycherly place inspecting its renovated attractions—among others the
 new old-fashioned garden full of new old-fashioned flowers so
 marvellously developed by modern skill that he recognised scarcely any
 of them. Petunias, with their great fluted and scalloped blossoms
@@ -5057,7 +5057,7 @@ waters exquisitely, and bits of sky lay level as in a looking-glass.</p>
 it; only the glitter of some drifting dragon-fly accented the intense
 calm.</p>
 
-<p>"Are you&mdash;offended?" she said at last, her gaze now riveted on the
+<p>"Are you—offended?" she said at last, her gaze now riveted on the
 water.</p>
 
 <p>"Of course not!" he replied cordially.</p>
@@ -5072,9 +5072,9 @@ water.</p>
 
 <p>"You did not answer it."</p>
 
-<p>"I didn't know how&mdash;then."</p>
+<p>"I didn't know how—then."</p>
 
-<p>His reply seemed to perplex her&mdash;so did his light and effortless
+<p>His reply seemed to perplex her—so did his light and effortless
 good-humour.</p>
 
 <p>"I know how to answer it now," he added.</p>
@@ -5093,22 +5093,22 @@ pocket.</p>
 
 <p>"Now," he said, smiling, "I am ready to answer your letter."</p>
 
-<p>"Really, Mr. Quarren&mdash;&mdash;"</p>
+<p>"Really, Mr. Quarren——"</p>
 
 <p><span class="pagenum" id="Page_279">[Pg 279]</span></p>
 
 <p>"Don't you want me to?"</p>
 
-<p>"I&mdash;don't think&mdash;it matters, now&mdash;&mdash;"</p>
+<p>"I—don't think—it matters, now——"</p>
 
 <p>"But it's only civil of me to answer it," he insisted, laughing.</p>
 
 <p>She could not entirely interpret his mood. Of one thing she had been
-instantly conscious&mdash;he had changed since she had seen him&mdash;changed
+instantly conscious—he had changed since she had seen him—changed
 radically. There was about him, now, a certain inexplicable air
-suggesting assurance&mdash;an individuality which had not heretofore clearly
-distinguished him&mdash;a hidden hint of strength. Or was she
-mistaken&mdash;abashed&mdash;remembering what she had written him in a bitter hour
+suggesting assurance—an individuality which had not heretofore clearly
+distinguished him—a hidden hint of strength. Or was she
+mistaken—abashed—remembering what she had written him in a bitter hour
 of fear and self-abasement? A thousand times she had regretted writing
 to him what she had written.</p>
 
@@ -5119,7 +5119,7 @@ unanswered."</p>
 
 <p>She looked at him steadily:</p>
 
-<p>"Yes, you are too late&mdash;in every sense."</p>
+<p>"Yes, you are too late—in every sense."</p>
 
 <p>"You are mistaken," he said, cheerfully.</p>
 
@@ -5152,7 +5152,7 @@ and worthy citizens you've hastened up here to admonish the frivolous, I
 suppose."</p>
 
 <p>"I'm so respectable and worthy," he admitted, "that I couldn't resist
-rushing up here to exhibit myself. Look at that bruise!"&mdash;he held out to
+rushing up here to exhibit myself. Look at that bruise!"—he held out to
 her his left hand badly discoloured between thumb and forefinger.</p>
 
 <p>"Oh," she exclaimed, half serious, "what <i>is</i> it?"</p>
@@ -5170,8 +5170,8 @@ inwardly wondering what his attitude toward her might really mean.</p>
 
 <p>"Do you admit my worthiness as a son of toil?" he insisted.</p>
 
-<p>"How can I deny it?&mdash;with that horrid corroboration on your hand. I'll
-lend you some witch-hazel&mdash;&mdash;"</p>
+<p>"How can I deny it?—with that horrid corroboration on your hand. I'll
+lend you some witch-hazel——"</p>
 
 <p>"Witch-hazel from Witch-Hollow ought to accomplish all kinds of magic,"
 he said. "I'll be delighted to have you bind it up."</p>
@@ -5188,7 +5188,7 @@ handkerchief soaked with witch-hazel."</p>
 <p>"Is that why you didn't include yourself in your first-aid offer?"</p>
 
 <p>"Perhaps," she said, quietly, watching him out of her violet-gray
-eyes&mdash;a little curiously and shyly now, because he had moved nearer to
+eyes—a little curiously and shyly now, because he had moved nearer to
 her, and her arm, extended along the back of the seat, almost touched
 his shoulder.</p>
 
@@ -5213,7 +5213,7 @@ she could not ignore his unwarranted freedom.</p>
 
 <p>"Because I always think of you as Strelsa, not as Mrs. Leeds."</p>
 
-<p>"Is that a reason?"&mdash;very gravely.</p>
+<p>"Is that a reason?"—very gravely.</p>
 
 <p>"You can make it so if you will."</p>
 
@@ -5221,7 +5221,7 @@ she could not ignore his unwarranted freedom.</p>
 
 <p><span class="pagenum" id="Page_282">[Pg 282]</span></p>
 
-<p>"You say that you always think of me&mdash;that way. But I'm afraid that,
+<p>"You say that you always think of me—that way. But I'm afraid that,
 even in your thoughts, the repetition of my name has scarcely accustomed
 you to the use of it."</p>
 
@@ -5229,11 +5229,11 @@ you to the use of it."</p>
 
 <p>"Something like that. But please, Mr. Quarren, if you really mean to
 give me a little of that friendship which I had begun to despair of,
-don't let our very first reunion degenerate into silly conversation&mdash;&mdash;"</p>
+don't let our very first reunion degenerate into silly conversation——"</p>
 
-<p>"Strelsa&mdash;&mdash;"</p>
+<p>"Strelsa——"</p>
 
-<p>"No!&mdash;please."</p>
+<p>"No!—please."</p>
 
 <p>"When?"</p>
 
@@ -5248,39 +5248,39 @@ Quarren?"</p>
 
 <p>"Have you ever found me dishonest?"</p>
 
-<p>"Sometimes&mdash;with yourself."</p>
+<p>"Sometimes—with yourself."</p>
 
 <p>Suddenly the colour surged in her cheeks and she turned her head
 abruptly. After a few moments' silence:</p>
 
 <p>"Ask your question," she said in a calm and indifferent voice.</p>
 
-<p>"Then&mdash;do you ever, by any accident, think of me?"</p>
+<p>"Then—do you ever, by any accident, think of me?"</p>
 
 <p>She foresaw at once what was coming, bit her lip, but saw no way to
 avoid it.</p>
 
-<p>"I think of my friends&mdash;and you among them."</p>
+<p>"I think of my friends—and you among them."</p>
 
 <p>"Do you always think of me as 'Mr. Quarren'?"</p>
 
-<p>"I&mdash;your friends&mdash;people are eternally dinning your name into my
-ears&mdash;&mdash;"</p>
+<p>"I—your friends—people are eternally dinning your name into my
+ears——"</p>
 
 <p><span class="pagenum" id="Page_283">[Pg 283]</span></p>
 
 <p>"Please answer."</p>
 
 <p>"What?" She turned toward him disdainfully: "Would it gratify you to
-know that I think of you as Rix, Ricky, Dick&mdash;whatever they call you?"</p>
+know that I think of you as Rix, Ricky, Dick—whatever they call you?"</p>
 
 <p>"Which?" he insisted, laughing. And finally she laughed, too, partly in
 sheer exasperation.</p>
 
 <p>"Rix!" she said: "Now are you satisfied? I don't know why on earth I
-made such a scene about it. It's the way I think of you&mdash;when I happen
+made such a scene about it. It's the way I think of you—when I happen
 to remember you. But if you fancy for a moment I am going to call you
-that, please awake from vain dreams, my airy friend&mdash;&mdash;"</p>
+that, please awake from vain dreams, my airy friend——"</p>
 
 <p>"Won't you?"</p>
 
@@ -5289,8 +5289,8 @@ that, please awake from vain dreams, my airy friend&mdash;&mdash;"</p>
 <p>"Some day?"</p>
 
 <p>"Certainly not. Why should I? I don't want to. I don't feel like
-it. It would be forced, artificial&mdash;an effort&mdash;and I don't
-desire&mdash;wish&mdash;care&mdash;&mdash;"</p>
+it. It would be forced, artificial—an effort—and I don't
+desire—wish—care——"</p>
 
 <p>"Good Heavens!" he exclaimed, laughing, "that's enough, you poor child!
 Do you think I'd permit you to undergo the suffering necessary to the
@@ -5302,7 +5302,7 @@ were swiftly lifted every few moments to watch him. Suddenly she became
 acutely conscious of her extended arm where her hand now was lightly in
 touch with the rough cloth of his sleeve; and she checked a violent
 impulse to withdraw her hand. Then, once more, and after all these
-months, the same strange sensation passed through her&mdash;a thrilling
+months, the same strange sensation passed through her—a thrilling
 consciousness of his nearness.</p>
 
 <p>Absolutely motionless, confused yet every instinct<span class="pagenum" id="Page_284">[Pg 284]</span> alert to his
@@ -5325,7 +5325,7 @@ specimen known to you as <i>Mister</i> Quarren?"</p>
 
 <p>"How absurd. Of course there is a wall."</p>
 
-<p>"I've got to climb over it then&mdash;&mdash;"</p>
+<p>"I've got to climb over it then——"</p>
 
 <p>"I don't wish you to!"</p>
 
@@ -5335,27 +5335,27 @@ specimen known to you as <i>Mister</i> Quarren?"</p>
 
 <p>"That wall isn't a golden one, is it?"</p>
 
-<p>"I&mdash;I don't know what you mean."</p>
+<p>"I—I don't know what you mean."</p>
 
 <p>"I mean money," he said; and she blushed from neck to hair.</p>
 
-<p>"Please don't say such things&mdash;&mdash;"</p>
+<p>"Please don't say such things——"</p>
 
 <p>"No, I won't. Because if you cared enough for me you wouldn't let that
-kind of a wall remain between us&mdash;&mdash;"</p>
+kind of a wall remain between us——"</p>
 
-<p>"I ask you not to talk about such&mdash;&mdash;"</p>
+<p>"I ask you not to talk about such——"</p>
 
 <p>"You <i>wouldn't</i>," he insisted, smiling. "Nor is there now any reason why
 such a man as I am becoming, and ultimately will be, should not tell you
-that he cares&mdash;&mdash;"</p>
+that he cares——"</p>
 
 <p><span class="pagenum" id="Page_285">[Pg 285]</span></p>
 
-<p>"Please&mdash;if you please&mdash;I had rather not&mdash;&mdash;"</p>
+<p>"Please—if you please—I had rather not——"</p>
 
 <p>"So," he concluded, still smiling, "the matter, as it stands, is rather
-plain. You don't care for me enough. I love you&mdash;I don't know how much,
+plain. You don't care for me enough. I love you—I don't know how much,
 yet. When a girl interposes such an occult barrier and a man comes slap
 up against it, he's too much addled to understand exactly how seriously
 he is in love with the unknown on the other side."</p>
@@ -5366,23 +5366,23 @@ along the back of the seat. And the contact seemed to paralyse every
 nerve in her body.</p>
 
 <p>"Because," he continued, leisurely, "the unknown does lie on the other
-side of that barrier&mdash;your unknown self, Strelsa&mdash;undiscovered as yet by
-me&mdash;&mdash;"</p>
+side of that barrier—your unknown self, Strelsa—undiscovered as yet by
+me——"</p>
 
 <p>Her lips moved mechanically:</p>
 
-<p>"I wrote you&mdash;<i>told</i> you what I am."</p>
+<p>"I wrote you—<i>told</i> you what I am."</p>
 
 <p>"Oh, that?" He laughed: "That was a mood. I don't think you know
-yourself&mdash;&mdash;"</p>
+yourself——"</p>
 
 <p>"I do. I <i>am</i> what I wrote you."</p>
 
-<p>"Partly perhaps&mdash;partly a rather frightened girl, still quivering from a
-sequence of blows&mdash;&mdash;"</p>
+<p>"Partly perhaps—partly a rather frightened girl, still quivering from a
+sequence of blows——"</p>
 
 <p>"Remembering all the other blows that have marked almost every year of
-my life!&mdash;But those would not count&mdash;if I were not selfish, dishonest,
+my life!—But those would not count—if I were not selfish, dishonest,
 and a coward."</p>
 
 <p>His hand closed slightly over hers; for a moment or two the pressure
@@ -5395,35 +5395,35 @@ motionless, looking down at the still lake below.</p>
 
 <p><span class="pagenum" id="Page_286">[Pg 286]</span></p>
 
-<p>"There is no barrier to your friendship&mdash;if you care to offer it, now
+<p>"There is no barrier to your friendship—if you care to offer it, now
 that you know me."</p>
 
 <p>"But I <i>don't</i> know you. And I care for more than your friendship even
 after the glimpse I have had of you."</p>
 
-<p>"I&mdash;care only for friendship, Mr. Quarren."</p>
+<p>"I—care only for friendship, Mr. Quarren."</p>
 
 <p>"<i>Could</i> you ever care for more?"</p>
 
 <p>"No.... I don't wish to.... There <i>is</i> nothing higher."</p>
 
-<p>"<i>Could</i> you&mdash;if there were?"</p>
+<p>"<i>Could</i> you—if there were?"</p>
 
 <p>But she remained silent, disturbed, troubled once more by the light
 weight of his hand over hers which seemed to be awaking again the new
-senses that his touch had discovered so long ago&mdash;and which had
+senses that his touch had discovered so long ago—and which had
 slumbered in her ever since. Was this acquiescence, this listless
-relaxation, this lassitude which was becoming almost painful&mdash;or
-sweet&mdash;she did not understand which&mdash;was this also a part of friendship?
-Was it a part of anything intellectual, spiritual, worthy?&mdash;this
+relaxation, this lassitude which was becoming almost painful—or
+sweet—she did not understand which—was this also a part of friendship?
+Was it a part of anything intellectual, spiritual, worthy?—this
 deepening emotion which, no longer vague and undefined, was threatening
-her pulses, her even breathing&mdash;menacing the delicate nerves in her hand
-so that already they had begun to warn her, quivering&mdash;&mdash;</p>
+her pulses, her even breathing—menacing the delicate nerves in her hand
+so that already they had begun to warn her, quivering——</p>
 
 <p>She withdrew her hand, sharply, and straightened her shoulders with a
 little quick indrawn breath.</p>
 
-<p>"I've got to tell you something," she said abruptly&mdash;scarcely knowing
+<p>"I've got to tell you something," she said abruptly—scarcely knowing
 what she was saying.</p>
 
 <p>"What, Strelsa?"</p>
@@ -5443,20 +5443,20 @@ became fixed and white, then he said, cheerfully:</p>
 
 <p>"You have no chance, Mr. Quarren."</p>
 
-<p>"With&mdash;<i>him</i>?" He shrugged his contempt. "I don't consider him at
-all&mdash;&mdash;"</p>
+<p>"With—<i>him</i>?" He shrugged his contempt. "I don't consider him at
+all——"</p>
 
 <p>"I don't care to hear you speak that way!" she said, hotly.</p>
 
 <p>"Oh, I won't. A man's an ass to vilify his rival. But I wasn't even
-thinking of him, Strelsa. My fight is with you&mdash;with your unknown self
+thinking of him, Strelsa. My fight is with you—with your unknown self
 behind that barrier. <i>Garde à vous!</i>"</p>
 
 <p>"I decline the combat, Monsieur," she said, trying to speak lightly.</p>
 
-<p>"Oh, I'm not afraid of <i>you</i>&mdash;the <i>visible</i> you that I'm looking at and
+<p>"Oh, I'm not afraid of <i>you</i>—the <i>visible</i> you that I'm looking at and
 which I know something about. That incarnation of Strelsa Leeds will
-fight me openly, fairly&mdash;and I have an even chance to win&mdash;&mdash;"</p>
+fight me openly, fairly—and I have an even chance to win——"</p>
 
 <p>"Do you think so?" she said, lip between her teeth.</p>
 
@@ -5469,10 +5469,10 @@ knows what it may do to both of us."</p>
 
 <p>"There is no other self! What do you mean?"</p>
 
-<p>"There are <i>two</i> others&mdash;not this intellectual, friendly, kindly,
-visible self that offers friendship and accepts it&mdash;not even the occult,
+<p>"There are <i>two</i> others—not this intellectual, friendly, kindly,
+visible self that offers friendship and accepts it—not even the occult,
 aloof, spiritual self that I sometimes see brooding in your gray
-eyes&mdash;&mdash;"</p>
+eyes——"</p>
 
 <p>"There <i>is</i> no other!" she said, flushing and rising to her feet.</p>
 
@@ -5482,7 +5482,7 @@ eyes&mdash;&mdash;"</p>
 
 <p>"It never lived!"</p>
 
-<p>"Then," he said coolly, "it will be born as sure as I stand here!&mdash;born
+<p>"Then," he said coolly, "it will be born as sure as I stand here!—born
 to complete the trinity." He glanced out over the lake, then swung
 around sharply: "You are wrong. It <i>has</i> been born. And that unknown
 self is hostile to me; and I know it!"</p>
@@ -5496,7 +5496,7 @@ said: "I think we have talked some nonsense. Don't you?"</p>
 
 <p>"You say so."</p>
 
-<p>"Oh, I'll cheerfully admit it. If you weren't you'd detest me&mdash;perhaps
+<p>"Oh, I'll cheerfully admit it. If you weren't you'd detest me—perhaps
 despise me."</p>
 
 <p>"Men don't detest or despise a hurt and frightened child."</p>
@@ -5509,12 +5509,12 @@ her?"</p>
 <p>She strove to laugh but her mouth suddenly became tremulous. After a
 while when she could control her lips she said:</p>
 
-<p>"I want to talk some more to you&mdash;and I don't know how; I don't even
-know what I want to say except that&mdash;that&mdash;&mdash;"</p>
+<p>"I want to talk some more to you—and I don't know how; I don't even
+know what I want to say except that—that——"</p>
 
 <p>"What, Strelsa?"</p>
 
-<p>"Please be&mdash;kind to me." She smiled at him, but her lips still quivered.</p>
+<p>"Please be—kind to me." She smiled at him, but her lips still quivered.</p>
 
 <p>He said after a moment: "I couldn't be anything else."</p>
 
@@ -5540,11 +5540,11 @@ wanted to speak to Quarren. He could hear her laughing before she spoke:</p>
 
 <p>"Am I an angel or otherwise?"</p>
 
-<p>"Angel always&mdash;but why particularly at this instant?"</p>
+<p>"Angel always—but why particularly at this instant?"</p>
 
 <p>"Stupid! Haven't you had her alone all the after-noon?"</p>
 
-<p>"Yes&mdash;you corker!"</p>
+<p>"Yes—you corker!"</p>
 
 <p>"Well, then!"</p>
 
@@ -5598,7 +5598,7 @@ her frail pink gown looking distractingly pretty and demure.</p>
 
 <p>"Yes, you were!"</p>
 
-<p>"I'm delighted you found the time too long&mdash;&mdash;"</p>
+<p>"I'm delighted you found the time too long——"</p>
 
 <p>"I did not say so! If you think it was short I shall warn Jim Wycherly
 how time flies with you and Molly.... Oh, dear! <i>Is</i> that a mosquito?"</p>
@@ -5623,7 +5623,7 @@ aureole for you?" he said.</p>
 
 <p>"I meant to offer you a <i>double</i> halo."</p>
 
-<p>"You do say sweet things&mdash;for a rather obstinate young man," she said,
+<p>"You do say sweet things—for a rather obstinate young man," she said,
 flashing a laughing side glance at him. Then she walked slowly through
 the sunshine into the dimmer music-room, and found a seat at the piano.
 Her mood changed; she became gay, capricious, even a trifle imperative:</p>
@@ -5633,7 +5633,7 @@ Her mood changed; she became gay, capricious, even a trifle imperative:</p>
 <p>"Otherwise," she said, "you'd have attempted to seat yourself on this
 bench; and there isn't room for both of us without crowding."</p>
 
-<p>"If you moved a little&mdash;&mdash;"</p>
+<p>"If you moved a little——"</p>
 
 <p>"But I won't," she said serenely, and dropped her slim hands on the
 key-board.</p>
@@ -5696,25 +5696,25 @@ seven solemn handsprings?"</p>
 <p>He prepared to do so but she wouldn't permit him:</p>
 
 <p>"No! I don't want to remember you doing such a thing.... All the same I
-believe <i>you</i> could do it and not lose&mdash;lose&mdash;&mdash;"</p>
+believe <i>you</i> could do it and not lose—lose——"</p>
 
 <p>"Dignity?"</p>
 
-<p>"No&mdash;I don't know what I mean. Come, Mr. Quarren; I am waiting for you
+<p>"No—I don't know what I mean. Come, Mr. Quarren; I am waiting for you
 to do something silly."</p>
 
 <p>"Shall I say it or do it?"</p>
 
 <p>"Either."</p>
 
-<p>"Then I'll recite something very, very precious&mdash;subtly, intricately,
+<p>"Then I'll recite something very, very precious—subtly, intricately,
 and psychologically precious."</p>
 
 <p><span class="pagenum" id="Page_297">[Pg 297]</span></p>
 
 <p>"Oh, please do!"</p>
 
-<p>"It's&mdash;it's about a lover."</p>
+<p>"It's—it's about a lover."</p>
 
 <p>She blushed.</p>
 
@@ -5726,7 +5726,7 @@ and psychologically precious."</p>
 
 <p>"Naturally."</p>
 
-<p>"And love&mdash;rash, precipitate, unwarranted, unrequited, and fatal love."</p>
+<p>"And love—rash, precipitate, unwarranted, unrequited, and fatal love."</p>
 
 <p>"I can stand it if you can," she said with the faintest glimmer of
 malice in her smile.</p>
@@ -5794,62 +5794,62 @@ lips and eyes that looked up blindly into his.</p>
 <p>Then her face burned scarlet and she sprang up, retreating as he caught
 her slender hand:</p>
 
-<p>"No!&mdash;please. Let me go! This is too serious&mdash;even if we did not mean
-it&mdash;&mdash;"</p>
+<p>"No!—please. Let me go! This is too serious—even if we did not mean
+it——"</p>
 
 <p>"You know I mean it," he said simply.</p>
 
-<p>"You must not! You understand why!... And don't&mdash;again! I am not&mdash;I do
-not choose to&mdash;to allow&mdash;endure&mdash;such&mdash;things&mdash;&mdash;"</p>
+<p>"You must not! You understand why!... And don't—again! I am not—I do
+not choose to—to allow—endure—such—things——"</p>
 
 <p><span class="pagenum" id="Page_299">[Pg 299]</span></p>
 
 <p>He still held her by one hand and she stood twisting at it and looking
 at him with cheeks still crimson and eyes still a little dazed.</p>
 
-<p>"Please!" she repeated&mdash;and "please!" And she came toward him a step,
+<p>"Please!" she repeated—and "please!" And she came toward him a step,
 and laid her other hand over the one that still held hers.</p>
 
 <p>"Won't you be kind to me?" she said under her breath. "Be kind to
-me&mdash;and let me go."</p>
+me—and let me go."</p>
 
 <p>"Am I unkind?"</p>
 
-<p>"Yes&mdash;yes! You know&mdash;you know how it is with me! Let me go my way.... I
-<i>am</i> going anyhow!" she added fiercely; "you can't check me&mdash;not for one
+<p>"Yes—yes! You know—you know how it is with me! Let me go my way.... I
+<i>am</i> going anyhow!" she added fiercely; "you can't check me—not for one
 moment!"</p>
 
 <p>"Check you from what, Strelsa?"</p>
 
-<p>"From&mdash;what I want out of life!&mdash;tranquillity, ease, security,
-happiness&mdash;&mdash;"</p>
+<p>"From—what I want out of life!—tranquillity, ease, security,
+happiness——"</p>
 
 <p>"Happiness?"</p>
 
-<p>"Yes&mdash;yes! It <i>will</i> be that! I don't need anything except what I shall
+<p>"Yes—yes! It <i>will</i> be that! I don't need anything except what I shall
 have. I don't want anything else. Can't you understand? Do you think
-women feel as&mdash;as men do? Do you think the kind of love that men
+women feel as—as men do? Do you think the kind of love that men
 experience is also experienced by women? I don't want it; I don't
-require it! I've&mdash;I've always had a contempt for it&mdash;and I have
+require it! I've—I've always had a contempt for it—and I have
 still.... Anyway I have offered you the best that is in me to offer any
-man&mdash;friendship. That is the nearest I can come to love. Why can't you
-take it&mdash;and let me alone! What is it to you if I marry and find
+man—friendship. That is the nearest I can come to love. Why can't you
+take it—and let me alone! What is it to you if I marry and find
 security and comfort and quiet and protection, as long as I give you my
-friendship&mdash;as long as I never swerve in it&mdash;as long as I hold you first
-among my friends&mdash;first among men if you wish! More I cannot offer
-you&mdash;I will not! Now let me go!"</p>
+friendship—as long as I never swerve in it—as long as I hold you first
+among my friends—first among men if you wish! More I cannot offer
+you—I will not! Now let me go!"</p>
 
 <p><span class="pagenum" id="Page_300">[Pg 300]</span></p>
 
 <p>"Your <i>other</i> self, fighting me," he said, half to himself.</p>
 
-<p>"No, <i>I</i> am! What do you mean by my other self! There <i>is</i> no other&mdash;&mdash;"</p>
+<p>"No, <i>I</i> am! What do you mean by my other self! There <i>is</i> no other——"</p>
 
 <p>"Its lips rested on mine for a moment!"</p>
 
 <p>She blushed scarlet:</p>
 
-<p>"Is <i>that</i> what you mean!&mdash;the stupid, unworthy, material self&mdash;&mdash;"</p>
+<p>"Is <i>that</i> what you mean!—the stupid, unworthy, material self——"</p>
 
 <p>"The trinity is incomplete without it."</p>
 
@@ -5861,10 +5861,10 @@ pockets, his teeth worrying his under lip:</p>
 
 <p>"I'm not going to give you up," he said. "I love you. Whatever is
 lacking in you makes no difference to me. My being poor and your being
-poor makes no difference either. I simply don't care&mdash;I don't even care
+poor makes no difference either. I simply don't care—I don't even care
 what you think about it. Because I know that we will be worth it to each
-other&mdash;whether you think so or not. And you evidently don't, but I can't
-help that. If I'm any good I'll make you think as I do&mdash;&mdash;"</p>
+other—whether you think so or not. And you evidently don't, but I can't
+help that. If I'm any good I'll make you think as I do——"</p>
 
 <p>He swung on his heel and came straight up to her, took her in his arms
 and kissed her, then, releasing her, turned toward the window, his brows
@@ -5878,7 +5878,7 @@ under his cheeks.</p>
 
 <p>She stood dumb, still cold and rigid with repulsion from the swift and
 almost brutal contact. That time nothing in her had responded. Vaguely
-she felt that<span class="pagenum" id="Page_301">[Pg 301]</span> what had been there was now dead&mdash;that she never could
+she felt that<span class="pagenum" id="Page_301">[Pg 301]</span> what had been there was now dead—that she never could
 respond again; that, from the lesser emotions, she was clean and free
 forever.</p>
 
@@ -5889,14 +5889,14 @@ turning toward her.</p>
 
 <p>He shook his head, hopelessly:</p>
 
-<p>"Oh, it's everything else, too&mdash;everything on earth&mdash;and
-afterward&mdash;everything&mdash;mind, soul and body&mdash;birth, life, death&mdash;sky and
-land and sea&mdash;everything that is or was or will be&mdash;&mdash;"</p>
+<p>"Oh, it's everything else, too—everything on earth—and
+afterward—everything—mind, soul and body—birth, life, death—sky and
+land and sea—everything that is or was or will be——"</p>
 
-<p>His hands clenched, relaxed; he made a gesture, half checked&mdash;looked up
+<p>His hands clenched, relaxed; he made a gesture, half checked—looked up
 at her, looked long and steadily into her expressionless eyes.</p>
 
-<p>"You care for money, position, ease, security, tranquillity&mdash;more than
+<p>"You care for money, position, ease, security, tranquillity—more than
 for love; do you?"</p>
 
 <p>"Yes."</p>
@@ -5912,7 +5912,7 @@ for love; do you?"</p>
 <p>"Then there <i>is</i> something lacking in you."</p>
 
 <p>"Perhaps. I have never loved in the manner you mean. I do not wish to.
-Perhaps I am incapable of it.... I hope I am; I believe&mdash;I believe&mdash;"
+Perhaps I am incapable of it.... I hope I am; I believe—I believe—"
 But she fell silent, standing with eyes lowered and the warm blood once
 more stinging her cheeks.</p>
 
@@ -5928,7 +5928,7 @@ more stinging her cheeks.</p>
 
 <p>To keep her composure became difficult:</p>
 
-<p>"It is your affair, Mr. Quarren&mdash;if you still care to preserve our
+<p>"It is your affair, Mr. Quarren—if you still care to preserve our
 friendship."</p>
 
 <p>"Would a kiss shatter it?"</p>
@@ -5939,7 +5939,7 @@ friendship."</p>
 
 <p>"It doesn't seem to be very solidly founded, does it?"</p>
 
-<p>"Friendship is the frailest thing in the world&mdash;and the mightiest.... I
+<p>"Friendship is the frailest thing in the world—and the mightiest.... I
 am waiting for your decision."</p>
 
 <p>He walked up to her again, and she steeled herself, not knowing what to
@@ -5962,7 +5962,7 @@ anyway."</p>
 
 <p>"Wouldn't," she said calmly; but her face was crimson.</p>
 
-<p>"Oh," he said under his breath&mdash;"you <i>are</i> capable of love."</p>
+<p>"Oh," he said under his breath—"you <i>are</i> capable of love."</p>
 
 <p>"I think not, Mr. Quarren; but I am very capable of hate."</p>
 
@@ -5989,39 +5989,39 @@ herself.</p>
 
 <p>She was playing rag-time when the motor party entered; Quarren came
 forward and shook hands with Chrysos Lacy and Sir Charles; Langly Sprowl
-passed him with a short nod, saying "How are you, Quarren?"&mdash;and kept
+passed him with a short nod, saying "How are you, Quarren?"—and kept
 straight on to Strelsa.</p>
 
 <p>"Rotten luck," he said in his full, careless voice; "I'd meant to ride
 over and chance a gallop with you but Wycherly picked me up and started
 on one of his break-neck tears.... What have you been up to all day?"</p>
 
-<p>"Nothing&mdash;Mr. Quarren came."</p>
+<p>"Nothing—Mr. Quarren came."</p>
 
-<p>"I see&mdash;showed him about, I expect."</p>
+<p>"I see—showed him about, I expect."</p>
 
-<p>"A&mdash;little."</p>
+<p>"A—little."</p>
 
 <p>"Are you feeling fit, Strelsa?"</p>
 
 <p>"Perfectly.... Why?"</p>
 
-<p>"You look a bit streaky&mdash;&mdash;"</p>
+<p>"You look a bit streaky——"</p>
 
 <p>"Thank you!"</p>
 
-<p>"'Pon my word you do&mdash;a bit under the weather, you know&mdash;&mdash;"</p>
+<p>"'Pon my word you do—a bit under the weather, you know——"</p>
 
-<p>"Woman's only friend and protector&mdash;a headache," she said, gaily
+<p>"Woman's only friend and protector—a headache," she said, gaily
 rattling off more rag-time. "Where did you go, Langly?"</p>
 
-<p>"To look over some silly horses&mdash;&mdash;"</p>
+<p>"To look over some silly horses——"</p>
 
-<p>"They're fine nags!" remonstrated Molly&mdash;"and I was perfectly sure that
+<p>"They're fine nags!" remonstrated Molly—"and I was perfectly sure that
 Langly would buy half a dozen."</p>
 
 <p>"Not I," said that hatchet-faced young man; and<span class="pagenum" id="Page_304">[Pg 304]</span> into his sleek and
-restless features came a glimmer of shrewdness&mdash;the sly thrift that
+restless features came a glimmer of shrewdness—the sly thrift that
 lurks in the faces of those who bargain much and wisely in petty wares.
 It must have been a momentary ancestral gleam from his rum-smuggling
 ancestors, for Langly Sprowl had never dealt in little things.</p>
@@ -6041,7 +6041,7 @@ to earth, Molly!"</p>
 
 <p>"You'll come to earth if you go sky-skating around the clouds in that
 horrid little Stinger, Jim," she said. "Why couldn't <i>you</i> take out the
-Stinger for a little exercise?"&mdash;turning to Sprowl.</p>
+Stinger for a little exercise?"—turning to Sprowl.</p>
 
 <p>"I'm going to," said Sprowl in his full penetrating voice, not conscious
 that it required courage to risk a flight with the Stinger. Nobody had
@@ -6065,14 +6065,14 @@ she were speaking an unfamiliar language.</p>
 
 <p>"Isn't she built for two?"</p>
 
-<p>"Well, I suppose she <i>could</i> get off the ground with you and me&mdash;&mdash;"</p>
+<p>"Well, I suppose she <i>could</i> get off the ground with you and me——"</p>
 
 <p>"All right; let's try her?"</p>
 
 <p>"Jim! I won't let you," said his wife.</p>
 
 <p>"Don't be silly, Molly. Rix and I are not going up if she won't take
-us&mdash;&mdash;"</p>
+us——"</p>
 
 <p>"I forbid you to try! It's senseless!"</p>
 
@@ -6080,7 +6080,7 @@ us&mdash;&mdash;"</p>
 motor goggles around his fingers he stood looking at Strelsa.</p>
 
 <p>"You're a pretty little peach," he said sentimentally, "and I'm sorry
-Molly is here or&mdash;&mdash;"</p>
+Molly is here or——"</p>
 
 <p>"Do <i>you</i> care?" laughed Strelsa, looking around at him over her
 shoulder. "<i>I</i> don't mind being adored by <i>you</i>, Jim."</p>
@@ -6103,7 +6103,7 @@ and sinister dog turns when laughed at.</p>
 Wycherly.</p>
 
 <p>Molly said: "It's time to dress, good people.<span class="pagenum" id="Page_306">[Pg 306]</span> Langly, your man is
-upstairs with your outfit. Come, Chrysos, dear&mdash;Rix, have you everything
+upstairs with your outfit. Come, Chrysos, dear—Rix, have you everything
 you want?" she added in a low voice as he stood aside for her to pass:
 "Have you <i>everything</i>, Ricky?"</p>
 
@@ -6130,7 +6130,7 @@ little Dankmere?"</p>
 <p>"He happens to be my partner," said the other.</p>
 
 <p>"He suits your business no doubt," said Sprowl with a contempt he took
-no pains to conceal&mdash;a contempt which very plainly included Quarren as
+no pains to conceal—a contempt which very plainly included Quarren as
 well as the Earl and the picture business.</p>
 
 <p>Arrived at his door he glanced around to stare absently at Quarren. The
@@ -6158,21 +6158,21 @@ speak, twice, then jerked open his door and disappeared.</p>
 the long-distance telephone.</p>
 
 <p>"Do you want me to come back?" asked the young fellow. "I don't mind if
-you do; I'm quite ready to return&mdash;&mdash;"</p>
+you do; I'm quite ready to return——"</p>
 
 <p>"Not at all, my dear chap," said his lordship. "I fancied you might care
 to hear how matters are going in the Dankmere Galleries."</p>
 
 <p>"Of course I do, but I rather hoped nothing in particular would happen
-for a week or so&mdash;&mdash;"</p>
+for a week or so——"</p>
 
 <p>"Plenty has. You know those experts of yours, Valasco, Drayton-Quinn,
 and that Hollander Van Boschoven. Well, they don't get on. Each has come
 to me privately, and in turn, and told me that the others were no
-good&mdash;&mdash;"</p>
+good——"</p>
 
 <p>"Your rôle is to remain amiable and non-committal," said Quarren. "Let
-them talk&mdash;&mdash;"</p>
+them talk——"</p>
 
 <p>"Valasco and Drayton-Quinn won't speak, and Van Boschoven has notified
 me that he declines to come to the house as long as either of the others
@@ -6186,7 +6186,7 @@ are there."</p>
 
 <p><span class="pagenum" id="Page_308">[Pg 308]</span></p>
 
-<p>"Because&mdash;the fact is&mdash;I believe I practically&mdash;so to speak&mdash;hit him."</p>
+<p>"Because—the fact is—I believe I practically—so to speak—hit him."</p>
 
 <p>"What!"</p>
 
@@ -6195,33 +6195,33 @@ are there."</p>
 <p>"Why?"</p>
 
 <p>"Well, he asked me if I knew more about anything than I did about
-pictures. I didn't catch his drift for about an hour&mdash;but then it came
+pictures. I didn't catch his drift for about an hour—but then it came
 to me, and I got up out of my chair and walked over and punched his
 head. I don't think he'll come back, do you?"</p>
 
 <p>"No, I don't. What else have you been doing?" said Quarren angrily.</p>
 
-<p>"Nothing. One picture&mdash;the Raeburn portrait&mdash;has a bad hole in it."</p>
+<p>"Nothing. One picture—the Raeburn portrait—has a bad hole in it."</p>
 
 <p>"How did it happen?"</p>
 
 <p>"Rather extraordinary thing, that! I was giving a most respectable card
-party&mdash;some ladies and gentlemen of sorts&mdash;from the Winter Garden I
-believe&mdash;and one of the ladies inadvertently shyed a glass at another
-lady&mdash;&mdash;"</p>
+party—some ladies and gentlemen of sorts—from the Winter Garden I
+believe—and one of the ladies inadvertently shyed a glass at another
+lady——"</p>
 
-<p>"For Heaven's sake, Dankmere&mdash;&mdash;"</p>
+<p>"For Heaven's sake, Dankmere——"</p>
 
-<p>"Quite right old chap&mdash;my fault entirely&mdash;I won't do it again. But, do
+<p>"Quite right old chap—my fault entirely—I won't do it again. But, do
 you know, the gallery already has become a most popular resort. People
-are coming and going all day&mdash;a lot of dealers among them I suspect&mdash;and
+are coming and going all day—a lot of dealers among them I suspect—and
 there have been a number of theatrical people who want to hire pictures
-for certain productions to be staged next winter&mdash;&mdash;"</p>
+for certain productions to be staged next winter——"</p>
 
 <p>"We don't do that sort of thing!"</p>
 
 <p>"That's what I thought; but there was one very fetching girl who opens
-in 'Ancestors' next October&mdash;&mdash;"</p>
+in 'Ancestors' next October——"</p>
 
 <p>"No, no, no!"</p>
 
@@ -6232,12 +6232,12 @@ wants the gallery to-night. May I let him have it?"</p>
 
 <p>"Certainly. What for?"</p>
 
-<p>"Oh, some idea of his&mdash;I've forgotten what he said."</p>
+<p>"Oh, some idea of his—I've forgotten what he said."</p>
 
 <p>"I believe I'd better come down," said Quarren bluntly.</p>
 
 <p>"Don't dream of it, old fellow. Everything is doing nicely. My respects
-to the fair. By-the-bye&mdash;anything in my line up there?"</p>
+to the fair. By-the-bye—anything in my line up there?"</p>
 
 <p>Quarren laughed:</p>
 
@@ -6273,11 +6273,11 @@ strike you?"</p>
 
 <p>"Her maid told mine," admitted Molly shamelessly.<span class="pagenum" id="Page_310">[Pg 310]</span> "Now if you are going
 to criticise my channels of information I'll remind you that Richelieu
-himself&mdash;&mdash;"</p>
+himself——"</p>
 
 <p>"Oh, Molly! Molly! What a funny girl you are!" he said, laughing.
-"You're a sweet, loyal little thing, too&mdash;but there's no use&mdash;" His face
-became expressionless, almost haggard&mdash;"there's no use," he repeated
+"You're a sweet, loyal little thing, too—but there's no use—" His face
+became expressionless, almost haggard—"there's no use," he repeated
 under his breath.</p>
 
 <p>Slowly, side by side, they walked out to the veranda, her hand resting
@@ -6294,7 +6294,7 @@ his pipe.</p>
 
 <p>"Do you know," said Molly, thoughtfully, "she <i>is</i> a sort of a fish. She
 has the emotions of a mollusc as far as your sex is concerned. Some
-women <i>are</i> that way&mdash;more women than men would care to believe.... Do
+women <i>are</i> that way—more women than men would care to believe.... Do
 you know, Ricky, if you'll let us alone, it is quite natural for us to
 remain indifferent to considerations of that sort?"</p>
 
@@ -6302,10 +6302,10 @@ remain indifferent to considerations of that sort?"</p>
 
 <p>"It's only when you keep at us long enough that we respond," she said.
 "Some of us are quickly responsive; it takes many of us a long while to
-catch fire. Threatened emotion instinctively repels many of us&mdash;the more
+catch fire. Threatened emotion instinctively repels many of us—the more
 fastidious among us, the finer grained and more delicately nerved, are
 essentially reserved. Modesty, pride, a natural aloofness, are as much a
-part of many women as their noses and fingers&mdash;&mdash;"</p>
+part of many women as their noses and fingers——"</p>
 
 <p><span class="pagenum" id="Page_311">[Pg 311]</span></p>
 
@@ -6321,7 +6321,7 @@ impossible for them to accord to a more intimate and emotional demand."</p>
 many modern marriages in our particular vicinity are marriages of
 inclination, Ricky?"</p>
 
-<p>"You're a washed-out lot," he said&mdash;"you're satiated as schoolgirls. If
+<p>"You're a washed-out lot," he said—"you're satiated as schoolgirls. If
 you have any emotions left they're twisted ones by the time you are
 introduced. Most débutantes of your sort make their bow equipped for
 business, and with the experience of what, practically, has amounted to
@@ -6338,13 +6338,13 @@ pretends to know anything about it."</p>
 all this to do with you and Strelsa Leeds?"</p>
 
 <p>"Nothing." He shrugged. "She is part of your last word in social
-civilisation&mdash;&mdash;"</p>
+civilisation——"</p>
 
 <p>"She is a very normal, sensitive, proud girl, who has known little
-except unhappiness all her life, Rix&mdash;including two years of marital
-misery&mdash;two years of<span class="pagenum" id="Page_312">[Pg 312]</span> horror.&mdash;And you forget that those two years were
-the result of a demand purely and brutally emotional&mdash;to which, a
-novice, utterly ignorant, she yielded&mdash;pushed on by her mother....
+except unhappiness all her life, Rix—including two years of marital
+misery—two years of<span class="pagenum" id="Page_312">[Pg 312]</span> horror.—And you forget that those two years were
+the result of a demand purely and brutally emotional—to which, a
+novice, utterly ignorant, she yielded—pushed on by her mother....
 Please be fair to her; remember that her childhood was pinched with
 poverty, that her girlhood in school was a lonely one, embarrassed by
 lack of everything which her fashionable schoolmates had as matters of
@@ -6352,7 +6352,7 @@ course.</p>
 
 <p>"She could not go to the homes of her schoolmates in vacation times,
 because she could not ask them, in turn, to her own. She was still in
-school when Reggie Leeds saw her&mdash;and misbehaved&mdash;and the poor little
+school when Reggie Leeds saw her—and misbehaved—and the poor little
 thing was sent home, guiltless but already half-damned. No wonder her
 mother chased Reggie Leeds half around the world dragging her daughter
 by the wrist!"</p>
@@ -6368,11 +6368,11 @@ robins and bluebirds covered the soaked lawns, and their excited
 call-notes prophesied blue skies.</p>
 
 <p>"It doesn't make any difference one way or the other," said Quarren,
-half to himself. "She will go on in the predestined orbit&mdash;&mdash;"</p>
+half to himself. "She will go on in the predestined orbit——"</p>
 
 <p>"Not if a stronger body pulls her out of it."</p>
 
-<p>"There is nothing to which she responds&mdash;except what I have not."</p>
+<p>"There is nothing to which she responds—except what I have not."</p>
 
 <p>"Make what you do possess more powerful, then."</p>
 
@@ -6382,8 +6382,8 @@ half to himself. "She will go on in the predestined orbit&mdash;&mdash;"</p>
 
 <p><span class="pagenum" id="Page_313">[Pg 313]</span></p>
 
-<p>"Perhaps so&mdash;now&mdash;after a fashion.... But I am not the man who could
-ever attract her&mdash;&mdash;"</p>
+<p>"Perhaps so—now—after a fashion.... But I am not the man who could
+ever attract her——"</p>
 
 <p>"Wake her, and find out."</p>
 
@@ -6391,8 +6391,8 @@ ever attract her&mdash;&mdash;"</p>
 
 <p>"Didn't I tell you that many of us are asleep, and that few of us awake
 easily? Didn't I tell you that nobody likes to be awakened from the warm
-comfort and idle security of emotionless slumber?&mdash;that it is the
-instinct of many of us to resist&mdash;just as I hear my maid speak to me in
+comfort and idle security of emotionless slumber?—that it is the
+instinct of many of us to resist—just as I hear my maid speak to me in
 the morning and then turn over for another forty winks, hating her!"</p>
 
 <p>They both laughed.</p>
@@ -6438,15 +6438,15 @@ this afternoon," she remarked, casting a brief glance in his direction.</p>
 
 <p>Sprowl said:</p>
 
-<p>"There's a housemaid in my employ&mdash;she's saved something I understand.
-You might notify Dankmere&mdash;" he half wheeled toward Quarren, eyes
+<p>"There's a housemaid in my employ—she's saved something I understand.
+You might notify Dankmere—" he half wheeled toward Quarren, eyes
 slightly bulging without a shadow of expression on his sleek, narrow
 face.</p>
 
 <p>Molly flushed; Quarren glanced at Sprowl, amazed at his insolence out of
 a clear sky.</p>
 
-<p>"What?" he said slowly&mdash;then stepped back a pace as Strelsa passed close
+<p>"What?" he said slowly—then stepped back a pace as Strelsa passed close
 in front of him, apparently perfectly unconscious of any discord:</p>
 
 <p>"Will you get me a lump of sugar, Mr. Quarren? My mare must be pampered
@@ -6473,27 +6473,27 @@ canter without even noticing his bridle.</p>
 
 <p>"Characterised his bad manners the other day. It wasn't worth while;
 there's no money in cursing.... And I think, Molly dear, that I'll take
-an afternoon train&mdash;&mdash;"</p>
+an afternoon train——"</p>
 
 <p>"I won't let you," said his hostess. "I won't have you treated that way
-under my roof&mdash;&mdash;"</p>
+under my roof——"</p>
 
 <p>"It was outdoors, dear lady," said Quarren, smiling. "It's only his
 rudeness before you that I mind. Where is Sir Charles?"</p>
 
-<p>"Off with Chrysos somewhere on the river&mdash;there's their motor-launch,
+<p>"Off with Chrysos somewhere on the river—there's their motor-launch,
 now.... Ricky!"</p>
 
 <p>"Yes."</p>
 
-<p>"I'm angry all through.... Strelsa might have said something&mdash;showed her
+<p>"I'm angry all through.... Strelsa might have said something—showed her
 lack of sympathy for Langly's remark by being a little more cordial to
 you.... I don't like it in her. I don't know whether I am going to like
-that girl or not&mdash;&mdash;"</p>
+that girl or not——"</p>
 
-<p>"Nonsense. There was nothing for her to say or do&mdash;&mdash;"</p>
+<p>"Nonsense. There was nothing for her to say or do——"</p>
 
-<p>"There was! She <i>is</i> a fish!&mdash;unless she gives Langly the dickens this
+<p>"There was! She <i>is</i> a fish!—unless she gives Langly the dickens this
 morning.... Will you motor with Jim and me, Ricky dear?"</p>
 
 <p>"If you like."</p>
@@ -6512,11 +6512,11 @@ herbage.</p>
 and so did water, and very soon Molly had enough. So they tore back
 again to the house, Molly to change her muddy clothes and write letters,
 her husband to return to his beloved Stinger, Quarren to put on a pair
-of stout shoes and heather spats and go wandering off cross-lots&mdash;past
+of stout shoes and heather spats and go wandering off cross-lots—past
 woodlands still dripping with golden rain from every leaf, past tiny
 streams swollen amber where mint and scented grasses swayed half
 immersed; past hedge and orchard and wild tangles ringing with bird
-music&mdash;past fields of young crops of every kind washed green and fresh
+music—past fields of young crops of every kind washed green and fresh
 above the soaking brown earth.</p>
 
 <p>Swallows settled on the wet road around every puddle; bluebirds
@@ -6546,46 +6546,46 @@ little foot-bridge over a stream.</p>
 <p>The young fellow stopped and looked down curiously at the sunken,
 unhealthy face, then, shocked, came forward hastily and shook hands.</p>
 
-<p>"Why, Ledwith," he said, "what are you doing here?&mdash;Oh, I forgot; you
+<p>"Why, Ledwith," he said, "what are you doing here?—Oh, I forgot; you
 live here, don't you?"</p>
 
-<p>"That's my house yonder&mdash;or was," said the man with a slight motion of
+<p>"That's my house yonder—or was," said the man with a slight motion of
 his head. And, after a moment: "You didn't recognise me. Have I changed
 much?"</p>
 
-<p>Quarren said: "You seem to have been&mdash;ill."</p>
+<p>Quarren said: "You seem to have been—ill."</p>
 
 <p>"Yes; I have been. I'm ill, all right.... Will you have a seat for a few
-minutes&mdash;unless you are going somewhere in particular&mdash;or don't care to
-talk to me&mdash;&mdash;"</p>
+minutes—unless you are going somewhere in particular—or don't care to
+talk to me——"</p>
 
 <p>"Thank you." Quarren seated himself. It was his instinct to be
-gentle&mdash;even with such a man.</p>
+gentle—even with such a man.</p>
 
-<p>"I haven't seen much of you, for a couple of years&mdash;I haven't seen much
+<p>"I haven't seen much of you, for a couple of years—I haven't seen much
 of anybody," said Ledwith, turning the pages of his book without looking
 at them. Then, furtively, his sunken eyes rested a moment on Quarren:</p>
 
 <p><span class="pagenum" id="Page_320">[Pg 320]</span></p>
 
-<p>"You are stopping with&mdash;&mdash;"</p>
+<p>"You are stopping with——"</p>
 
 <p>"The Wycherlys."</p>
 
-<p>"Oh, yes.... I haven't seen them lately.... They are neighbours"&mdash;he
-waved his sickly coloured hand&mdash;"but I'm rather quiet&mdash;I read a good
-deal&mdash;as you see."&mdash;He moistened his bluish lips every few moments, and
+<p>"Oh, yes.... I haven't seen them lately.... They are neighbours"—he
+waved his sickly coloured hand—"but I'm rather quiet—I read a good
+deal—as you see."—He moistened his bluish lips every few moments, and
 his nose seemed to annoy him, too, for he rubbed it continually.</p>
 
 <p>"It's a pretty country," said Quarren.</p>
 
-<p>"Yes&mdash;I thought so once. I built that house.... There's no use in my
+<p>"Yes—I thought so once. I built that house.... There's no use in my
 keeping up social duties," he said with another slinking glance at
 Quarren. "So I'm giving up the house."</p>
 
 <p>"Really."</p>
 
-<p>"Hasn't&mdash;you have heard so, haven't you?"</p>
+<p>"Hasn't—you have heard so, haven't you?"</p>
 
 <p>He kept twitching his shoulders and shifting his place continually, and
 his fingers were never still, always at the leaves of his book or
@@ -6597,7 +6597,7 @@ continuously as he jerked about in his seat.</p>
 <p>"Do you know anybody immune to gossip?" inquired Quarren, smiling.</p>
 
 <p>"No; that's true. But I don't care anything for people.... I read, I
-have my horses and dogs&mdash;but I'm going to move away. I told you that,
+have my horses and dogs—but I'm going to move away. I told you that,
 didn't I?"</p>
 
 <p>"I believe you did."</p>
@@ -6611,8 +6611,8 @@ imperceptibly shifted his gaze craftily askance:</p>
 
 <p>Quarren said nothing.</p>
 
-<p>"You know all the gossip&mdash;all the dirty little faits divers of your
-world. And you're a sort of doctor and confidential&mdash;&mdash;"</p>
+<p>"You know all the gossip—all the dirty little faits divers of your
+world. And you're a sort of doctor and confidential——"</p>
 
 <p>"You're mistaken, Ledwith," he said pleasantly. "I'm done with it."</p>
 
@@ -6623,13 +6623,13 @@ useful and amusing any longer."</p>
 
 <p>Ledwith's dead eyes stared:</p>
 
-<p>"I heard you had dropped out&mdash;were never seen about. Is that true?"</p>
+<p>"I heard you had dropped out—were never seen about. Is that true?"</p>
 
 <p>"Yes."</p>
 
 <p>"Found the game too rotten?"</p>
 
-<p>"Oh, no. It's no different from any other game&mdash;a mixture of the same
+<p>"Oh, no. It's no different from any other game—a mixture of the same
 old good and bad, with good predominating. But there's more to be had
 out of life in other games."</p>
 
@@ -6644,8 +6644,8 @@ care what anybody calls me?"</p>
 <p>Quarren turned: "I beg your pardon, Ledwith; I had no business to make
 you such an answer."</p>
 
-<p>"Never mind.... In that last year&mdash;when I still knew people&mdash;and when
-they still knew me&mdash;you were very kind to me, Quarren."</p>
+<p>"Never mind.... In that last year—when I still knew people—and when
+they still knew me—you were very kind to me, Quarren."</p>
 
 <p>"Why not? You were always decent to me."</p>
 
@@ -6654,7 +6654,7 @@ dreadfully scarred and maltreated.</p>
 
 <p>"You've always been kind to me," repeated Ledwith,<span class="pagenum" id="Page_322">[Pg 322]</span> his extinct eyes
 fixed on space. "Other people would have halted at sight of me and gone
-the other way&mdash;or passed by cutting me dead.... <i>You</i> sat down beside
+the other way—or passed by cutting me dead.... <i>You</i> sat down beside
 me."</p>
 
 <p>"Am I anybody to refuse?"</p>
@@ -6662,12 +6662,12 @@ me."</p>
 <p>But Ledwith only blinked nervously down at his book, presently fell to
 twitching the uncut pages again.</p>
 
-<p>"Poems," he said&mdash;"scarcely what you'd think I'd wish to read,
-Quarren&mdash;poems of youth and love&mdash;&mdash;"</p>
+<p>"Poems," he said—"scarcely what you'd think I'd wish to read,
+Quarren—poems of youth and love——"</p>
 
-<p>"You're young, Ledwith&mdash;if you cared to help yourself&mdash;&mdash;"</p>
+<p>"You're young, Ledwith—if you cared to help yourself——"</p>
 
-<p>"Yes, if I cared&mdash;if I cared. In this book they all seem to care; youth
+<p>"Yes, if I cared—if I cared. In this book they all seem to care; youth
 and happiness care; sorrow and years still care. Listen to this:</p>
 
 <div class="poetry-container">
@@ -6676,19 +6676,19 @@ and happiness care; sorrow and years still care. Listen to this:</p>
     <div class="verse indent0">"'You who look forward through the shining tears</div>
     <div class="verse indent10">Of April's showers</div>
     <div class="verse indent0">Into the sunrise of the coming years</div>
-    <div class="verse indent0">Golden with unborn flowers&mdash;</div>
+    <div class="verse indent0">Golden with unborn flowers—</div>
     <div class="verse indent0">I who look backward where the sunset lowers</div>
     <div class="verse indent0">Counting November's hours!'</div>
   </div>
 </div>
 </div>
 
-<p>"But&mdash;I <i>don't</i> care. I care no longer, Quarren."</p>
+<p>"But—I <i>don't</i> care. I care no longer, Quarren."</p>
 
 <p>"<i>That's</i> losing your grip."</p>
 
 <p>He raised his ashy visage: "I'm <i>trying</i> to let go.... But it's
-slow&mdash;very slow&mdash;with a little pleasure&mdash;hell's own pleasure&mdash;" He
+slow—very slow—with a little pleasure—hell's own pleasure—" He
 turned his shoulder, fished something out of his pocket, and pulling
 back his cuff, bent over. After a few moments he turned around, calmly:</p>
 
@@ -6696,7 +6696,7 @@ back his cuff, bent over. After a few moments he turned around, calmly:</p>
 
 <p>"Otherwise, also."</p>
 
-<p>"Quite likely. I've known a pretty woman&mdash;" He<span class="pagenum" id="Page_323">[Pg 323]</span> ended with a weary
+<p>"Quite likely. I've known a pretty woman—" He<span class="pagenum" id="Page_323">[Pg 323]</span> ended with a weary
 gesture and dropped his head between his hands.</p>
 
 <p>"Quarren," he said, "there's only one hurt left in it all. I have two
@@ -6704,16 +6704,16 @@ little children."</p>
 
 <p>Quarren was silent.</p>
 
-<p>"I suppose&mdash;it won't last&mdash;that hurt. They're with my mother. It was
+<p>"I suppose—it won't last—that hurt. They're with my mother. It was
 agreed that they should remain with her.... But it's the only hurt I
-feel at all now&mdash;except&mdash;rarely&mdash;when those damned June roses are in
+feel at all now—except—rarely—when those damned June roses are in
 bloom.... She wore them a good deal.... Quarren, I'm glad it came early
 to me if it had to come.... Like yellow dogs unsuccessful men are the
 fastest breeders. The man in permanent hard luck is always the most
 prolific.... I'm glad there are no more children."</p>
 
 <p>His sunken eyes fell to the book, and, thinking of his wife, he read
-what was not written there&mdash;</p>
+what was not written there—</p>
 
 <div class="poetry-container">
 <div class="poetry">
@@ -6760,7 +6760,7 @@ river, and Chrysos prettily sun-burned, just entering the house.</p>
 
 <p>"We broke down," said the girl; "I thought we'd never get back, but Sir
 Charles is quite wonderful and he mended that very horrid machinery with
-the point of a file. Think of it, Ricky!&mdash;the point of a file!"</p>
+the point of a file. Think of it, Ricky!—the point of a file!"</p>
 
 <p>Sir Charles laughed and explained the simplicity of the repairs; and
 Chrysos, not a whit less impressed, stared at him out of her pretty
@@ -6799,7 +6799,7 @@ Lacy asked me to have Chrysos because she needed the quiet and calm. And
 
 <p>"Then it ought to be nipped in the bud. But her mother wants her here
 and Sir Charles wants to be here and if I write to her mother she'll let
-her remain anyway. I'm cross, Ricky. I'm tired, too&mdash;having dictated
+her remain anyway. I'm cross, Ricky. I'm tired, too—having dictated
 letters and signed checks until my head aches. Where have you been?"</p>
 
 <p>"Prowling."</p>
@@ -6830,7 +6830,7 @@ and handsome Englishman did while they swung in old-fashioned hammocks
 under the maple trees, enjoying the rare treat of hearing their own
 language properly spoken.</p>
 
-<p>Molly had a book to herself on the veranda&mdash;the newest and wickedest of
+<p>Molly had a book to herself on the veranda—the newest and wickedest of
 French yellow-covered fiction; her husband returned to the Stinger;
 Quarren listened to Sir Charles for a while, then without disturbing the
 reading, slipped quietly off and wandered toward the kennels.</p>
@@ -6884,12 +6884,12 @@ concerning you."</p>
 looking down, said slowly:</p>
 
 <p>"I am sorry for what Langly did this morning.... He has expressed his
-contrition to me&mdash;&mdash;"</p>
+contrition to me——"</p>
 
 <p>"<i>That</i> is all right as long as he doesn't express it to me,"
 interrupted Quarren, bluntly.</p>
 
-<p>"He means to speak to you&mdash;&mdash;"</p>
+<p>"He means to speak to you——"</p>
 
 <p>"Please say to him that your report of his mental anguish is
 sufficient."</p>
@@ -6899,18 +6899,18 @@ sufficient."</p>
 <p>"Not permanently. But I either like or I dislike. So let the incident
 close quietly."</p>
 
-<p>"Very well&mdash;if you care to humiliate me&mdash;him&mdash;&mdash;"</p>
+<p>"Very well—if you care to humiliate me—him——"</p>
 
 <p>"Dear Mrs. Leeds, he isn't going to be humiliated,<span class="pagenum" id="Page_328">[Pg 328]</span> because he doesn't
-care. And you know I wouldn't humiliate you for all the world&mdash;&mdash;"</p>
+care. And you know I wouldn't humiliate you for all the world——"</p>
 
-<p>"You will unless you let Langly express his formal regrets to you&mdash;&mdash;"</p>
+<p>"You will unless you let Langly express his formal regrets to you——"</p>
 
 <p>He looked up at her:</p>
 
 <p>"Would <i>that</i> make it easier for you?"</p>
 
-<p>"I&mdash;perhaps&mdash;please do as you see fit, Mr. Quarren."</p>
+<p>"I—perhaps—please do as you see fit, Mr. Quarren."</p>
 
 <p>"Very well," he said quietly.</p>
 
@@ -6924,7 +6924,7 @@ successful."</p>
 
 <p>"I know you do. It is very sweet of you to care."</p>
 
-<p>"I care&mdash;greatly.... As much as I&mdash;dare."</p>
+<p>"I care—greatly.... As much as I—dare."</p>
 
 <p>He laughed: "Don't you dare care about me?"</p>
 
@@ -6935,7 +6935,7 @@ occasions."</p>
 might again mistake it for something deeper." He was still laughing, and
 she lifted her gray eyes in silence for a moment, then:</p>
 
-<p>"There is nothing in the world deeper than my regard for you&mdash;if you
+<p>"There is nothing in the world deeper than my regard for you—if you
 will let it be what it is, and seek to make nothing less spiritual out
 of it."</p>
 
@@ -6946,7 +6946,7 @@ of it."</p>
 <p>"I thought I spoiled that for both of us," he said.</p>
 
 <p>"I didn't say so. I told you that I didn't know<span class="pagenum" id="Page_329">[Pg 329]</span> what you had done. I've
-had time to reflect. It&mdash;our friendship isn't spoiled&mdash;if you still
+had time to reflect. It—our friendship isn't spoiled—if you still
 value it."</p>
 
 <p>"I value it above everything in the world, Strelsa."</p>
@@ -6954,8 +6954,8 @@ value it."</p>
 <p>There was a silence. The emotion in his face and voice was faintly
 reflected in hers.</p>
 
-<p>"Then let us have peace," she said unsteadily. "I have&mdash;been&mdash;not very
-happy since you&mdash;since we&mdash;&mdash;"</p>
+<p>"Then let us have peace," she said unsteadily. "I have—been—not very
+happy since you—since we——"</p>
 
 <p>"I know. I've been utterly miserable, too." He lifted one of her hands
 and kissed it, and she changed colour but left her hand lying inert in
@@ -6968,19 +6968,19 @@ his.</p>
 <p>He laid his lips to her fingers again; she stirred uneasily, then rested
 her other arm on the back of the seat and shaded her eyes.</p>
 
-<p>"I think&mdash;you had better not&mdash;touch me&mdash;any more&mdash;" she said faintly.</p>
+<p>"I think—you had better not—touch me—any more—" she said faintly.</p>
 
 <p>"Is it disagreeable?"</p>
 
-<p>"Yes&mdash;n-no.... It is&mdash;it has nothing to do with friendship&mdash;" she looked
+<p>"Yes—n-no.... It is—it has nothing to do with friendship—" she looked
 up, flushed, curious: "Why do you always want to touch me, Mr. Quarren?"</p>
 
 <p>"Did you never caress a flower?"</p>
 
-<p>"Rix!"&mdash;she caught her breath as his name escaped her for the first
+<p>"Rix!"—she caught her breath as his name escaped her for the first
 time, and he saw her face surging in the loveliest colour. "It was your
-nonsensical answer!&mdash;I&mdash;it took me by surprise ... and I ask your pardon
-for being stupid.... And&mdash;may I have my hand? I use it occasionally."</p>
+nonsensical answer!—I—it took me by surprise ... and I ask your pardon
+for being stupid.... And—may I have my hand? I use it occasionally."</p>
 
 <p>He quietly reversed it, laid his lips to the palm, and released her
 fingers.</p>
@@ -6994,30 +6994,30 @@ fingers.</p>
 <p>"<i>Are</i> you?"</p>
 
 <p>"Yes, I am. Yes, yes, yes! Why can't you be to me what I wish to be to
-you? Why can't you be what I want&mdash;what I need&mdash;&mdash;"</p>
+you? Why can't you be what I want—what I need——"</p>
 
 <p>"Do you know what you need?"</p>
 
-<p>"Yes, I&mdash;&mdash;"</p>
+<p>"Yes, I——"</p>
 
-<p>"No, you don't. You need to love&mdash;and to be loved. You don't know it,
+<p>"No, you don't. You need to love—and to be loved. You don't know it,
 but you do!"</p>
 
-<p>"That is a&mdash;a perfectly brutal thing to say&mdash;&mdash;"</p>
+<p>"That is a—a perfectly brutal thing to say——"</p>
 
 <p>"Does it sound so to you?"</p>
 
-<p>"Yes, it does! It is brutal&mdash;common, unworthy of you and of me&mdash;&mdash;"</p>
+<p>"Yes, it does! It is brutal—common, unworthy of you and of me——"</p>
 
 <p>He took both her hands in a grip that almost hurt her:</p>
 
 <p>"<i>Can't</i> you have any understanding, any sympathy with human love? Can't
 you? Doesn't a man's love mean anything to you but words? Is there
-anything to be ashamed of in it?&mdash;merely because nothing has ever yet
+anything to be ashamed of in it?—merely because nothing has ever yet
 awakened <i>you</i> to it?"</p>
 
 <p>"Nothing ever will," she said steadily. "The friendship you can have of
-me is more than love&mdash;cleaner, better, stronger&mdash;&mdash;"</p>
+me is more than love—cleaner, better, stronger——"</p>
 
 <p>"It isn't strong enough to make you renounce what you are planning to
 do!"</p>
@@ -7027,61 +7027,61 @@ do!"</p>
 <p>"Yet love would be strong enough to make you renounce anything!"</p>
 
 <p>She said calmly: "Call it by its right name. Yes, they say its slaves
-become irresponsible. I know nothing about it&mdash;I could not&mdash;I
-will not! I loathe and detest any hint of it&mdash;to me it is
-degrading&mdash;contemptible&mdash;&mdash;"</p>
+become irresponsible. I know nothing about it—I could not—I
+will not! I loathe and detest any hint of it—to me it is
+degrading—contemptible——"</p>
 
 <p>"What are you saying?"</p>
 
 <p><span class="pagenum" id="Page_331">[Pg 331]</span></p>
 
 <p>"I am telling you the truth," she retorted, pale, and breathing faster.
-"I'm telling you what I know&mdash;what I have learned in a bitter
-school&mdash;during two dreadful years&mdash;&mdash;"</p>
+"I'm telling you what I know—what I have learned in a bitter
+school—during two dreadful years——"</p>
 
 <p>"<i>That!</i>"</p>
 
 <p>"Yes, that! Now you know! Now perhaps you can understand why I crave
 friendship and hold anything less in horror! Why can't you be kind to
-me? You are the one man I could ask it of&mdash;the only man I ever saw who
+me? You are the one man I could ask it of—the only man I ever saw who
 seemed fitted to give me what I want and need, and to whom I could
-return what he gave me with all my heart&mdash;all my heart&mdash;&mdash;"</p>
+return what he gave me with all my heart—all my heart——"</p>
 
 <p>She bowed her face over the hands which he still held; suddenly he drew
 her close into his arms; and she rested so, her head against his
 shoulder.</p>
 
 <p>"I won't <i>talk</i> to you of love any more," he whispered. "You poor little
-girl&mdash;you poor little thing. I didn't realise&mdash;I don't want to think
-about it&mdash;&mdash;"</p>
+girl—you poor little thing. I didn't realise—I don't want to think
+about it——"</p>
 
 <p>"I don't either," she said. "You will be kind to me, won't you?"</p>
 
-<p>"Of course&mdash;of course&mdash;you little, little girl. Nobody is going to find
+<p>"Of course—of course—you little, little girl. Nobody is going to find
 fault with you, nobody is going to blame you or be unkind or hurt you or
 demand anything at all of you or tell you that you make mistakes. People
 are just going to like you, Strelsa, and you needn't love them if you
 don't want to. You shall feel about everything exactly as you
-please&mdash;about Tom, Dick, and Harry and about me, too."</p>
+please—about Tom, Dick, and Harry and about me, too."</p>
 
 <p>Her hot face against his shoulder was quivering.</p>
 
-<p>"There," he whispered&mdash;"there, there&mdash;you little, little girl. That's
-all I want of you after all&mdash;only what you want of me. I don't wish to
-marry you if you don't wish it; I won't&mdash;I perhaps couldn't really love<span class="pagenum" id="Page_332">[Pg 332]</span>
+<p>"There," he whispered—"there, there—you little, little girl. That's
+all I want of you after all—only what you want of me. I don't wish to
+marry you if you don't wish it; I won't—I perhaps couldn't really love<span class="pagenum" id="Page_332">[Pg 332]</span>
 you very deeply if you didn't respond. I shall not bother you any
-more&mdash;or worry or nag or insist. What you do is right as far as I am
+more—or worry or nag or insist. What you do is right as far as I am
 concerned; what you offer I take; and whenever you find yourself unable
-to respond to anything I offer, say so fearlessly&mdash;look so, even, and
+to respond to anything I offer, say so fearlessly—look so, even, and
 I'll understand. Is all well between us now, Strelsa?"</p>
 
 <p>"Yes.... You are so good.... I wanted this.... You don't mean anything,
-do you by&mdash;by your arm around me&mdash;&mdash;"</p>
+do you by—by your arm around me——"</p>
 
-<p>"No more than your face against my shoulder means." He smiled&mdash;"Which I
+<p>"No more than your face against my shoulder means." He smiled—"Which I
 suppose signifies merely that you feel very secure with me."</p>
 
-<p>"I&mdash;begin to.... Will you let me?"</p>
+<p>"I—begin to.... Will you let me?"</p>
 
 <p>"Yes.... Do you feel restless? Do you want to lift your head?"</p>
 
@@ -7094,24 +7094,24 @@ curve of her cheek against his shoulder. It was rather colourless.</p>
 
 <p>"On account of that Trust business?"</p>
 
-<p>"Yes.... But I was tired before that&mdash;I had done too much&mdash;lived too
-much&mdash;and I've felt as though I were being hunted for so long.... And
-then&mdash;I was unhappy about you."</p>
+<p>"Yes.... But I was tired before that—I had done too much—lived too
+much—and I've felt as though I were being hunted for so long.... And
+then—I was unhappy about you."</p>
 
 <p>"Because I had joined in the hunt," he said.</p>
 
-<p>"You were different, but&mdash;you made me feel that way, too&mdash;a little&mdash;&mdash;"</p>
+<p>"You were different, but—you made me feel that way, too—a little——"</p>
 
 <p>"I understand now."</p>
 
 <p>"Do you really?"</p>
 
 <p>"Yes. It's been a case of men following, crowding after you, urging,
-importuning you to consider their<span class="pagenum" id="Page_333">[Pg 333]</span> desires&mdash;to care for them in their
-own way&mdash;all sorts I suppose, sad and sentimental, eager and exacting,
-head-long and boisterous&mdash;all at you constantly to give them what is
-not in you to give&mdash;what has never been awakened&mdash;what lies stunned,
-crippled, perhaps mangled in its sleep&mdash;&mdash;"</p>
+importuning you to consider their<span class="pagenum" id="Page_333">[Pg 333]</span> desires—to care for them in their
+own way—all sorts I suppose, sad and sentimental, eager and exacting,
+head-long and boisterous—all at you constantly to give them what is
+not in you to give—what has never been awakened—what lies stunned,
+crippled, perhaps mangled in its sleep——"</p>
 
 <p>"Killed," she whispered.</p>
 
@@ -7124,7 +7124,7 @@ lay close to the arm that sheltered her, thinking, wondering that she
 could endure it, and all the while conscious that the old fear of him
 was no longer there.</p>
 
-<p>"Do you&mdash;know about me?" she asked in a still, low voice.</p>
+<p>"Do you—know about me?" she asked in a still, low voice.</p>
 
 <p>"About the past?"</p>
 
@@ -7138,7 +7138,7 @@ was no longer there.</p>
 
 <p>"You know what the papers said?"</p>
 
-<p>"Yes.... Don't speak of it&mdash;unless you care to, Strelsa."</p>
+<p>"Yes.... Don't speak of it—unless you care to, Strelsa."</p>
 
 <p>"I want to.... Do you know this is the first time?"</p>
 
@@ -7153,11 +7153,11 @@ mother lived I did not once speak of it to her."</p>
 
 <p>"Could I tell you?"</p>
 
-<p>"My dear, my dear!&mdash;of course you can."</p>
+<p>"My dear, my dear!—of course you can."</p>
 
-<p>"I&mdash;it's been unsaid so long&mdash;there was nobody to tell it to. I've done
-my best to forget it&mdash;and for days I seem to forget it. But sometimes
-when I wake at night it is there&mdash;the horror of it&mdash;the terror sinking
+<p>"I—it's been unsaid so long—there was nobody to tell it to. I've done
+my best to forget it—and for days I seem to forget it. But sometimes
+when I wake at night it is there—the horror of it—the terror sinking
 deeper into my breast.... I was very young. You knew that?"</p>
 
 <p>"Yes."</p>
@@ -7166,15 +7166,15 @@ deeper into my breast.... I was very young. You knew that?"</p>
 
 <p>"Yes."</p>
 
-<p>"I wouldn't have cared; I was an imaginative child&mdash;and could have lived
+<p>"I wouldn't have cared; I was an imaginative child—and could have lived
 quite happy with my fancies on very, very little.... I was a sensitive
-and affectionate child&mdash;inclined to be demonstrative. You wouldn't
+and affectionate child—inclined to be demonstrative. You wouldn't
 believe it, would you?"</p>
 
 <p>"I can understand it."</p>
 
 <p>"Can you? It's odd because I have changed so.... I was quite romantic
-about my mother&mdash;madly in love with her.... There is nothing more to
+about my mother—madly in love with her.... There is nothing more to
 say.... In boarding-school I was perfectly aware that I was being given
 the best grooming that we could afford. Even then romance persisted. I
 had the ideas of a coloured picture-book concerning men and love and
@@ -7188,19 +7188,19 @@ lay silent for a while. Presently she continued in a low voice:</p>
 
 <p><span class="pagenum" id="Page_335">[Pg 335]</span></p>
 
-<p>"It was when we were returning for the April vacation&mdash;and the platform
+<p>"It was when we were returning for the April vacation—and the platform
 was crowded and some of the girls' brothers were there. There were two
-trains in&mdash;and much confusion&mdash;I don't know how I became separated from
-Miss Buckley and my schoolmates&mdash;I don't know to this day how I found
+trains in—and much confusion—I don't know how I became separated from
+Miss Buckley and my schoolmates—I don't know to this day how I found
 myself on the Baltimore train, and Gladys Leeds's brother laughing and
 talking and the train moving faster and faster.... There is no use
-saying any more. I was as ignorant as I was innocent&mdash;a perfect little
+saying any more. I was as ignorant as I was innocent—a perfect little
 fool, frightened, excited, even amused by turns.... He had been
 attentive to me. We both were fools. Only finally I became badly scared
-and he talked such nonsense&mdash;and I managed to slip away from him and
+and he talked such nonsense—and I managed to slip away from him and
 board the train at Baltimore as soon as we arrived there.... If he
 hadn't found me and returned to New York with me, it might not have been
-known. But we were recognised on the train and&mdash;it was a dreadful thing
+known. But we were recognised on the train and—it was a dreadful thing
 for me when I arrived home after midnight...."</p>
 
 <p>She fell silent; once or twice he looked down at her and saw that her
@@ -7211,44 +7211,44 @@ eyes were closed. Then, with a quick, uneven breath:</p>
 <p>"I think so."</p>
 
 <p>But she went on in a low, emotionless voice: "I was treated like a
-damaged gown&mdash;for which depreciation in value somebody was to be made
+damaged gown—for which depreciation in value somebody was to be made
 responsible. I suffered; days and nights seemed unreal. There were
 lawyers; did you know it?"</p>
 
 <p>"No."</p>
 
-<p>"Yes," she said wearily, "it was a bad dream&mdash;my mother, others&mdash;<i>his</i>
-family&mdash;many people strange and familiar passed through it. Then we
+<p>"Yes," she said wearily, "it was a bad dream—my mother, others—<i>his</i>
+family—many people strange and familiar passed through it. Then we
 travelled; I saw<span class="pagenum" id="Page_336">[Pg 336]</span> nothing, feeling half dead.... We were married in the
 Hawaiian Islands."</p>
 
 <p>"I know."</p>
 
-<p>"Then&mdash;the two years began."</p>
+<p>"Then—the two years began."</p>
 
 <p>After a long while she said again: "That was the real nightmare. I
 passed through the depths as in a trance. There was nothing lower, not
 even hell.... We travelled in Europe, Africa, and India for two
 years.... I scarcely remember a soul I saw or one single object. And
-then&mdash;<i>that</i> happened."</p>
+then—<i>that</i> happened."</p>
 
 <p>"I know, dear."</p>
 
 <p>A slight shudder passed over her:</p>
 
-<p>"I've told you," she whispered&mdash;"I've told you at last. Shall I tell you
+<p>"I've told you," she whispered—"I've told you at last. Shall I tell you
 more?"</p>
 
-<p>"Not unless&mdash;&mdash;"</p>
+<p>"Not unless——"</p>
 
-<p>"I don't know whether I want to&mdash;about the gendarmes&mdash;and that terrible
-woman who screamed when they touched her with the handcuffs&mdash;and how ill
-I was&mdash;&mdash;"</p>
+<p>"I don't know whether I want to—about the gendarmes—and that terrible
+woman who screamed when they touched her with the handcuffs—and how ill
+I was——"</p>
 
 <p>She had begun to tremble so perceptibly that Quarren's arm tightened
 around her; and presently she became limp and motionless.</p>
 
-<p>"This&mdash;what I have told you&mdash;is a very close bond between us, isn't it?"
+<p>"This—what I have told you—is a very close bond between us, isn't it?"
 she said.</p>
 
 <p>"Very close, Strelsa."</p>
@@ -7278,9 +7278,9 @@ him. But one can't abandon a helpless person."</p>
 
 <p>"Every word you utter," he said, "forges a new link in my love for you."</p>
 
-<p>"You don't mean&mdash;love?"</p>
+<p>"You don't mean—love?"</p>
 
-<p>"We mean the same I think&mdash;differing only in degree."</p>
+<p>"We mean the same I think—differing only in degree."</p>
 
 <p>"Thank you. That is nice of you."</p>
 
@@ -7288,38 +7288,38 @@ him. But one can't abandon a helpless person."</p>
 
 <p>"Is your little fortune quite gone, Strelsa?"</p>
 
-<p>"All gone&mdash;all of it."</p>
+<p>"All gone—all of it."</p>
 
 <p>"I see.... And something has got to be done."</p>
 
-<p>"You know it has.... And I'm old before my time&mdash;tired, worn out. I
-can't work&mdash;I have no heart, no courage. My heart and strength were
+<p>"You know it has.... And I'm old before my time—tired, worn out. I
+can't work—I have no heart, no courage. My heart and strength were
 burnt out; I haven't the will to struggle; I have no capacity to endure.
 What am I to do?"</p>
 
 <p>"Not what you plan to do."</p>
 
-<p>"Why not? As long as I need help&mdash;and the best is offered&mdash;&mdash;"</p>
+<p>"Why not? As long as I need help—and the best is offered——"</p>
 
-<p>"Wouldn't you take less&mdash;and me?"</p>
+<p>"Wouldn't you take less—and me?"</p>
 
 <p>"Oh, Rix! I couldn't <i>use you</i>!"</p>
 
 <p>She turned and looked up at him, blushed, and dis-engaged herself from
 his arm.</p>
 
-<p>"I&mdash;I&mdash;you are my <i>friend</i>. I couldn't do that. I have nothing to give
-anybody&mdash;not even you." She smiled, tremulously&mdash;"And I suspect that as
+<p>"I—I—you are my <i>friend</i>. I couldn't do that. I have nothing to give
+anybody—not even you." She smiled, tremulously—"And I suspect that as
 far as your fortune is concerned, you can offer me little more.... But
 it's sweet of you. You <i>are</i> generous, having so little and wishing to
-share it with me&mdash;&mdash;"</p>
+share it with me——"</p>
 
 <p><span class="pagenum" id="Page_338">[Pg 338]</span></p>
 
 <p>"Could you wait for me, Strelsa?"</p>
 
 <p>"Wait? You mean until you become wealthy? Why, you dear boy, how can
-I?&mdash;even if it were a certainty."</p>
+I?—even if it were a certainty."</p>
 
 <p>"Can't you hold on for a couple of years?"</p>
 
@@ -7329,33 +7329,33 @@ house."</p>
 <p>He bit his lip and frowned at the sunlit water.</p>
 
 <p>"Besides," she said, "I haven't anything to offer you that I haven't
-already given you&mdash;&mdash;"</p>
+already given you——"</p>
 
 <p>"I ask no more."</p>
 
 <p>"Oh, but you <i>do</i>!"</p>
 
-<p>"No, I want only what you want, Strelsa&mdash;only what you have to offer of
+<p>"No, I want only what you want, Strelsa—only what you have to offer of
 your own accord."</p>
 
 <p>They fell silent, leaning forward on their knees, eyes absent, remote.</p>
 
 <p>"I don't see how it can be done; do you?" she said.</p>
 
-<p>"If you could wait&mdash;&mdash;"</p>
+<p>"If you could wait——"</p>
 
 <p>"But Rix; I've told him that I would marry him."</p>
 
 <p>"Does that count?"</p>
 
-<p>"Yes&mdash;I don't know. I don't know how dishonest I might be.... I don't
-know what is going to happen. I'm so poor, Rix&mdash;you don't realise&mdash;and
-I'm tired and sad&mdash;old before my time&mdash;perplexed, burnt out&mdash;&mdash;"</p>
+<p>"Yes—I don't know. I don't know how dishonest I might be.... I don't
+know what is going to happen. I'm so poor, Rix—you don't realise—and
+I'm tired and sad—old before my time—perplexed, burnt out——"</p>
 
 <p>She rested her head on one slender curved hand and closed her eyes.
 After a while she opened them with a weary smile.</p>
 
-<p>"I'll try to think&mdash;after you are gone.... What time does your train
+<p>"I'll try to think—after you are gone.... What time does your train
 leave?"</p>
 
 <p>He glanced at his watch and rose; and she sprang up, too:</p>
@@ -7364,11 +7364,11 @@ leave?"</p>
 
 <p><span class="pagenum" id="Page_339">[Pg 339]</span></p>
 
-<p>"No; I can make it. We'll have to walk rather fast&mdash;&mdash;"</p>
+<p>"No; I can make it. We'll have to walk rather fast——"</p>
 
 <p>"I'd rather you left me here."</p>
 
-<p>"Would you? Then&mdash;good-bye&mdash;&mdash;"</p>
+<p>"Would you? Then—good-bye——"</p>
 
 <p>"Good-bye.... Will you come up again?"</p>
 
@@ -7385,12 +7385,12 @@ welfare and happiness. Will you always remember that?"</p>
 
 <p>"Yes, dear."</p>
 
-<p>"Then&mdash;I mustn't keep you a moment longer. Good-bye."</p>
+<p>"Then—I mustn't keep you a moment longer. Good-bye."</p>
 
 <p>"Good-bye."</p>
 
 <p>They stood a moment, neither stirring; then he put his arms around her;
-she touched his shoulder once more, lightly with her cheek&mdash;a second's
+she touched his shoulder once more, lightly with her cheek—a second's
 contact; then he kissed her clasped hands and was gone.</p>
 <hr class="chap x-ebookmaker-drop" />
 
@@ -7410,7 +7410,7 @@ heat-cursed city grew cooler, sweeter for her memory. Through the
 avenue's lamp-lit dusk passed the pale ghosts of Gath and the phantoms
 of the Philistines, and he thought their shadowy forms moved less
 wearily; and that strange faces looked less wanly at him as they grew
-out of the night&mdash;"clothed in scarlet and ornaments of gold"&mdash;and
+out of the night—"clothed in scarlet and ornaments of gold"—and
 dissolved again into darkness.</p>
 
 <p>Still thrilled, almost buoyant, he walked on, passing the high-piled
@@ -7447,16 +7447,16 @@ were applauding.</p>
 gallery for this evening," said the Englishman calmly. "So I let him
 have it."</p>
 
-<p>"What did he want of it? Who has he got in there?"&mdash;demanded Quarren as
+<p>"What did he want of it? Who has he got in there?"—demanded Quarren as
 another ripple of applause sounded from within.</p>
 
 <p>Dankmere thought a moment: "I really don't know the audience,
-Quarren&mdash;they're not a very fragrant lot."</p>
+Quarren—they're not a very fragrant lot."</p>
 
 <p>"What audience? Who are they?"</p>
 
-<p>"You Americans would call them a 'tough-looking<span class="pagenum" id="Page_346">[Pg 346]</span> bunch&mdash;except
-Westguard and Bleecker De Groot and Mrs. Caldera&mdash;&mdash;"</p>
+<p>"You Americans would call them a 'tough-looking<span class="pagenum" id="Page_346">[Pg 346]</span> bunch—except
+Westguard and Bleecker De Groot and Mrs. Caldera——"</p>
 
 <p>[Illustration: "A high and soulful tenor was singing 'Perfumes of
 Araby.'"]</p>
@@ -7496,10 +7496,10 @@ De Groot. Also there was a table supporting a Calla lily.</p>
 
 <p>Westguard was saying very earnestly: "The world calls me a novelist. I
 am not! Thank Heaven, I aspire to something loftier. I am not a mere
-scribbler of fiction; I am a man with a message&mdash;a plain, simple,
+scribbler of fiction; I am a man with a message—a plain, simple,
 earnest, warm-hearted humanitarian who has been roused to righteous
 indignation by the terrible contrast in this miserable city between
-wealth and poverty&mdash;&mdash;"</p>
+wealth and poverty——"</p>
 
 <p>"That's right," interrupted a hoarse voice; "it's all a con game, an'
 the perlice is into it, too!"</p>
@@ -7513,21 +7513,21 @@ artlessly comprehensive gesture calculated to make the entire East Side
 feel that it was reposing upon his beautifully laundered bosom.</p>
 
 <p>"Ah, my friends!" cried De Groot, "if you could only realise how great
-is the love for humanity within my breast!&mdash;If you could only know of
+is the love for humanity within my breast!—If you could only know of
 the hours and days and even weeks that I have devoted to solving the
 problems of the poor!</p>
 
-<p>"And I <i>have</i> solved them&mdash;every one. And <i>this</i> is the
-answer!"&mdash;grasping dauntlessly at a dirty hand and shaking it&mdash;"this!"
-seizing another&mdash;"and this, and this! And now I ask you, <i>what</i> is this
+<p>"And I <i>have</i> solved them—every one. And <i>this</i> is the
+answer!"—grasping dauntlessly at a dirty hand and shaking it—"this!"
+seizing another—"and this, and this! And now I ask you, <i>what</i> is this
 mute answer which I have given you?"</p>
 
 <p>"De merry mitt," said a voice, promptly. Mr. De Groot smiled with
 sweetness and indulgence.</p>
 
 <p>"I apprehend your quaint and trenchant vernacular,"<span class="pagenum" id="Page_348">[Pg 348]</span> he said. "It <i>is</i>
-the 'merry mitt'&mdash;the 'glad glove,' the 'happy hand'! Fifth Avenue
-clasps palms with Doyers Street&mdash;&mdash;"</p>
+the 'merry mitt'—the 'glad glove,' the 'happy hand'! Fifth Avenue
+clasps palms with Doyers Street——"</p>
 
 <p>"Ding!" said a weary voice, "yer in wrong, boss. It's nix f'r the Tongs
 wit us gents. We transfer to Avenue A."</p>
@@ -7537,14 +7537,14 @@ really happy." His plump, highly coloured features altered; presently a
 priceless tear glimmered in his monocle eye; and he brushed it away with
 a kind of noble pity for his own weakness.</p>
 
-<p>"Dear, dear friends," he said tremulously, "believe me&mdash;oh, believe me
+<p>"Dear, dear friends," he said tremulously, "believe me—oh, believe me
 that the rich are not happy! Only the perspiring labourer knows what is
 true contentment. The question of poverty is a great social question.
 With me it is a religion. Oh, I could go on forever on this subject,
-dear friends, and talk on and on and on&mdash;&mdash;"</p>
+dear friends, and talk on and on and on——"</p>
 
-<p>Emotion again checked him&mdash;or perhaps he had lost the thread of his
-discourse&mdash;or possibly he had attained its limit&mdash;but he filled it out
+<p>Emotion again checked him—or perhaps he had lost the thread of his
+discourse—or possibly he had attained its limit—but he filled it out
 by coming down from the platform and shaking hands so vigorously that
 the gardenia in his lapel presently fell out.</p>
 
@@ -7560,7 +7560,7 @@ and absorbed in<span class="pagenum" id="Page_349">[Pg 349]</span> his own busin
 feet on the floor alone interrupted him.</p>
 
 <p>"Has anybody," inquired De Groot, sweetly, "any vital question to
-ask&mdash;any burning inquiry of deeper, loftier import, which has perhaps
+ask—any burning inquiry of deeper, loftier import, which has perhaps
 long remained unanswered in his heart?"</p>
 
 <p>A gentleman known usually as "Mike the Mink" arose and indicated with
@@ -7573,7 +7573,7 @@ attributed to Correggio:</p>
 
 <p>"No, my dear friend; that is a picture painted hundreds of years ago by
 a great Italian master. It is called 'Danaë.' Jupiter, you know, came to
-her in a shower of gold&mdash;&mdash;"</p>
+her in a shower of gold——"</p>
 
 <p>"They all have to come across with it," remarked the Mink.</p>
 
@@ -7618,7 +7618,7 @@ need the difference."</p>
 
 <p>"No; I don't either. It's easy, cheap, and popular to knock the
 clergy.... Still, somehow or other, I can't seem to forget that the
-disciples were poor&mdash;and it bothers me a lot, Quarren."</p>
+disciples were poor—and it bothers me a lot, Quarren."</p>
 
 <p>Quarren said: "Haven't you and I enough to worry us concerning our own
 morals?"</p>
@@ -7652,8 +7652,8 @@ in darkness and silence, then the Englishman said abruptly:</p>
 <p>Quarren, amused, said: "How do you know that I have, Dankmere?"</p>
 
 <p>"A man knows some things. For example, most people take me for an
-ass&mdash;they don't tell me so but I know it. And if they don't take me for
-an ass they assume that I'm something worse&mdash;because I have a title of
+ass—they don't tell me so but I know it. And if they don't take me for
+an ass they assume that I'm something worse—because I have a title of
 sorts, no money, an inclination for the stage and the people who make a
 living out of it."</p>
 
@@ -7673,17 +7673,17 @@ first I also thought it was merely stupidity."</p>
 
 <p>"The majority of your better people have managed<span class="pagenum" id="Page_352">[Pg 352]</span> not to know me. I've
 met a lot of men of sorts, but they draw the line across their home
-thresholds&mdash;most of them. Is it the taint of vaudeville that their wives
+thresholds—most of them. Is it the taint of vaudeville that their wives
 sniff at, or my rather celebrated indigence?"</p>
 
-<p>"Both, Dankmere&mdash;and then some."</p>
+<p>"Both, Dankmere—and then some."</p>
 
 <p>"Oh, I see. Many thanks for telling me. I take it you mean that it was
 my first wife they shy at."</p>
 
 <p>Quarren remained silent.</p>
 
-<p>"She was a bar-maid," remarked the Earl. "We were quite happy&mdash;until she
+<p>"She was a bar-maid," remarked the Earl. "We were quite happy—until she
 died."</p>
 
 <p>Quarren made a slight motion of comprehension.</p>
@@ -7693,14 +7693,14 @@ died."</p>
 <p>"Of course."</p>
 
 <p>"Quite so. People would have stood for anything else.... But she
-wouldn't&mdash;you may think it odd.... And I was in love&mdash;so there you are."</p>
+wouldn't—you may think it odd.... And I was in love—so there you are."</p>
 
 <p>For a while they smoked in the semi-darkness without exchanging further
 speech; and finally Dankmere knocked out his pipe, pocketed it, and put
 on his hat.</p>
 
 <p>"You know," he said, "I'm not really an ass. My tastes and my caste
-don't happen to coincide&mdash;that's all, Quarren."</p>
+don't happen to coincide—that's all, Quarren."</p>
 
 <p>They walked together to the front stoop.</p>
 
@@ -7742,7 +7742,7 @@ his sleep.</p>
 <p>The heated silence of a Sunday morning in June awoke him from a somewhat
 restless night. Bathed and shaved, he crept forth limply to breakfast at
 the Founders' Club where he still retained a membership. There was not a
-soul there excepting himself and the servants&mdash;scarcely a person on the
+soul there excepting himself and the servants—scarcely a person on the
 avenues and cross-streets which he traversed going and coming, only one
 or two old men selling Sunday papers at street-stands, an old hag
 gleaning in the gutters, and the sparrows.</p>
@@ -7753,10 +7753,10 @@ julep, and a cigarette, and awaited the event of the young lady who
 had<span class="pagenum" id="Page_358">[Pg 358]</span> advertised that she knew all about book-keeping, stenography,
 and typewriting, and could prove it.</p>
 
-<p>[Illustration: "She came about noon&mdash;a pale young girl, very slim in her
+<p>[Illustration: "She came about noon—a pale young girl, very slim in her
 limp black gown."]</p>
 
-<p>She came about noon&mdash;a pale young girl, very slim in her limp black
+<p>She came about noon—a pale young girl, very slim in her limp black
 gown, and, at Quarren's invitation, seated herself at the newly
 purchased desk of the firm.</p>
 
@@ -7834,10 +7834,10 @@ unhappy, poor, underfed, and the prettiest thing you ever saw out of a
 business college. So, being unhappy, poor, underfed <i>and</i> pretty, I take
 it that she's all to the good."</p>
 
-<p>"It's a generous world of men," said Dankmere&mdash;"so I guess she <i>is</i>
+<p>"It's a generous world of men," said Dankmere—"so I guess she <i>is</i>
 good."</p>
 
-<p>"I'm sure of it. She was Sprowl's private stenographer&mdash;and he sent her
+<p>"I'm sure of it. She was Sprowl's private stenographer—and he sent her
 away.... There are three reasons why he might have dismissed her. I've
 taken my choice of them."</p>
 
@@ -7868,21 +7868,21 @@ himself and to the pictures:</p>
 have killed the artist who transferred it to canvas!... Number sixteen
 for you there in your armour! Somebody in Springfield will buy you for
 an ancestor and that's what will happen to you.... And you, too, in a
-bag-wig!&mdash;<i>you'll</i> be some rich Yankee's ancestor before you know it!
+bag-wig!—<i>you'll</i> be some rich Yankee's ancestor before you know it!
 That's the way you'll end, my smirking friend.... Hello! <i>Tiens!</i> <i>In
-Gottes namen</i>&mdash;whom have we here? Why, it's Venus!... And hot weather is
+Gottes namen</i>—whom have we here? Why, it's Venus!... And hot weather is
 no excuse for going about <i>that</i> way!... Listen to this, Quarren, for an
-impromptu patter-song&mdash;</p>
+impromptu patter-song—</p>
 
 <div class="poetry-container">
 <div class="poetry">
   <div class="stanza">
     <div class="verse indent0">"'Venus, dear, you ought to know</div>
-    <div class="verse indent2">What the proper caper is&mdash;</div>
+    <div class="verse indent2">What the proper caper is—</div>
     <div class="verse indent0">Even Eve, who wasn't slow,</div>
     <div class="verse indent2">Robbed the neighbours' graperies!</div>
     <div class="verse indent0">Even Mænads on the go,</div>
-    <div class="verse indent0">Fat Bacchantes in a row&mdash;</div>
+    <div class="verse indent0">Fat Bacchantes in a row—</div>
     <div class="verse indent0">Even ladies in a show</div>
     <div class="verse indent2">Wear <i>some</i> threads of naperies!</div><span class="pagenum" id="Page_361">[Pg 361]</span>
     <div class="verse indent0">Through the heavens planet-strewn</div>
@@ -7890,20 +7890,20 @@ impromptu patter-song&mdash;</p>
     <div class="verse indent0">Quickly clothes herself the Moon!</div>
     <div class="verse indent0">Get you to a modiste soon</div>
     <div class="verse indent2">Where the tissue-paper is,</div>
-    <div class="verse indent0">Cut in fashions fit for June&mdash;</div>
-    <div class="verse indent2">Wear 'em, dear, for draperies&mdash;&mdash; '"</div>
+    <div class="verse indent0">Cut in fashions fit for June—</div>
+    <div class="verse indent2">Wear 'em, dear, for draperies—— '"</div>
   </div>
 </div>
 </div>
 
-<p>"<i>Good</i> heavens!" protested Quarren&mdash;"how long can you run on like
+<p>"<i>Good</i> heavens!" protested Quarren—"how long can you run on like
 that?"</p>
 
-<p>"Years and years, my dear fellow. It's in me&mdash;born in me! Can you beat
+<p>"Years and years, my dear fellow. It's in me—born in me! Can you beat
 it? Though I appear to be a peer appearance is a liar; cast for a part
 apart from caste, departing I climb higher toward the boards to bore the
 hordes and lord it, sock and buskin dispensing sweetness, art, and light
-as per our old friend Ruskin&mdash;&mdash;"</p>
+as per our old friend Ruskin——"</p>
 
 <p>"Dankmere!"</p>
 
@@ -7941,7 +7941,7 @@ desk:</p>
 that?"</p>
 
 <p>"I think so. If it were only a decent example I'd ask ten times
-that&mdash;and probably get it in the end."</p>
+that—and probably get it in the end."</p>
 
 <p>Dankmere inspected the picture more respectfully for a few moments, then
 pasted a label on an exquisite head by Greuze.</p>
@@ -7964,16 +7964,16 @@ meantime it's not for sale."</p>
 
 <p>"I see. And this battle-scene?"</p>
 
-<p>"Wouverman's&mdash;ruined by restoring. It's not worth much."</p>
+<p>"Wouverman's—ruined by restoring. It's not worth much."</p>
 
 <p>"And this Virgin?"</p>
 
-<p>"Pure as the Virgin Herself&mdash;not a mark&mdash;flawless. It's by 'The Master
+<p>"Pure as the Virgin Herself—not a mark—flawless. It's by 'The Master
 of the Death of Mary.' Isn't it a beauty? Do you notice St. John holding
 the three cherries and the Christ-child caressing the goldfinch? Did you
 ever see such colour?"</p>
 
-<p>"It's&mdash;er&mdash;pretty," said his lordship.</p>
+<p>"It's—er—pretty," said his lordship.</p>
 
 <p><span class="pagenum" id="Page_363">[Pg 363]</span></p>
 
@@ -7982,13 +7982,13 @@ catalogue, marking copies for what they were, noting such pictures as
 had been ruined by restoring or repainted so completely as to almost
 obliterate the last original brush stroke. Also Quarren reserved for his
 own investigations such canvases as he doubted or of which he had
-hopes&mdash;a number that under their crocked, battered, darkened or
+hopes—a number that under their crocked, battered, darkened or
 discoloured surfaces hinted of by-gone glories that might still be
 living and only imprisoned beneath the thick opacity of dust, soot,
 varnish, and the repainting of many years ago.</p>
 
 <p>And that night he went to bed happier than he had ever been in all his
-life&mdash;unless his moments with Strelsa Leeds might be termed happy ones.</p>
+life—unless his moments with Strelsa Leeds might be termed happy ones.</p>
 
 <hr class="tb" />
 
@@ -8047,8 +8047,8 @@ inclination of gravely preoccupied faces.</p>
 <p>When the last leisurely lingerer had taken his leave Quarren said to
 Jessie Vining:</p>
 
-<p>"Those are representatives of various first-class<span class="pagenum" id="Page_365">[Pg 365]</span> dealers&mdash;confidential
-buyers, sons&mdash;even dealers themselves&mdash;like that handsome gray-haired
+<p>"Those are representatives of various first-class<span class="pagenum" id="Page_365">[Pg 365]</span> dealers—confidential
+buyers, sons—even dealers themselves—like that handsome gray-haired
 young-looking man who is Max Von Ebers, head of that great house."</p>
 
 <p>"But they didn't buy one single thing!" said Jessie.</p>
@@ -8062,13 +8062,13 @@ here at all. I wrote to each of them personally."</p>
 appeared, and now and then a man who might be an agent or a prowling and
 wealthy amateur or perhaps one of those curious haunters of all art
 marts who never buy but who never miss assisting at all inaugurations in
-person&mdash;like an ubiquitous and silent dog who turns up wherever more
-than two people assemble with any purpose in view&mdash;or without any.</p>
+person—like an ubiquitous and silent dog who turns up wherever more
+than two people assemble with any purpose in view—or without any.</p>
 
 <p>During the forenoon and early afternoon several women came into the
 galleries; and they seemed to be a little different from ordinary women,
 although it would be hard to say wherein they were different except in
-one instance&mdash;a tall, darkly handsome girl whose jewellery was as
+one instance—a tall, darkly handsome girl whose jewellery was as
 conspicuously oriental as her brilliant colour.</p>
 
 <p>Later Quarren told Jessie Vining that they were expert buyers on
@@ -8076,15 +8076,15 @@ commission or brokers having clients among those very wealthy people who
 bought pictures now and then because it was fashionable to do so. Also,
 these same women-brokers represented a number of those unhappy old
 families who, incognito, were being forced by straitened circumstances
-to part secretly with heirlooms&mdash;family plate, portraits, miniatures,
-furniture&mdash;even with the antique mirrors on the walls<span class="pagenum" id="Page_366">[Pg 366]</span> and the very
+to part secretly with heirlooms—family plate, portraits, miniatures,
+furniture—even with the antique mirrors on the walls<span class="pagenum" id="Page_366">[Pg 366]</span> and the very
 fire-dogs on the hearth amid the ashes of a burnt-out race almost
 extinct.</p>
 
-<p>A few Jews came&mdash;representing the extreme types of the most wonderful
-race of people in the world&mdash;one tall, handsome, immaculate young man
+<p>A few Jews came—representing the extreme types of the most wonderful
+race of people in the world—one tall, handsome, immaculate young man
 whose cultivated accent, charming manners, and quiet bearing challenged
-exception&mdash;and one or two representing the other extreme, loud,
+exception—and one or two representing the other extreme, loud,
 restless, aggressive, and as impertinent as they dared be, discussing
 the canvases in noisy voices and with callous manners verging always on
 the offensive.</p>
@@ -8118,12 +8118,12 @@ of the room in a sort of sweet and silent dignity.</p>
 
 <p>Dankmere, who, innately, possessed the effrontery of a born comedian,
 for some reason utterly unknown to himself, was inclined to be afraid of
-her&mdash;afraid of the clear brown eyes indifferently lifted to his when he
-entered&mdash;afraid of the quiet "Good-morning, Lord Dankmere," with which
-she responded to his morning greeting&mdash;afraid of her cool skilful little
-hands busy with pencil, pen, or lettered key&mdash;afraid of everything about
+her—afraid of the clear brown eyes indifferently lifted to his when he
+entered—afraid of the quiet "Good-morning, Lord Dankmere," with which
+she responded to his morning greeting—afraid of her cool skilful little
+hands busy with pencil, pen, or lettered key—afraid of everything about
 her from her rippling brown hair and snowy collar to the tips of her
-little tan shoes&mdash;even afraid of the back of her head when it presented
+little tan shoes—even afraid of the back of her head when it presented
 only a slender neck and two little rosy, close-set ears. But he didn't
 mention his state of abasement to Quarren.</p>
 
@@ -8134,7 +8134,7 @@ returned, one card had vanished; and she searched quietly but thoroughly
 before she left for home that evening, but she did not find the card.
 But she said nothing about it.</p>
 
-<p>The dreadful part of the affair was that it was theft&mdash;the Earl of
+<p>The dreadful part of the affair was that it was theft—the Earl of
 Dankmere's first crime.</p>
 
 <p>Why he had taken it he did not know. The awful impulse of kleptomania
@@ -8178,7 +8178,7 @@ last ten years.</p>
 
 <p>This news extenuated the Earl's guilt in her eyes to a degree which
 permitted a slight emotion resembling pity to pervade her. And one day
-she said to him, casually pleasant&mdash;"Would you care for that post-card,
+she said to him, casually pleasant—"Would you care for that post-card,
 Lord Dankmere? If it resembles your wife I would be very glad to return
 it to you."</p>
 
@@ -8191,7 +8191,7 @@ surprised her when she had leisure to think it over afterward.</p>
 of water on her desk; and that ended the incident for them both except
 that Dankmere was shyer of her than ever and she was beginning to
 realise that his aloof and expressionless deportment was due to
-shyness&mdash;which seemed to be inexplicable because otherwise timidity was
+shyness—which seemed to be inexplicable because otherwise timidity was
 scarcely the word to characterise his lively little lordship.</p>
 
 <p>Once, looking out of the rear windows, through the lace curtains she saw
@@ -8205,26 +8205,26 @@ Oxfords were at rest, then returned with heightened colour and a stifled
 desire to laugh which she disguised under an absent-minded nod of
 greeting.</p>
 
-<p>Meanwhile one or two pictures had been sold to dealers&mdash;not important
-ones&mdash;but the sales were significant enough to justify the leasing of
+<p>Meanwhile one or two pictures had been sold to dealers—not important
+ones—but the sales were significant enough to justify the leasing of
 the basement. And here Quarren installed himself from morning to noon as
 apprentice to an old Englishman who, before the failure of his eyesight,
 had amassed a little fortune as surgeon, physician, and trained nurse to
 old and decrepit pictures.</p>
 
 <p>Not entirely unequipped in the beginning, Quarren now learned more about
-his trade&mdash;the guarded secrets of mediums and solvents, the composition
+his trade—the guarded secrets of mediums and solvents, the composition
 of ancient and modern canvases, how old and modern colours were ground
 and prepared, how mixed, how applied.</p>
 
 <p><span class="pagenum" id="Page_372">[Pg 372]</span></p>
 
 <p>He learned how the old masters of the various schools of painting
-prepared a canvas or panel&mdash;how the snowy "veil" was spread and dried,
+prepared a canvas or panel—how the snowy "veil" was spread and dried,
 how the under painting was executed in earth-red and bone-black, how the
 glaze was used and why, what was the medium, what the varnish.</p>
 
-<p>He learned about the "baths of sunlight," too&mdash;those clarifying
+<p>He learned about the "baths of sunlight," too—those clarifying
 immersions practised so openly yet until recently not understood. He
 comprehended the mechanics, physics, and simple chemistry of that
 splendid, mysterious "inward glow" which seemed to slumber under the
@@ -8232,15 +8232,15 @@ colours of the old masters like the exquisite warmth in the heart of a
 gem.</p>
 
 <p>To him, little by little, was revealed the only real wonder of the old
-masters&mdash;their astonishing honesty. He began to understand that, first
+masters—their astonishing honesty. He began to understand that, first
 of all, they were self-respecting artisans, practising their trade of
 making pictures and painting each picture as well as they knew how;
 that, like other artisans, their pride was in knowing their trade, in a
 mastery of their tools, and in executing commissions as honestly as they
 knew how and leaving the "art" to take care of itself.</p>
 
-<p>Also he learned&mdash;for he was obliged to learn in self-protection&mdash;the
-tricks and deceptions and forgeries of the trade&mdash;all that was unworthy
+<p>Also he learned—for he was obliged to learn in self-protection—the
+tricks and deceptions and forgeries of the trade—all that was unworthy
 about it, all its shabby disguises and imitations and crude artifices
 and cunning falsehoods.</p>
 
@@ -8251,7 +8251,7 @@ both paint and varnish cracks; canvases that almost defied detection by
 needle-point or glass or thumb friction<span class="pagenum" id="Page_373">[Pg 373]</span> or solvent, so ingenious was
 the forgery simulating age.</p>
 
-<p>Every known adjunct was provided to carry out deception&mdash;genuinely old
+<p>Every known adjunct was provided to carry out deception—genuinely old
 canvases or panels, old stretchers really worm-eaten, aged frames of the
 period, half-obliterated seals bearing sometimes even the cross-keys of
 the Vatican. Even, in some cases, pretence that the pictures had been
@@ -8259,7 +8259,7 @@ cut from the frame and presumably stolen was carried out by a
 knife-slashed and irregular ridge where the canvas had actually been so
 cut and then sewed to a modern <i>toile</i>.</p>
 
-<p>For forgery of art is as old as the Greeks and as new as to-day&mdash;the one
+<p>For forgery of art is as old as the Greeks and as new as to-day—the one
 sinister art that perhaps will never become a lost art; and Quarren and
 his aged mentor in the basement of the Dankmere Galleries discovered
 more than enough frauds among the Dankmere family pictures showing how
@@ -8268,7 +8268,7 @@ lordship lay in his cradle.</p>
 
 <p>To Quarren the work was fascinating and, except for his increasing worry
 over Strelsa Leeds, would have been all-absorbing to the degree of
-happiness&mdash;or that interested contentment which passes for it on earth.</p>
+happiness—or that interested contentment which passes for it on earth.</p>
 
 <p>To see the dull encasing armour of varnish disappear from some ancient
 masterpiece under the thumb, as the delicate thumb of the Orient
@@ -8281,7 +8281,7 @@ identities; to study threads of canvas, flakes of varnish,<span class="pagenum" 
 globules of paint under the microscope; to learn, little by little, the
 technical manners and capricious mannerisms significant of the progress
 periods of each dead master; to pore over endless volumes, monographs,
-illustrated foreign catalogues of public and private collections&mdash;in
+illustrated foreign catalogues of public and private collections—in
 these things and through them happiness came to Quarren.</p>
 
 <p>Never a summer sun rose over the streets of Ascalon arousing the
@@ -8295,9 +8295,9 @@ infatuation.</p>
 exercise made him rather thin and pale. Close work with the magnifying
 glass had left his features slightly careworn, and had begun little
 converging lines at the outer corners of his eyes. Only one line in his
-face expressed anything less happy&mdash;the commencement of a short
+face expressed anything less happy—the commencement of a short
 perpendicular crease between his eyebrows. Anxious pondering over old
-canvases was not deepening that faint signature of perplexity&mdash;or the
+canvases was not deepening that faint signature of perplexity—or the
 forerunner of Care's signs manual nervously etched from the wing of
 either nostril.</p>
 <hr class="chap x-ebookmaker-drop" />
@@ -8310,7 +8310,7 @@ either nostril.</p>
 
 
 <p>Since Quarren had left Witch-Hollow, he and Strelsa had exchanged
-half-a-dozen letters of all sorts&mdash;gay, impersonal notes, sober epistles
+half-a-dozen letters of all sorts—gay, impersonal notes, sober epistles
 reflecting more subdued moods, then letters fairly sparkling with high
 spirits and the happy optimism of young people discovering that there is
 more of good than evil in a world still really almost new to them. Then
@@ -8324,15 +8324,15 @@ deliberate letter mentioning once more her critical worldly
 circumstances and the necessity of confronting them promptly and with
 intelligence and decision.</p>
 
-<p>To which he answered vigorously, begging her to hold out&mdash;either fit
-herself for employment&mdash;or throw her fortunes in with his and take the
+<p>To which he answered vigorously, begging her to hold out—either fit
+herself for employment—or throw her fortunes in with his and take the
 chances.</p>
 
 <div class="blockquot">
 
 <p>"Rix dear," she answered, "don't you suppose I have thought of
 that? But I can't do it. There is nothing left in me to go on with.
-I'm burnt out&mdash;deadly tired, wanting nothing more than I shall have
+I'm burnt out—deadly tired, wanting nothing more than I shall have
 by marrying as I must marry. For I shall have you, too, as I have
 always had you. You said so, didn't you?</p>
 
@@ -8343,15 +8343,15 @@ am married?</p>
 
 <p>"If you were sufficiently equipped to take care of me, and if I
 married you, I could not give you anything more than I have given
-already&mdash;I would not wish to if I could. All that many other women
-consider part of love&mdash;all that lesser side of it and of marriage I
-could not give to you or to any man&mdash;could not endure; because it
+already—I would not wish to if I could. All that many other women
+consider part of love—all that lesser side of it and of marriage I
+could not give to you or to any man—could not endure; because it
 is not in me and never has been. It is foreign to me, unpleasant,
-distasteful&mdash;even hateful.</p>
+distasteful—even hateful.</p>
 
 <p>"So as I can give you nothing more than I have given or ever shall
-give, and as you have given me all you can&mdash;anyway all I care for
-in you&mdash;let me feel free to seek my worldly salvation and find the
+give, and as you have given me all you can—anyway all I care for
+in you—let me feel free to seek my worldly salvation and find the
 quiet and rest and surcease from anxiety which comes only under
 such circumstances.</p>
 
@@ -8363,23 +8363,23 @@ spent mainly in troubling the world as little as possible?</p>
 
 <hr class="tb" />
 
-<p>"There are a number of people here&mdash;among them several friends of
+<p>"There are a number of people here—among them several friends of
 Jim Wycherly, all of them aviation-mad. Jim took out the Stinger,
 smashed the planes and got a fall which was not very serious.
 Lester Caldera did the same thing to the Kent biplane except that
 he fell into the river and Sir Charles and Chrysos, in the launch,
-fished him out&mdash;swearing, they say.</p>
+fished him out—swearing, they say.</p>
 
 <p>"Vincent Wier made a fine flight in his Delatour Dragon, sailing
 'round and 'round like a big hawk for a quarter of an hour, but the
 wind came up and he<span class="pagenum" id="Page_377">[Pg 377]</span> couldn't land, and he finally came down thirty
 miles north of us in a swamp.</p>
 
-<p>"Langly took me for a short flight in his Owlet No. 3&mdash;only two
+<p>"Langly took me for a short flight in his Owlet No. 3—only two
 miles and not very high, but the sensation was simply horrid. I
 never even cared for motoring, you see, so the experience left me
 most unenthusiastic, greatly to Langly's disgust. Really, all I
-care for is a decently gaited horse&mdash;and I prefer to walk him half
+care for is a decently gaited horse—and I prefer to walk him half
 the time. There is nothing speedy about me, Rix. If I ever had the
 inclination it's gone now.</p>
 
@@ -8391,7 +8391,7 @@ now, and that cold-eyed gentleman completely ignores him. Which is
 <i>not</i> very agreeable for me.</p>
 
 <p>"Oh, Rix, there seems to be so many misunderstandings in this
-exceedingly small world of ours&mdash;rows innumerable, heartburns,
+exceedingly small world of ours—rows innumerable, heartburns,
 recriminations, quarrels secret and open, and endless
 misunderstandings.</p>
 
@@ -8430,22 +8430,22 @@ dormant in me. All I know clearly is that you came into my life and
 found a fool wasting it, capering about in a costume half livery,
 half motley. My ambition was limited to my cap and bells; my
 aspirations never reached beyond the tip of my bauble. Then I saw
-you&mdash;and, all by themselves, my rags of motley fell from me, and
+you—and, all by themselves, my rags of motley fell from me, and
 something resembling a man stepped clear of them.</p>
 
 <p>"I am trying to make out of myself all that there is in me to
-develop. It is not much&mdash;scarcely more than the ability to earn a
+develop. It is not much—scarcely more than the ability to earn a
 living.</p>
 
 <p>"I have come to care for nothing more than the right to look this
 sunny world straight in the face. Until I knew you I had scarcely
-seen it except through artificial light&mdash;scarce heard its voice;
+seen it except through artificial light—scarce heard its voice;
 for the laughter of your world and the jingle of my cap and bells
 drowned it in my ass's ears.</p>
 
-<p>"I could tell you&mdash;for in dark moments I often believe it&mdash;that
-there is only one thing that counts in the world&mdash;one thing worth
-having, worth giving&mdash;love!</p>
+<p>"I could tell you—for in dark moments I often believe it—that
+there is only one thing that counts in the world—one thing worth
+having, worth giving—love!</p>
 
 <p><span class="pagenum" id="Page_379">[Pg 379]</span></p>
 
@@ -8453,40 +8453,40 @@ having, worth giving&mdash;love!</p>
 mistaken; and so is the heart denied.</p>
 
 <p>"Better and worth more than love of man or woman is the mind's
-silent approval&mdash;whether given in tranquillity or accorded in dumb
+silent approval—whether given in tranquillity or accorded in dumb
 anguish.</p>
 
 <p>"Strelsa dear, I shall always care for you; but I have discovered
-that love is another matter&mdash;higher or lower as you will&mdash;but
+that love is another matter—higher or lower as you will—but
 different. And I do not think I shall be able to love the girl who
 does what you are decided to do. And that does not mean that I
 criticise you or blame you, or that my sympathy, affection,
 interest, in you will be less. On the contrary all these emotions
 may become keener; only one little part will die out, and that
-without changing the rest&mdash;merely that mysterious, curious, elusive
+without changing the rest—merely that mysterious, curious, elusive
 and illogical atom in the unstable molecule, which we call
-love&mdash;and which, when separated, leaves the molecule changed only
+love—and which, when separated, leaves the molecule changed only
 in name. We call it friendship, then.</p>
 
 <p>"And this is, I think, what you would most desire. So when you do
 what you have determined to do, I will really become toward you
-what you are&mdash;and have always been&mdash;toward me. And could either of
+what you are—and have always been—toward me. And could either of
 us ask for more?</p>
 
-<p>"Only&mdash;forgive me&mdash;I wish it had been Sir Charles&mdash;or almost any
+<p>"Only—forgive me—I wish it had been Sir Charles—or almost any
 other man. But that is for your decision. Strelsa governs and alone
 is responsible to Strelsa.</p>
 
-<p>"Meanwhile do not doubt my affection&mdash;do not fear unkindness,
+<p>"Meanwhile do not doubt my affection—do not fear unkindness,
 judgment, or criticism. I wish I were what you cared for most in
-the world&mdash;after the approval of your own mind. I wish you cared
+the world—after the approval of your own mind. I wish you cared
 for me not only as you do but with all that has never been aroused
 in you. For without that I am helpless to fight for you.</p>
 
 <p><span class="pagenum" id="Page_380">[Pg 380]</span></p>
 
 <p>"So, in your own way, you will live life through, knowing that in
-me you will always have an unchanged friend&mdash;even though the lover
+me you will always have an unchanged friend—even though the lover
 died when you became a wife. Is all clear between us now?</p>
 
 <hr class="tb" />
@@ -8495,7 +8495,7 @@ died when you became a wife. Is all clear between us now?</p>
 Harbour, stop and inspect our gallery.</p>
 
 <p>"It is really quite pretty and some of the pictures are excellent.
-You should see it now&mdash;sunlight slanting in through the dusty
+You should see it now—sunlight slanting in through the dusty
 bay-window, Dankmere at a long polished table doing his level best
 to assemble certain old prints out of a portfolio containing nearly
 a thousand; pretty little Miss Vining, pencil in hand, checking off
@@ -8503,13 +8503,13 @@ at her desk the reference books we require in our eternal hunt for
 information; I below stairs in overalls if you please, paint and
 varnish stained, a jeweller's glass screwed into my left eye,
 examining an ancient panel which I strongly hope may have been the
-work of a gentleman named Bronzino&mdash;for its mate is almost
+work of a gentleman named Bronzino—for its mate is almost
 certainly the man in armour in the Metropolitan Museum.</p>
 
 <p>"Strelsa, it is the most exciting business I ever dreamed of. And
-the beauty of it is that it leads out into everything&mdash;stretches a
+the beauty of it is that it leads out into everything—stretches a
 thousand sensitive tentacles which grasp at knowledge of beauty
-everywhere&mdash;whether it lie in the sombre splendour of the
+everywhere—whether it lie in the sombre splendour of the
 tapestries of Bayeux, of Italy, of Flanders; or deep in the woven
 magnificence of some dead Sultan's palace rug; or in the beauty of
 the work of silversmiths, goldsmiths, of sculptors in ivory or in
@@ -8534,21 +8534,21 @@ cat begin an intermezzo on the back fence.</p>
 astounded, listening; then, giving me one wild glance, fled under
 the piano. I shied an empty bottle at the moon-lit minstrel; and I
 supposed that Daisy approved. But man supposes and cat proposes
-and&mdash;Daisy's kittens are certainly ornamental. Dankmere carries one
+and—Daisy's kittens are certainly ornamental. Dankmere carries one
 in each pocket, Daisy trotting at his heels with an occasional
 little exclamation of solicitude and pride.</p>
 
-<p>"Really we're a funny lot here in the Dankmere Galleries&mdash;not
+<p>"Really we're a funny lot here in the Dankmere Galleries—not
 superficially business-like perhaps, for we close at five and have
 tea in the extension, Dankmere, Miss Vining, I, Daisy, and her
-young ones&mdash;Daisy and the latter taking their nourishment together
+young ones—Daisy and the latter taking their nourishment together
 in a basket which Miss Vining has lined with blue silk.</p>
 
 <p>"In the evenings sometimes Miss Vining remains and dines with
 Dankmere and myself at some near restaurant; and after dinner Karl
 Westguard comes in and reads the most recent chapter of his
-novel&mdash;or perhaps Dankmere plays and sings old-time songs for
-us&mdash;or, if the heat makes us feel particularly futile, I perform
+novel—or perhaps Dankmere plays and sings old-time songs for
+us—or, if the heat makes us feel particularly futile, I perform
 some of those highly intellectual tricks which once made<span class="pagenum" id="Page_386">[Pg 386]</span> me
 acceptable among people I now seldom or never see.</p>
 
@@ -8581,7 +8581,7 @@ never to return. <i>Ubi amici, ibi opes!</i></p>
 
 <p>"When you pass through this furnace of Ascalon called New York will
 you stop among the Philistines long enough to take a cup of tea
-with us?&mdash;I'll show you the pictures; Dankmere will play 'Shannon
+with us?—I'll show you the pictures; Dankmere will play 'Shannon
 Water' for you; Miss Vining will talk pretty platitudes to you,
 Daisy will purr for you, and the painted eyes of Dankmere's
 ancestors will look down approvingly at you from the wall; and all
@@ -8621,11 +8621,11 @@ keepers of the house shall tremble"? Perhaps he was unconsciously
 obeying nature's first law.</p>
 
 <p>And yet, slowly within him grew a certainty that these reasons were not
-the real ones&mdash;not the vital impulse<span class="pagenum" id="Page_388">[Pg 388]</span> that moved his hand steadily
+the real ones—not the vital impulse<span class="pagenum" id="Page_388">[Pg 388]</span> that moved his hand steadily
 through critical and delicate moments as he bent, breathless, over the
 faded splendours of ancient canvases. No; somehow or other he had
-already begun to work for the sake of the work itself&mdash;whatever that
-really meant. That was the basic impulse&mdash;the occult motive; and,
+already begun to work for the sake of the work itself—whatever that
+really meant. That was the basic impulse—the occult motive; and,
 somehow he knew that, once aroused, the desire to strive could never
 again in him remain wholly quiescent.</p>
 
@@ -8641,9 +8641,9 @@ from a relined canvas. Presently the front door-bell rang.</p>
 blouse, mounted the basement stairs and opened the front door. And Mrs.
 Sprowl supported by a footman waddled in, panting.</p>
 
-<p>"Tell your master I want to see him," she said&mdash;"I don't mean that fool
-of an Englishman; I mean Mr. Quar&mdash;Good Lord! Ricky, is that <i>you</i>?
-Here, get me a chair&mdash;those front steps nearly killed me. Long ago I
+<p>"Tell your master I want to see him," she said—"I don't mean that fool
+of an Englishman; I mean Mr. Quar—Good Lord! Ricky, is that <i>you</i>?
+Here, get me a chair—those front steps nearly killed me. Long ago I
 swore I'd never enter a house which was not basement-built and had an
 elevator!... Hand me one of those fans. And if there's any water in the
 house not swarming with typhoid germs, get me a glass of it."</p>
@@ -8660,7 +8660,7 @@ glistened under her sparklike eyes.</p>
 <p>He said, smilingly, that he was well.</p>
 
 <p>"You don't look it. You look gaunt.... Well, I never thought you'd come
-to this&mdash;that you had it in you to do anything useful."</p>
+to this—that you had it in you to do anything useful."</p>
 
 <p>"I believe I've heard you say so now and then," he said with perfect
 good-humour.</p>
@@ -8684,20 +8684,20 @@ and make faces to amuse them, was there?"</p>
 <p>Mrs. Sprowl's little green eyes travelled all over the walls.</p>
 
 <p>"Umph," she snorted, "I suppose these are some of Dankmere's heirlooms.
-I never fancied that little bounder&mdash;&mdash;"</p>
+I never fancied that little bounder——"</p>
 
 <p>"Wait!"</p>
 
 <p>"What!"</p>
 
-<p>"Wait a moment. I like Dankmere, and he isn't a bounder&mdash;&mdash;"</p>
+<p>"Wait a moment. I like Dankmere, and he isn't a bounder——"</p>
 
 <p>"He <i>is</i> one!"</p>
 
 <p>"Keep that opinion to yourself," he said bluntly.</p>
 
-<p>The old lady's eyes blazed. "I'm damned if I do!" she retorted&mdash;"I'll
-say what&mdash;&mdash;"</p>
+<p>The old lady's eyes blazed. "I'm damned if I do!" she retorted—"I'll
+say what——"</p>
 
 <p><span class="pagenum" id="Page_390">[Pg 390]</span></p>
 
@@ -8709,7 +8709,7 @@ he had said. The process was awful to behold, but she accomplished it at
 last with a violent effort.</p>
 
 <p>"Ricky," she said, "I didn't come here to quarrel with you over an
-Englishman who&mdash;of whom I&mdash;have my personal opinion."</p>
+Englishman who—of whom I—have my personal opinion."</p>
 
 <p>He laughed, leaned over and deliberately patted her fat wrist; and she
 glared at him somewhat as a tigress inspects a favourite but overgrown
@@ -8740,8 +8740,8 @@ learn anything from Strelsa Leeds; and as for Langly he won't even
 answer my letters.</p>
 
 <p>"Now I want to know what is going on there? I've been as short with
-Strelsa as I dare be&mdash;she's got to be<span class="pagenum" id="Page_391">[Pg 391]</span> led with sugar. I've almost
-ordered her to come to me at Newport&mdash;but she doesn't come."</p>
+Strelsa as I dare be—she's got to be<span class="pagenum" id="Page_391">[Pg 391]</span> led with sugar. I've almost
+ordered her to come to me at Newport—but she doesn't come."</p>
 
 <p>"She's resting," said Quarren coolly.</p>
 
@@ -8749,22 +8749,22 @@ ordered her to come to me at Newport&mdash;but she doesn't come."</p>
 what keeps Langly there? He has nothing to look at except a few
 brood-mares. Do you suppose he has the bad taste to hang around waiting
 for Chester Ledwith to get out and Mary Ledwith to return? Or is it
-something else that glues him there&mdash;with the <i>Yulan</i> in the North
+something else that glues him there—with the <i>Yulan</i> in the North
 River?"</p>
 
 <p>Quarren shrugged his lack of interest in the subject.</p>
 
-<p>"If I thought," muttered the old lady&mdash;"if I imagined for one moment
+<p>"If I thought," muttered the old lady—"if I imagined for one moment
 that Langly was daring to try any of his low, cold-blooded tricks on
-Strelsa Leeds, I'd go up there myself&mdash;I'd take the next train and tell
+Strelsa Leeds, I'd go up there myself—I'd take the next train and tell
 that girl plainly what kind of a citizen my charming nephew really is!"</p>
 
 <p>Quarren was silent.</p>
 
 <p>"Why the dickens don't you say something?" she demanded. "I want to know
-whether I ought to go up there or not. Have you ever observed&mdash;have you
+whether I ought to go up there or not. Have you ever observed—have you
 ever suspected that there might be anything between Langly and Strelsa
-Leeds?&mdash;any tacit understanding&mdash;any interest on her part in him?... Why
+Leeds?—any tacit understanding—any interest on her part in him?... Why
 don't you answer me?"</p>
 
 <p>"You know," he said, "that it's none of your business what I believe."</p>
@@ -8785,8 +8785,8 @@ remind you that you cannot expect me to answer them."</p>
 <p>"If I were, do you imagine I'd discuss it with you?"</p>
 
 <p>"I'll tell you what!" she shouted, purple with rage, "you might do a
-damn sight worse! I'd&mdash;I'd rather see her your wife than his!&mdash;and God
-knows <i>what</i> he wants of her at that&mdash;as Mary Ledwith has first call or
+damn sight worse! I'd—I'd rather see her your wife than his!—and God
+knows <i>what</i> he wants of her at that—as Mary Ledwith has first call or
 the world will turn Langly out of doors!"</p>
 
 <p>Quarren, slightly paler, looked at her in silence.</p>
@@ -8798,7 +8798,7 @@ to her and her husband."</p>
 <p>"He has too much money," said Quarren. "Besides there's an ordinance
 against it."</p>
 
-<p>"You watch and see! Some things are <i>too</i> rotten to be endured&mdash;&mdash;"</p>
+<p>"You watch and see! Some things are <i>too</i> rotten to be endured——"</p>
 
 <p>"What? I haven't noticed any either abroad or here. Anyway it doesn't
 concern me."</p>
@@ -8809,15 +8809,15 @@ concern me."</p>
 
 <p>"Friends, eh!" she mimicked him wickedly, plying her fan like a
 madwoman; "well I fancy I know what sort of friendship has made you look
-ten years older in half a year. Oh, Ricky, Ricky!"&mdash;she added with an
-abrupt change of feeling&mdash;"I'm sorry for you. I like you even when you
-are impertinent to me&mdash;and you know I do! But I&mdash;my heart is set on her
+ten years older in half a year. Oh, Ricky, Ricky!"—she added with an
+abrupt change of feeling—"I'm sorry for you. I like you even when you
+are impertinent to me—and you know I do! But I—my heart is set on her
 marrying Sir Charles. You know it is. Could anything on earth be more
-suitable?&mdash;happier for her as well as for him? Isn't he a man where
-Langly is a&mdash;a toad, a cold-blooded worm!&mdash;a&mdash;a thing!</p>
+suitable?—happier for her as well as for him? Isn't he a man where
+Langly is a—a toad, a cold-blooded worm!—a—a thing!</p>
 
 <p>"I tell you my heart's set on it; there is nothing else<span class="pagenum" id="Page_393">[Pg 393]</span> interests me; I
-think of nothing else, care for nothing else&mdash;&mdash;"</p>
+think of nothing else, care for nothing else——"</p>
 
 <p>"Why?"</p>
 
@@ -8830,7 +8830,7 @@ think of nothing else, care for nothing else&mdash;&mdash;"</p>
 <p>"Then answer it without taking time to search for any reason except the
 real one."</p>
 
-<p>"Ricky, you insolent&mdash;&mdash;"</p>
+<p>"Ricky, you insolent——"</p>
 
 <p>"Never mind. Answer me; <i>why</i> are you so absorbed in this marriage?"</p>
 
@@ -8840,7 +8840,7 @@ deeply in love with her, and I am fond of them both."</p>
 <p>"Is that sufficient reason for such strenuous and persistent efforts on
 your part?"</p>
 
-<p>"That&mdash;and hatred for Langly," she said stolidly.</p>
+<p>"That—and hatred for Langly," she said stolidly.</p>
 
 <p>"Just those three reasons?"</p>
 
@@ -8850,8 +8850,8 @@ your part?"</p>
 
 <p>"Do you disbelieve me?" she demanded.</p>
 
-<p>"I am compelled to&mdash;knowing that never in all your life have you made
-the slightest effort in behalf of friendship&mdash;never inconvenienced
+<p>"I am compelled to—knowing that never in all your life have you made
+the slightest effort in behalf of friendship—never inconvenienced
 yourself in the least for the sake of anybody on earth."</p>
 
 <p>She stared at him, amazed, then angry, then burst into a loud laugh;
@@ -8872,7 +8872,7 @@ pencil you wield, isn't it, Ricky?"</p>
 
 <p>"I believe it. I never knew you to do or say a deliberately unkind
 thing. I never knew you to abuse a confidence, either.... And you were
-the receptacle for many&mdash;Heaven only knows how many trivial, petty,
+the receptacle for many—Heaven only knows how many trivial, petty,
 miserable little intrigues you were made aware of, or how many secret
 kindnesses you have done.... Let that go, too. I want to tell you
 something."</p>
@@ -8903,25 +8903,25 @@ these things, Rix?"</p>
 
 <p><span class="pagenum" id="Page_395">[Pg 395]</span></p>
 
-<p>"Yes, I&mdash;" he hesitated, looking straight at her in silence. And after a
+<p>"Yes, I—" he hesitated, looking straight at her in silence. And after a
 while a slight colour not due to the heat deepened the florid hue of her
 features.</p>
 
-<p>"I knew Sir Charles's father," she said in a voice so modulated&mdash;a voice
+<p>"I knew Sir Charles's father," she said in a voice so modulated—a voice
 so unexpected and almost pretty, that he could scarcely believe it was
 she who had spoken.</p>
 
 <p>"You said," she went on under her breath, "that in all my life
 friendship has never inspired in me a kindly action. You are wrong, Rix.
-In the matter of this marriage my only inspiration is friendship&mdash;the
+In the matter of this marriage my only inspiration is friendship—the
 friendship I had for a man who is dead.... Sir Charles is his only son."</p>
 
 <p>Quarren looked at her in silence.</p>
 
 <p>"I was young once, Ricky. I suppose you can scarcely believe that. Life
-and youth began early for me&mdash;and lasted a little more than a year&mdash;and
-then they both burnt out in my heart&mdash;leaving the rest of me alive&mdash;this
-dross!&mdash;" She touched herself on her bosom, then lowered her eyes, and
+and youth began early for me—and lasted a little more than a year—and
+then they both burnt out in my heart—leaving the rest of me alive—this
+dross!—" She touched herself on her bosom, then lowered her eyes, and
 sat thinking for a while.</p>
 
 <p>Daisy walked into the room and seated herself in a bar of sunlight,
@@ -8935,28 +8935,28 @@ Quarren, all the cunning and hardness gone from her heavy features.</p>
 pleased that man were he alive," she said. "Sir Charles was a little lad
 when he died. But he left a letter for him to read when he was grown up.
 I never saw the letter, but Sir Charles has told me that,<span class="pagenum" id="Page_396">[Pg 396]</span> in it, his
-father spoke&mdash;amiably&mdash;of me and said that in me his son would always
+father spoke—amiably—of me and said that in me his son would always
 find a friend.... That is all, Rix. Do you believe me?"</p>
 
 <p>"Yes."</p>
 
-<p>"Then&mdash;should I go to Witch-Hollow?"</p>
+<p>"Then—should I go to Witch-Hollow?"</p>
 
 <p>"I can't answer you."</p>
 
 <p>"Why?"</p>
 
-<p>"Because&mdash;because I care for her too much. And I can do absolutely
+<p>"Because—because I care for her too much. And I can do absolutely
 nothing for her. I could not swerve her or direct her. She alone knows
 what is in her heart and mind to do. I cannot alter it. She will act
 according to her strength; none can do otherwise.... And she is tired to
 the very soul.... You tell me that life and youth in you died within a
 year's space. I believe it.... But with her it took two years to die.
 And then it died.... Let her alone, in God's name! The child is weary of
-pursuit, deathly weary of importunity&mdash;tired, sad, frightened at the
+pursuit, deathly weary of importunity—tired, sad, frightened at the
 disaster to her fortune. Let her alone. If she marries it will be
-because of physical strength lacking&mdash;strength of character, of
-mind&mdash;perhaps moral, perhaps spiritual strength&mdash;I don't know. All I
+because of physical strength lacking—strength of character, of
+mind—perhaps moral, perhaps spiritual strength—I don't know. All I
 know is that no man or woman can help her, because the world has bruised
 her too long and she's afraid of it."</p>
 
@@ -8980,15 +8980,15 @@ make a convenience of one another."</p>
 there is in her to give to any man. And so, perhaps, she could not make
 the convenience of a husband out of either of us."</p>
 
-<p>"What a twisted, ridiculous, morbid&mdash;&mdash;"</p>
+<p>"What a twisted, ridiculous, morbid——"</p>
 
 <p>"Let her alone," he said gently.</p>
 
 <p>"Very well.... But I'll be hanged if I let Langly alone! He's still got
-me to deal with, thank God!&mdash;whatever he dares do to Mary
-Ledwith&mdash;whatever he has done to that wretched creature Chester
-Ledwith&mdash;he's still got a perfectly vigorous aunt to reckon with. And
-we'll see," she added&mdash;"we'll see what can be done&mdash;&mdash;"</p>
+me to deal with, thank God!—whatever he dares do to Mary
+Ledwith—whatever he has done to that wretched creature Chester
+Ledwith—he's still got a perfectly vigorous aunt to reckon with. And
+we'll see," she added—"we'll see what can be done——"</p>
 
 <p>The front door opened noisily.</p>
 
@@ -8997,9 +8997,9 @@ hadn't you better go?"</p>
 
 <p>"I'll be civil to him," she snorted, "but I'm going anyway. Good-bye,
 Ricky. I'll buy a picture of you when the weather's cooler....
-How-de-do!"&mdash;as his lordship entered looking rather hot and mussy&mdash;"Hope
+How-de-do!"—as his lordship entered looking rather hot and mussy—"Hope
 your venture into the realms of art will prove successful, Lord
-Dankmere. Really, Rix, I must be going&mdash;if you'll call my man&mdash;&mdash;"</p>
+Dankmere. Really, Rix, I must be going—if you'll call my man——"</p>
 
 <p>"I'll take you down," he said, smilingly offering his support.</p>
 
@@ -9010,7 +9010,7 @@ the<span class="pagenum" id="Page_398">[Pg 398]</span> basement, and he went dow
 sorting out old prints and Jessie Vining, who had just returned, writing
 business letters on her machine.</p>
 
-<p>There were not many business letters to write&mdash;one to the Metropolitan
+<p>There were not many business letters to write—one to the Metropolitan
 Museum people declining to present them with a charming little picture
 by Netscher which they wanted but did not wish to pay for; one to the
 Worcester Museum advising that progressive institution that, at the
@@ -9038,11 +9038,11 @@ belted Earl?</p>
 
 <p>In spite of herself her short upper lip curled slightly<span class="pagenum" id="Page_399">[Pg 399]</span> as she turned
 from her book to glance at him. He looked up at the same moment, and
-smiled on meeting her eye&mdash;such a kindly yet diffident smile that she
+smiled on meeting her eye—such a kindly yet diffident smile that she
 blushed a trifle.</p>
 
 <p>"I say, Miss Vining, I've gone over all these prints and I can't find
-one that resembles the Hogarth portrait&mdash;if it is a Hogarth."</p>
+one that resembles the Hogarth portrait—if it is a Hogarth."</p>
 
 <p>"Mr. Quarren thinks it is."</p>
 
@@ -9056,7 +9056,7 @@ to the top of it, and sat down. Miss Vining resumed her reading.</p>
 
 <p>"How <i>old</i> do you think I am?"</p>
 
-<p>"I beg your pardon&mdash;&mdash;"</p>
+<p>"I beg your pardon——"</p>
 
 <p>"How old do you think I am?"</p>
 
@@ -9133,7 +9133,7 @@ shoulders, horrified.</p>
 <p>"Oh, that's nothing," he said. "I know plenty of chaps in England who
 are far worse off."</p>
 
-<p>"But&mdash;that is terrible!" she faltered.</p>
+<p>"But—that is terrible!" she faltered.</p>
 
 <p>Dankmere waved his hand:</p>
 
@@ -9145,17 +9145,17 @@ are far worse off."</p>
 
 <p>"I like it," he explained simply.</p>
 
-<p>She flushed: "It seems strange for a&mdash;a man of your kind to sing comic
+<p>She flushed: "It seems strange for a—a man of your kind to sing comic
 songs and dance before an audience."</p>
 
-<p>"Not at all. I've a friend, Exford by name&mdash;who goes about grinding a
+<p>"Not at all. I've a friend, Exford by name—who goes about grinding a
 barrel-organ."</p>
 
 <p>"Why?"</p>
 
 <p>"He likes to do it.... I've another pal of sorts who chucked the Guards
 to become a milliner. He always did like to crochet and trim hats. Why
-not?&mdash;if he likes it!"</p>
+not?—if he likes it!"</p>
 
 <p>"It is not," said Jessie Vining, "my idea of a British peer."</p>
 
@@ -9185,7 +9185,7 @@ I'll be out of debt fast enough."</p>
 <p><span class="pagenum" id="Page_402">[Pg 402]</span></p>
 
 <p>"What use am I? We'd share alike; he'd manage the business and I'd
-manage a musical comedy I'm writing after hours&mdash;&mdash;"</p>
+manage a musical comedy I'm writing after hours——"</p>
 
 <p>He jumped up and went to the piano where for the next ten minutes he
 rattled off some lively and very commonplace music which to Jessie
@@ -9193,15 +9193,15 @@ Vining sounded like everything she had ever before heard.</p>
 
 <p>"Do you like it?" he asked hopefully, swinging around on his stool.</p>
 
-<p>"It's&mdash;lively."</p>
+<p>"It's—lively."</p>
 
 <p>"You <i>don't</i> like it!"</p>
 
-<p>"I&mdash;it seems&mdash;very entertaining," she said, reddening.</p>
+<p>"I—it seems—very entertaining," she said, reddening.</p>
 
 <p>The Earl sat looking at her in silence for a moment; then he said:</p>
 
-<p>"To care for anything and make a failure of it&mdash;can you beat it for
+<p>"To care for anything and make a failure of it—can you beat it for
 straight misery, Miss Vining?"</p>
 
 <p>"Oh, please don't speak that way. I really am no judge of musical
@@ -9227,7 +9227,7 @@ quaint and lovely old song in perfect taste. Then, very lightly, he sang
 <p>When he turned Miss Vining was resting her head on both hands, eyes
 lowered.</p>
 
-<p>"Those were the real musicians and poets," he said&mdash;"not these Strausses
+<p>"Those were the real musicians and poets," he said—"not these Strausses
 and 'Girls from the Golden West.'"</p>
 
 <p>"Will you sing some more?"</p>
@@ -9258,7 +9258,7 @@ with a nod of good-night, when he said:</p>
 
 <p>"May I go a little way?"</p>
 
-<p>"Yes&mdash;if&mdash;&mdash;"</p>
+<p>"Yes—if——"</p>
 
 <p>Lord Dankmere waited, but she did not complete whatever it was she had
 meant to say. Then, very<span class="pagenum" id="Page_404">[Pg 404]</span> slowly she turned northward, and he went, too,
@@ -9285,7 +9285,7 @@ mechanically toward the goal which meant to her only the relief of
 absolute rest.</p>
 
 <p>For her troubles were accumulating and she found in herself no resisting
-power&mdash;only the nervous strength left to get away from them. Troubles of
+power—only the nervous strength left to get away from them. Troubles of
 every description were impending; some had already come upon her, like
 Quarren's last letter which she knew signified that the termination of
 their friendship was already in sight.</p>
@@ -9307,7 +9307,7 @@ her resignation from the Province Club was forwarded, all social
 engagements for the summer cancelled.</p>
 
 <p>There remained only two other matters to settle; and one of them could
-be put off&mdash;without hope of escape perhaps&mdash;but still it could be
+be put off—without hope of escape perhaps—but still it could be
 avoided for a little while longer.</p>
 
 <p>The other was to write to Quarren; and she wrote as follows:</p>
@@ -9316,9 +9316,9 @@ avoided for a little while longer.</p>
 
 <p>"I have been in town; necessity drove me, and I was too unhappy to
 see you. But this is the result: I can hold out a few months
-longer&mdash;to no purpose, I know&mdash;yet, you asked it of me, and I am
+longer—to no purpose, I know—yet, you asked it of me, and I am
 trying to do it. Meanwhile the pressure never eases; I feel your
-unhappiness deeply&mdash;deeply, Rix!&mdash;and it is steadily wearing me
+unhappiness deeply—deeply, Rix!—and it is steadily wearing me
 out. And the pressure from Molly in your behalf, from Mrs. Sprowl
 by daily letter in behalf of Sir Charles, from Langly in his own
 interest never slackens for one moment.</p>
@@ -9331,7 +9331,7 @@ offer for sale everything I possess except what wardrobe and
 unimportant trinkets I have with me.</p>
 
 <p>"So many suits have been threatened and even commenced against
-me&mdash;you don't know, Rix&mdash;but while there remains any chance of
+me—you don't know, Rix—but while there remains any chance of
 meeting my obligations dollar for dollar I have refused to go
 through bankruptcy.</p>
 
@@ -9345,7 +9345,7 @@ slept; I want that sleep. I long for the insensibility, the endless
 lethargy that the mortally bruised crave; and that is all I hope or
 care for now.</p>
 
-<p>"Love, as man professes it, would only hurt me&mdash;even yours. There
+<p>"Love, as man professes it, would only hurt me—even yours. There
 can be no response from a soul and body stunned. Nothing must
 disturb their bruised coma.</p>
 
@@ -9365,9 +9365,9 @@ end, my friend? Can you tell me?"</p>
 still in bed, laid aside the New Testament which she had been reading,
 and looked up questioningly at her agitated hostess.</p>
 
-<p>"It's your fault," began Molly without preliminaries&mdash;"that old woman
+<p>"It's your fault," began Molly without preliminaries—"that old woman
 certainly suspects what you're up to with her nephew or she wouldn't
-bother to come up here&mdash;&mdash;"</p>
+bother to come up here——"</p>
 
 <p>"Who?" said Strelsa, sitting up. "Mrs. Sprowl?"</p>
 
@@ -9387,7 +9387,7 @@ there's only one motive for her advent!"</p>
 <p>"She is not to be your guest, is she?"</p>
 
 <p>"No. She wrote hinting that she'd come if asked. I pretended not to
-understand. I don't want her here. Every servant I have would leave&mdash;as
+understand. I don't want her here. Every servant I have would leave—as
 a beginning. Besides I don't require the social prestige of such a
 visitation; and she knows that, too. So what do you think she's done?"</p>
 
@@ -9401,10 +9401,10 @@ she's to be entertained at South Linden by Mary Ledwith."</p>
 <p>"Why should that concern me?" she asked calmly.</p>
 
 <p>"Concern you, child! How can it help concerning you? Do you see what
-she's done?&mdash;do you count all the birds she's knocked over with one
+she's done?—do you count all the birds she's knocked over with one
 stone. Mary Ledwith returns from Reno and Mrs. Sprowl fixes and secures
 her social status by visiting her at once. And it's a perfectly plain
-notice to Langly, too, and&mdash;forgive me, dear!&mdash;to you!"</p>
+notice to Langly, too, and—forgive me, dear!—to you!"</p>
 
 <p>Strelsa scarlet and astonished, sat up rigid, her beautiful head thrown
 back.</p>
@@ -9414,11 +9414,11 @@ story is a base slander! Did <i>you</i> believe it, Molly?"</p>
 
 <p><span class="pagenum" id="Page_409">[Pg 409]</span></p>
 
-<p>"Believe it? Of course I believe it&mdash;&mdash;"</p>
+<p>"Believe it? Of course I believe it——"</p>
 
 <p>"Why should you? Because a lot of vile newspapers have hinted at such a
 thing? I tell you it is an infamous story without one atom of truth in
-it&mdash;&mdash;"</p>
+it——"</p>
 
 <p>"How do you know?" asked Molly bluntly.</p>
 
@@ -9444,24 +9444,24 @@ themselves open to suits for libel."</p>
 watching her; but Molly avoided her brilliant, level gaze.</p>
 
 <p>"There's no use in talking to you," she said, "but why on earth you
-don't marry Sir Charles&mdash;&mdash;"</p>
+don't marry Sir Charles——"</p>
 
-<p>"Molly! Please don't&mdash;&mdash;"</p>
+<p>"Molly! Please don't——"</p>
 
-<p>"&mdash;Or Rix&mdash;&mdash;"</p>
+<p>"—Or Rix——"</p>
 
 <p>"Molly! Molly! <i>Can't</i> you let me alone! Can't we be together for ten
 minutes unless you urge me to marry somebody? Why do you want me to
-marry anybody!&mdash;Why&mdash;&mdash;"</p>
+marry anybody!—Why——"</p>
 
 <p>"But you're going to marry Langly, you say!"</p>
 
 <p>"Yes, I am! I am! But can't you let me forget it for a moment or two?
-I&mdash;I'm not very well&mdash;&mdash;"</p>
+I—I'm not very well——"</p>
 
 <p>"I can't help it," said Molly, grimly. "I'm sorry, darling, but the
 moment your engagement to Langly is<span class="pagenum" id="Page_410">[Pg 410]</span> announced there'll be a horrid
-smash and some people are going to be spattered&mdash;&mdash;"</p>
+smash and some people are going to be spattered——"</p>
 
 <p>"It <i>isn't</i> announced!" said the girl hotly. "Only you and Rix know
 about it except Langly and myself!"</p>
@@ -9479,13 +9479,13 @@ foot of the bed:</p>
 
 <p>"Why?"</p>
 
-<p>"For that very reason!" said Strelsa, fiercely&mdash;"because of the
+<p>"For that very reason!" said Strelsa, fiercely—"because of the
 injustice the papers have done him in this miserable Ledwith matter. He
-chooses to wait until it is forgotten&mdash;in order to shield me, I suppose,
-from any libellous comment&mdash;&mdash;"</p>
+chooses to wait until it is forgotten—in order to shield me, I suppose,
+from any libellous comment——"</p>
 
 <p>"You talk like a little idiot!" said Molly between her teeth. "Strelsa,
-I could shake you&mdash;if it would wake you up! Do you suppose for a moment
+I could shake you—if it would wake you up! Do you suppose for a moment
 that this Ledwith matter will be forgotten? Do you suppose if there were
 nothing in it but libel that he'd be afraid? You listen to me; that man
 is not apt to be afraid of anything, but he evidently <i>is</i> afraid, now!
@@ -9499,12 +9499,12 @@ Of what, then?"</p>
 
 <p>Molly laughed:</p>
 
-<p>"We're a hardened lot&mdash;some of us. But our most deadly fear is that the
+<p>"We're a hardened lot—some of us. But our most deadly fear is that the
 papers may <i>not</i> notice us. No matter what they say if they'll only say
-something!&mdash;that's our necessity and our unadmitted prayer. Because<span class="pagenum" id="Page_411">[Pg 411]</span>
+something!—that's our necessity and our unadmitted prayer. Because<span class="pagenum" id="Page_411">[Pg 411]</span>
 we've neither brains nor culture nor any distinguishing virtue or
-ability&mdash;and we're nothing&mdash;absolutely nothing unless the papers create
-us! Don't tell me that any one among us is afraid of publicity!&mdash;not in
+ability—and we're nothing—absolutely nothing unless the papers create
+us! Don't tell me that any one among us is afraid of publicity!—not in
 the particular circle where you and I and Langly and his aunt pursue our
 eccentric orbits!</p>
 
@@ -9513,17 +9513,17 @@ from it; plenty of them would gladly remain unchronicled and unsung. But
 it is not so among the fixed stars and planets and meteors and
 satellites of our particularly flamboyant constellation. I <i>know</i>. I
 also know that you don't really belong in it. But you'll either become
-accustomed to it or it will kill you if you don't drop&mdash;or soar, as you
-please&mdash;into some other section of eternal space."</p>
+accustomed to it or it will kill you if you don't drop—or soar, as you
+please—into some other section of eternal space."</p>
 
 <p>She sat swinging her foot, flushed, animated, her eyes and colour
-brilliant&mdash;a slim, exquisitely groomed woman with all the superficial
+brilliant—a slim, exquisitely groomed woman with all the superficial
 smoothness of a girl save for the wisdom in her eyes and in her smile,
 alas!</p>
 
 <p>And the other's eyes reflected in their clear gray depths no such
 wisdom, only the haunting knowledge of sorrow and, vaguely, the
-inexplicable horror of man as he really is&mdash;or at least as she had only
+inexplicable horror of man as he really is—or at least as she had only
 known him.</p>
 
 <p>Still swinging her pretty foot, a deliberate smile edging her lips,
@@ -9534,7 +9534,7 @@ Molly said:</p>
 <p>Strelsa stared at her without comprehension, then dropped her head back
 on the pillows.</p>
 
-<p>"If you'll let me stay with you a little while longer&mdash;that is all I
+<p>"If you'll let me stay with you a little while longer—that is all I
 ask," she said almost drowsily.</p>
 
 <p>Molly sprang up, came around and kissed her, lightly: "Of course. That
@@ -9552,8 +9552,8 @@ was what I was going to ask of you."</p>
 beside the bed.</p>
 
 <p>"Dear," she whispered, "let us wait and see what happens. There's just
-one thing that has distorted your view&mdash;a dreadful experience with one
-man&mdash;two years of hell's own horror with one of its wretched
+one thing that has distorted your view—a dreadful experience with one
+man—two years of hell's own horror with one of its wretched
 inhabitants. I don't believe the impression is going to last a lifetime.
 I don't believe it is indelible. I believe somehow, some time you will
 learn that a man's love does not mean horror and degradation; that it is
@@ -9569,19 +9569,19 @@ will not use his friendship to aid yourself to material comfort.</p>
 
 <p>"Never mind; don't answer. I know you well enough to know that you said
 some such thing to Rix.... And it's all right in its way. But the
-alternative is not what you think it is&mdash;not this bargain with Langly
-for a place to lay your tired head&mdash;not this deal to decorate his name
-and estates in return for personal immunity. You are wrong&mdash;I'm not
-immoral, only unmoral&mdash;as many of us are&mdash;but you've gone all to pieces,
-dear&mdash;morally, mentally, nervously&mdash;and it's not from cowardice, not
+alternative is not what you think it is—not this bargain with Langly
+for a place to lay your tired head—not this deal to decorate his name
+and estates in return for personal immunity. You are wrong—I'm not
+immoral, only unmoral—as many of us are—but you've gone all to pieces,
+dear—morally, mentally, nervously—and it's not from cowardice, not
 from depravity. It is the direct result of the two years of terror and
-desperate self-control&mdash;two years of courage&mdash;high moral courage,
-determination, self-suppression&mdash;and of the startling and dreadful
+desperate self-control—two years of courage—high moral courage,
+determination, self-suppression—and of the startling and dreadful
 climax.</p>
 
 <p><span class="pagenum" id="Page_417">[Pg 417]</span></p>
 
-<p>"That is the blow you are now feeling&mdash;and the reaction even after two
+<p>"That is the blow you are now feeling—and the reaction even after two
 years more of half-stunned solitude. You are waking, darling; that is
 all. And it hurts."</p>
 
@@ -9591,11 +9591,11 @@ kneeling on the floor beside her.</p>
 
 <p>"Don't you ever cry?" she whispered.</p>
 
-<p>"Not&mdash;now."</p>
+<p>"Not—now."</p>
 
 <p>"It would be better if you could."</p>
 
-<p>"There are no tears&mdash;I&mdash;I am burnt out&mdash;all burnt out&mdash;&mdash;"</p>
+<p>"There are no tears—I—I am burnt out—all burnt out——"</p>
 
 <p>"You need strength."</p>
 
@@ -9603,8 +9603,8 @@ kneeling on the floor beside her.</p>
 
 <p>"Not the desire to face things pluckily?"</p>
 
-<p>"No&mdash;no longer. Everything's dead in me except the longing for&mdash;quiet.
-I'll pay any price for it&mdash;except misuse of friends."</p>
+<p>"No—no longer. Everything's dead in me except the longing for—quiet.
+I'll pay any price for it—except misuse of friends."</p>
 
 <p>"How could you misuse Rix by marrying him?"</p>
 
@@ -9616,10 +9616,10 @@ I'll pay any price for it&mdash;except misuse of friends."</p>
 
 <p>"Does he ask that?"</p>
 
-<p>"N-no&mdash;not now. But&mdash;he wants it. And I haven't it to give. So I can't
-take his&mdash;and let him work all his life for my comfort&mdash;I can't take it
+<p>"N-no—not now. But—he wants it. And I haven't it to give. So I can't
+take his—and let him work all his life for my comfort—I can't take it
 from Sir Charles and accept the position and fortune he offered me
-once&mdash;&mdash;"</p>
+once——"</p>
 
 <p>She lay silent a moment, then unclosed her eyes.</p>
 
@@ -9633,22 +9633,22 @@ telepathy passed between them. Then Strelsa smiled.</p>
 
 <p>"Yes.... Don't you think so?"</p>
 
-<p>"She's little more than a child.... I don't know. Men are that way&mdash;men
+<p>"She's little more than a child.... I don't know. Men are that way—men
 of Sir Charles's age and experience are likely to drift that way.... But
 if you are done with Sir Charles, what he does no longer interests
-me&mdash;except that the Lacys will become insufferable if&mdash;&mdash;"</p>
+me—except that the Lacys will become insufferable if——"</p>
 
 <p>"Don't talk that way, dear."</p>
 
-<p>"I don't <i>like</i> the family&mdash;except Chrysos."</p>
+<p>"I don't <i>like</i> the family—except Chrysos."</p>
 
-<p>"Then be glad for her&mdash;if it comes true.... Sir Charles is a
-dear&mdash;almost too perfectly ideal to be a man.... I do wish it for his
+<p>"Then be glad for her—if it comes true.... Sir Charles is a
+dear—almost too perfectly ideal to be a man.... I do wish it for his
 sake.... He was a little unhappy over me I think."</p>
 
 <p>"He adores you still, you little villain!" whispered Molly, fondling
-her. "But&mdash;let poets sing and romancers rave&mdash;there's nothing that
-starves as quickly as love. And Sir Charles has been long fasting&mdash;good
+her. "But—let poets sing and romancers rave—there's nothing that
+starves as quickly as love. And Sir Charles has been long fasting—good
 luck to him and more shame on you!"</p>
 
 <p>Strelsa laughed, cleared her brow and eyes of the soft bright hair, and,
@@ -9660,7 +9660,7 @@ better, too. I'm glad you talked to me.... Do you think I'll get
 anything for my house?"</p>
 
 <p>"Yes, when you sell it. That's the hopeless part of it just at this time
-of year&mdash;&mdash;"</p>
+of year——"</p>
 
 <p>"Perhaps my luck will turn," said Strelsa. "You know I've had an awful
 lot of the other kind all my life."</p>
@@ -9679,49 +9679,49 @@ chickens and a cow!"</p>
 though I could stand it forever, now. You know I seem to be changing a
 little all the while. First, when Mrs. Sprowl found me at Colorado
 Springs and persuaded me to come to New York I was mad for
-pleasure&mdash;crazy about anything that promised gaiety and
-amusement&mdash;anything to make me forget.</p>
+pleasure—crazy about anything that promised gaiety and
+amusement—anything to make me forget.</p>
 
-<p>"You know I never went anywhere in Colorado Springs; I was too ill&mdash;ill
-most of the time.... And Mrs. Sprowl said she knew my mother&mdash;it's
-curious, but mother never said anything about her&mdash;and she cared for
+<p>"You know I never went anywhere in Colorado Springs; I was too ill—ill
+most of the time.... And Mrs. Sprowl said she knew my mother—it's
+curious, but mother never said anything about her—and she cared for
 fashionable people.</p>
 
-<p>"So I came to New York last winter&mdash;and you know the rest&mdash;I got tired
-physically, first; then so many wanted to marry me&mdash;and so many women
-urged me to do so many things&mdash;and I was unhappy about Rix&mdash;and then
-came this awful financial crash&mdash;&mdash;"</p>
+<p>"So I came to New York last winter—and you know the rest—I got tired
+physically, first; then so many wanted to marry me—and so many women
+urged me to do so many things—and I was unhappy about Rix—and then
+came this awful financial crash——"</p>
 
 <p>"Stop thinking of it!"</p>
 
 <p>"Yes; I mean to. I only wanted you to understand how, one by one,
 emotions and desires have been killed in me during the last four
-years.... And even the desire for wealth and position&mdash;which I clung to
-up to yesterday&mdash;somehow, now&mdash;this morning&mdash;has become little more than
-a dreamy wish.... I'd rather have quiet if I could&mdash;if there's enough
-money left to let me rest somewhere&mdash;&mdash;"</p>
+years.... And even the desire for wealth and position—which I clung to
+up to yesterday—somehow, now—this morning—has become little more than
+a dreamy wish.... I'd rather have quiet if I could—if there's enough
+money left to let me rest somewhere——"</p>
 
 <p>"There will be," said Molly, watching her.</p>
 
 <p><span class="pagenum" id="Page_420">[Pg 420]</span></p>
 
-<p>"Do you think so? And&mdash;then there would be no necessity for&mdash;for&mdash;&mdash;"</p>
+<p>"Do you think so? And—then there would be no necessity for—for——"</p>
 
 <p>"Langly!"</p>
 
-<p>Strelsa flushed. "I wonder," she mused. "I wonder whether&mdash;but it seems
+<p>Strelsa flushed. "I wonder," she mused. "I wonder whether—but it seems
 impossible that I should suddenly find I didn't care for everything I
 cared for this winter. Perhaps I'm too tired to care just now."</p>
 
-<p>"It might be," said Molly, "that something&mdash;for example your friendship
-with Rix&mdash;had made other matters seem less important."</p>
+<p>"It might be," said Molly, "that something—for example your friendship
+with Rix—had made other matters seem less important."</p>
 
 <p>The girl looked up quickly, saw nothing in Molly's expression to disturb
 her, then turned her eyes away, and lay silent, considering.</p>
 
 <p>If her friendship for Quarren had imperceptibly filled her mind, even
 crowding aside other and most important matters, she did not realise it.
-She thought of it now, and of him&mdash;recalling the letter she had written.</p>
+She thought of it now, and of him—recalling the letter she had written.</p>
 
 <p>Vaguely she was aware of the difference in her attitude toward life
 since she wrote that letter only a few days before. To what was it due?
@@ -9732,9 +9732,9 @@ on the table beside her? This was his letter:</p>
 
 <p>"Hold out, Strelsa! Matters are going well with me. Your tide, too,
 will turn before you know it. But neither man nor woman is going to
-aid you, only time, Strelsa, and&mdash;something that neither you nor I
-have bothered about very much&mdash;something that has many names in
-many tongues&mdash;but they all mean the same. And the symbol of what
+aid you, only time, Strelsa, and—something that neither you nor I
+have bothered about very much—something that has many names in
+many tongues—but they all mean the same. And the symbol of what
 they mean is Truth.</p>
 
 <p>"Why not study it? We never have. All sages of all times have
@@ -9745,25 +9745,25 @@ it strength.</p>
 
 <p>"I find its traces in every ancient picture that I touch. But there
 are books still older that have lived because of it. And one man
-died for it&mdash;man or God as you will&mdash;the former is more
+died for it—man or God as you will—the former is more
 fashionable.</p>
 
 <p>"Lives that have been lived because of it, given for it, forgiven
 for its sake, are worth our casual study.</p>
 
 <p>"For they say there is no greater thing than Truth. I can imagine
-no greater. And the search for it is interesting&mdash;fascinating&mdash;I
-had no idea how absorbing until recently&mdash;until I first saw you,
+no greater. And the search for it is interesting—fascinating—I
+had no idea how absorbing until recently—until I first saw you,
 who sent me out into the world to work.</p>
 
-<p>"Hold out&mdash;and study this curious subject of Truth for a little
+<p>"Hold out—and study this curious subject of Truth for a little
 while. Will you?</p>
 
 <p>"If you'll only study it a while I promise that it will interest
-you&mdash;not in its formalisms, not in its petty rituals and
+you—not in its formalisms, not in its petty rituals and
 observances, nor in its endless nomenclature, nor its
-orthodoxy&mdash;but just as you discover it for yourself in the
-histories of men and women&mdash;of saint and sinner&mdash;and, above all, in
+orthodoxy—but just as you discover it for yourself in the
+histories of men and women—of saint and sinner—and, above all, in
 the matchless life of Him who understood them all.</p>
 
 <p>"<i>Non tu corpus eras sine pectore!</i>"</p>
@@ -9785,15 +9785,15 @@ cantered away down the wooded road that led to South Linden.</p>
 
 <p>After their first gallop they slowed to a walk on the farther hill
 slope, chatting of inconsequential things; and it seemed to her that he
-was in unusually good spirits&mdash;almost gay for him&mdash;and his short dry
+was in unusually good spirits—almost gay for him—and his short dry
 laugh rang out once or twice, which was more than she had heard from him
 in a week.</p>
 
 <p>From moment to moment she glanced sideways at him, curiously inspecting
 the sleek-headed symmetry of the man, noticing, as always, his perfectly
 groomed figure, his narrow head and the well-cut lines of the face and
-jaw. Once she had seen him&mdash;the very first time she had ever met him at
-Miami&mdash;eating a broiled lobster. And somehow his healthy appetite, the
+jaw. Once she had seen him—the very first time she had ever met him at
+Miami—eating a broiled lobster. And somehow his healthy appetite, the
 clean incision of his sun-bronzed jaw and the working muscles, chewing
 and swallowing, fascinated her; and she never saw him but she thought of
 him eating vigorously aboard the <i>Yulan</i>.</p>
@@ -9809,7 +9809,7 @@ Ledwith returns to South Linden?"</p>
 
 <p>"Probably," he said.</p>
 
-<p>"Then&mdash;what are you going to do about it?"</p>
+<p>"Then—what are you going to do about it?"</p>
 
 <p>"About what?"</p>
 
@@ -9817,7 +9817,7 @@ Ledwith returns to South Linden?"</p>
 
 <p>"Nothing."</p>
 
-<p>"Or&mdash;about Mrs. Ledwith?"</p>
+<p>"Or—about Mrs. Ledwith?"</p>
 
 <p>"Be civil if I see her."</p>
 
@@ -9837,7 +9837,7 @@ speaking; now they wandered restlessly over the landscape.</p>
 <p>"Anywhere you care to."</p>
 
 <p>He said: "I have told you a thousand times that the thing to do is to
-take Molly Wycherly 'board the <i>Yulan</i>, and&mdash;&mdash;"</p>
+take Molly Wycherly 'board the <i>Yulan</i>, and——"</p>
 
 <p>"I do not care to do it until our engagement is announced."</p>
 
@@ -9851,8 +9851,8 @@ of an aunt are coming to-morrow. Did you know that? Well, they are. And
 every dirty newspaper in town will make the matter insidiously
 significant! If my aunt hadn't taken it into her head to visit Mrs.
 Ledwith at this particular moment, there would have been few comments.
-As it is there'll be plenty&mdash;and I don't feel like putting up with
-them&mdash;I don't propose to for my own sake. The time comes, sooner or
+As it is there'll be plenty—and I don't feel like putting up with
+them—I don't propose to for my own sake. The time comes, sooner or
 later, when a man has got to consider himself."</p>
 
 <p>After a short silence Strelsa raised her gray eyes:</p>
@@ -9862,12 +9862,12 @@ later, when a man has got to consider himself."</p>
 <p><span class="pagenum" id="Page_424">[Pg 424]</span></p>
 
 <p>"What? Certainly. Haven't I been doing that ever since we've been
-engaged&mdash;&mdash;"</p>
+engaged——"</p>
 
-<p>"I&mdash;wonder," she mused.</p>
+<p>"I—wonder," she mused.</p>
 
-<p>"What else have I been doing?" he insisted&mdash;"denying myself the pleasure
-of you when I'm half crazy about you&mdash;&mdash;"</p>
+<p>"What else have I been doing?" he insisted—"denying myself the pleasure
+of you when I'm half crazy about you——"</p>
 
 <p>"What!"</p>
 
@@ -9895,23 +9895,23 @@ generous of your aunt to show people what <i>she</i> thought of such cruel
 stories."</p>
 
 <p>"Do you think," he said sneeringly, "that my excellent aunt was inspired
-by any such motive? You might as well know&mdash;if you don't know already&mdash;"
-and his pale eyes rested a moment on the girl beside him&mdash;"that my aunt
+by any such motive? You might as well know—if you don't know already—"
+and his pale eyes rested a moment on the girl beside him—"that my aunt
 is visiting Mrs. Ledwith solely to embarrass me!"</p>
 
 <p>"How could it embarrass you?"</p>
 
 <p>"By giving colour to the lies told about me and the<span class="pagenum" id="Page_425">[Pg 425]</span> Ledwiths," he said
-in a hard voice&mdash;"by hinting that Mary Ledwith, free to marry, is
+in a hard voice—"by hinting that Mary Ledwith, free to marry, is
 accepted by my aunt; and the rest is up to me! That's what that female
-relative of mine has just done&mdash;" His big, white teeth closed with a
+relative of mine has just done—" His big, white teeth closed with a
 click and he spurred his horse cruelly again and checked him until the
 slavering creature almost reared over backward.</p>
 
 <p>"If you maltreat that horse again, Langly, I'll leave you. Do you
 understand?" she said, exasperated.</p>
 
-<p>"I beg your pardon&mdash;" Again his jaw fairly snapped, but the horse did
+<p>"I beg your pardon—" Again his jaw fairly snapped, but the horse did
 not suffer from his displeasure.</p>
 
 <p>"What has enraged you so?" she demanded.</p>
@@ -9937,7 +9937,7 @@ shield Mrs. Ledwith?"</p>
 
 <p>"How?"</p>
 
-<p>"I don't know, Langly.... But if there is anything you could do&mdash;&mdash;"</p>
+<p>"I don't know, Langly.... But if there is anything you could do——"</p>
 
 <p>"What? My aunt and the papers are determined that I shall marry her! I
 take it that you are not suggesting that, are you?"</p>
@@ -9949,7 +9949,7 @@ take it that you are not suggesting that, are you?"</p>
 <p>"Well, <i>I</i> am. I'm suggesting that you and Molly and I go aboard the
 <i>Yulan</i> and clear out to-night!"</p>
 
-<p>"You mean&mdash;to announce our engagement first?"</p>
+<p>"You mean—to announce our engagement first?"</p>
 
 <p>"Just as you choose," he said without a shade of expression on his
 features.</p>
@@ -9962,12 +9962,12 @@ let them howl and tear things up."</p>
 
 <p>"Howl at Mrs. Ledwith and tear her to tatters while we start around the
 world on the <i>Yulan</i>?" nodded Strelsa. She was rather white, but she
-laughed; and he, hearing her, turned and laughed, too&mdash;a quick bark of a
+laughed; and he, hearing her, turned and laughed, too—a quick bark of a
 laugh that startled both horses who were unaccustomed to it.</p>
 
 <p>"Oh, I guess they won't put her out of business," he said. "She's young
-and handsome and there are plenty of her sort to marry her&mdash;even
-Dankmere would have a chance there or&mdash;" he hesitated, and decided to
+and handsome and there are plenty of her sort to marry her—even
+Dankmere would have a chance there or—" he hesitated, and decided to
 refrain. But she understood perfectly, and lost the remainder of her
 colour.</p>
 
@@ -9985,8 +9985,8 @@ hocks and drew bridle beside her.</p>
 <p>"How?"</p>
 
 <p>"How do I know? Ledwith and I were connected<span class="pagenum" id="Page_427">[Pg 427]</span> in business matters; I saw
-more or less of them both&mdash;and he was too busy to be with his wife every
-time I happened to be with her. So&mdash;you know what they said."</p>
+more or less of them both—and he was too busy to be with his wife every
+time I happened to be with her. So—you know what they said."</p>
 
 <p>"Yes. When you and she were lunching at different tables at the Santa
 Regina you used to write notes to her, and everybody saw you."</p>
@@ -9998,7 +9998,7 @@ Regina you used to write notes to her, and everybody saw you."</p>
 <p>"That is just it; there was nothing in it."</p>
 
 <p>"Except her reputation.... What a silly and careless girl! But a man
-doesn't think&mdash;doesn't care very much I fancy. And then everybody was
+doesn't think—doesn't care very much I fancy. And then everybody was
 offensively sorry for Chester Ledwith. But that was not your lookout,
 was it, Langly?"</p>
 
@@ -10013,17 +10013,17 @@ friendly with him until his gutter habits annoyed me."</p>
 <p>Once more Sprowl inspected her features, warily. Once more he misjudged
 her.</p>
 
-<p>"He's gone to smash," he said&mdash;"but what's that to us?"</p>
+<p>"He's gone to smash," he said—"but what's that to us?"</p>
 
 <p>"I wonder," she smiled, but had to control the tremor of her lower lip
 by catching it between her teeth and looking away from the man beside
-her. Quickly the hint of tears dried out in her gray eyes&mdash;from whatever
+her. Quickly the hint of tears dried out in her gray eyes—from whatever
 cause they sprang glimmering there to dim her eyesight. She bent her
 head, absently arranging, rearranging and shifting her bridle.</p>
 
 <p>"The thing to do," he said, curling his long moustache<span class="pagenum" id="Page_428">[Pg 428]</span> with powerful
-fingers&mdash;"is for the Wycherlys to stand by us now&mdash;and the others
-there&mdash;that little Lacy girl&mdash;and Sir Charles if he chooses. We'll have
+fingers—"is for the Wycherlys to stand by us now—and the others
+there—that little Lacy girl—and Sir Charles if he chooses. We'll have
 to take the whole lot of them aboard I suppose."</p>
 
 <p>"Suppose I go with you alone," she said in a low voice.</p>
@@ -10031,28 +10031,28 @@ to take the whole lot of them aboard I suppose."</p>
 <p>He started in his saddle, turned on her a face that was reddening
 heavily. For an instant she scarcely recognised him, so thick his lips
 seemed, so congested the veins in forehead and neck. He seemed all mouth
-and eyes and sanguine colour&mdash;and big, even teeth, now, as the lips drew
+and eyes and sanguine colour—and big, even teeth, now, as the lips drew
 aside disclosing them.</p>
 
 <p>"Would you do that, Strelsa?"</p>
 
 <p>"Why not?"</p>
 
-<p>"Would you do it&mdash;for me?"</p>
+<p>"Would you do it—for me?"</p>
 
 <p>Her rapid breathing impeded speech; she said something inarticulate; he
 leaned from his saddle and caught her in his left arm.</p>
 
 <p>"By God," he stammered, "I knew it! You can have what you like from
-me&mdash;I don't care what it is!&mdash;take it&mdash;fill out your own checks&mdash;only
+me—I don't care what it is!—take it—fill out your own checks—only
 let's get out of here before those damned women ruin us both!"</p>
 
 <p>She had strained back and aside from him, and was trying to guide her
 mare away, but his powerful arm crushed her and his hot breath fell on
 her face and neck.</p>
 
-<p>"You can have it your own way I tell you&mdash;I swear to God I'll marry
-you&mdash;&mdash;"</p>
+<p>"You can have it your own way I tell you—I swear to God I'll marry
+you——"</p>
 
 <p>"What!"</p>
 
@@ -10064,25 +10064,25 @@ heavily. "But we can touch at any port and manage that."</p>
 
 <p><span class="pagenum" id="Page_429">[Pg 429]</span></p>
 
-<p>"You&mdash;you <i>would</i> take me&mdash;permit me to go&mdash;in such a manner?" she
+<p>"You—you <i>would</i> take me—permit me to go—in such a manner?" she
 breathed, still staring at him.</p>
 
 <p>"It's necessity, isn't it? Didn't you propose it? It makes no difference
 to me, Strelsa. I told you I'd do anything you wished."</p>
 
-<p>"What did you mean&mdash;what did you mean by&mdash;by&mdash;" But she could go no
+<p>"What did you mean—what did you mean by—by—" But she could go no
 further in speech or thought.</p>
 
 <p>"The thing to do," he said calmly, "is not to fly off our heads or
 become panic-stricken. You're doing the latter; I lost control of
-myself&mdash;after what you gave me to hope&mdash;after what you said&mdash;showing
+myself—after what you gave me to hope—after what you said—showing
 your trust in me," he added, moistening his thick dry lips with his
-tongue. "I lost my self-command&mdash;because I <i>am</i> crazy for you,
-Strelsa&mdash;there's no sense in pretending otherwise&mdash;and you knew it all
+tongue. "I lost my self-command—because I <i>am</i> crazy for you,
+Strelsa—there's no sense in pretending otherwise—and you knew it all
 the time, you little coquette!</p>
 
 <p>"What do you think a man's made of? You wanted a business arrangement
-and I humoured you; but you knew all the while, and I knew, that&mdash;that I
+and I humoured you; but you knew all the while, and I knew, that—that I
 am infatuated, absolutely mad about you." He added, boldly: "And I have
 reason to think it doesn't entirely displease you, haven't I?"</p>
 
@@ -10093,9 +10093,9 @@ recoiled before her eyes as from a blow.</p>
 
 <p>Her teeth were still working on her under lip. She made no answer.</p>
 
-<p>"Strelsa&mdash;if you really feel nothing for me&mdash;if you mean what you have
-said about a purely business agreement&mdash;I will hold to it. I thought for
-a moment&mdash;when you said&mdash;something in your smile made me think&mdash;&mdash;"</p>
+<p>"Strelsa—if you really feel nothing for me—if you mean what you have
+said about a purely business agreement—I will hold to it. I thought for
+a moment—when you said—something in your smile made me think——"</p>
 
 <p>"You need not think any further," she said.</p>
 
@@ -10106,7 +10106,7 @@ a moment&mdash;when you said&mdash;something in your smile made me think&mdash;&
 <p>"I mean that I came with you this morning to tell you that I will not
 marry you."</p>
 
-<p>"That's nonsense! I've hurt you&mdash;made you angry&mdash;&mdash;"</p>
+<p>"That's nonsense! I've hurt you—made you angry——"</p>
 
 <p>"I came for that reason," she repeated. "I meant to do it as soon as I
 had the courage. I meant to do it gently. Now I don't care how I do it.
@@ -10116,8 +10116,8 @@ It's enough for you to know that I will not marry you."</p>
 
 <p>"Yes."</p>
 
-<p>"I don't believe it. I know perfectly well I was&mdash;was too impulsive, too
-ardent&mdash;&mdash;"</p>
+<p>"I don't believe it. I know perfectly well I was—was too impulsive, too
+ardent——"</p>
 
 <p>She turned her face away with a faint, sick look at the summer fields
 where scores of birds sang in the sunshine.</p>
@@ -10141,9 +10141,9 @@ her friends."</p>
 Strelsa, and then let us be reconciled."</p>
 
 <p>"No, it is too late. It was too late even before we started out
-together. Why&mdash;I didn't realise it then&mdash;but<span class="pagenum" id="Page_431">[Pg 431]</span> it was too late long
-ago&mdash;from the day you spoke as you did in my presence to Mr. Quarren.
-That finished you, Langly&mdash;if, indeed, you ever really began to mean
+together. Why—I didn't realise it then—but<span class="pagenum" id="Page_431">[Pg 431]</span> it was too late long
+ago—from the day you spoke as you did in my presence to Mr. Quarren.
+That finished you, Langly—if, indeed, you ever really began to mean
 anything at all to me."</p>
 
 <p>He made a last effort and the veins stood out on his forehead:</p>
@@ -10158,7 +10158,7 @@ it. My agents attend to such petty matters. What motive have I for
 disliking Quarren?"</p>
 
 <p>She shrugged her shoulders disdainfully: "Perhaps because you thought he
-was devoted to me&mdash;and I to him.... And you were right," she added: "I
+was devoted to me—and I to him.... And you were right," she added: "I
 am devoted to him because he is a man and a clean one."</p>
 
 <p>"Have you ended?"</p>
@@ -10179,10 +10179,10 @@ the proposed arrangement."</p>
 
 <p>His visage altered alarmingly:</p>
 
-<p>"Who have you got on the string now!" he broke out&mdash;"you little
+<p>"Who have you got on the string now!" he broke out—"you little
 adventuress! What damned fool is<span class="pagenum" id="Page_432">[Pg 432]</span> damned fool enough to marry you when
 anybody could get you for less if they care to spend the time on
-you&mdash;&mdash;"</p>
+you——"</p>
 
 <p>Suddenly his arm shot out and he wrenched her bridle, dragging her horse
 around and holding him there.</p>
@@ -10258,17 +10258,17 @@ at her.</p>
 
 <p>"You don't mean to say it's all off, Strelsa!"</p>
 
-<p>"Entirely. Please don't let's speak of it again&mdash;or of him&mdash;if you don't
-mind&mdash;&mdash;"</p>
+<p>"Entirely. Please don't let's speak of it again—or of him—if you don't
+mind——"</p>
 
-<p>"I don't!&mdash;you darling!&mdash;you poor darling! What has that creature done
+<p>"I don't!—you darling!—you poor darling! What has that creature done
 to <i>you</i>?"</p>
 
 <p>"Don't speak of him, please."</p>
 
-<p>"No, I won't. Oh, I'm so glad, Strelsa!&mdash;I can't tell you how happy, how
-immensely relieved&mdash;and that cat of an aunt of his here to make
-mischief!&mdash;and poor Mary Ledwith&mdash;&mdash;"</p>
+<p>"No, I won't. Oh, I'm so glad, Strelsa!—I can't tell you how happy, how
+immensely relieved—and that cat of an aunt of his here to make
+mischief!—and poor Mary Ledwith——"</p>
 
 <p><span class="pagenum" id="Page_435">[Pg 435]</span></p>
 
@@ -10277,7 +10277,7 @@ caressingly."]</p>
 
 <p><span class="pagenum" id="Page_438">[Pg 438]</span></p>
 
-<p>"Molly, I&mdash;I simply can't talk about it&mdash;any of it&mdash;&mdash;"</p>
+<p>"Molly, I—I simply can't talk about it—any of it——"</p>
 
 <p>She turned abruptly, entered the house, and ran lightly up the stairs.
 Molly waited for her, grimly content with the elimination of Langly
@@ -10301,8 +10301,8 @@ a renewal of the eternal pressure, looked at Molly with wide gray eyes.</p>
 
 <p>"I don't know what's the matter with me to-day," she said; "I seem to be
 able to laugh. I've not been very well physically; I've had a ghastly
-morning; I'm homeless and wretchedly poor&mdash;and I'm laughing at it
-all&mdash;the whole thing, Molly. What do you suppose is the matter with me?"</p>
+morning; I'm homeless and wretchedly poor—and I'm laughing at it
+all—the whole thing, Molly. What do you suppose is the matter with me?"</p>
 
 <p>"You're not in love, are you?" asked Molly with calm suspicion.</p>
 
@@ -10314,18 +10314,18 @@ the elder woman.</p>
 <p>"Then I don't see why you should be very happy," said Molly honestly.</p>
 
 <p>Strelsa considered: "Perhaps it's because to-day I feel unusually well.
-I slept&mdash;which I don't usually."</p>
+I slept—which I don't usually."</p>
 
 <p>"You're becoming devout, too," said Molly.</p>
 
 <p>"Devout? Oh, you saw me reading in my Testament.... It's an interesting
 book, Molly," she said naïvely. "You know, as children, and at school,
-and in church we don't read it with any intelligence&mdash;or listen to it in
+and in church we don't read it with any intelligence—or listen to it in
 the right way.... People <i>are</i> odd. We have our moments of contrition,
 abasement, fright, exaltation; but at bottom we know that our religion
 and a fair observance of it is a sound policy of insurance. We accept it
 as we take out insurance in view of eventualities and the chance of
-future fire&mdash;&mdash;"</p>
+future fire——"</p>
 
 <p>"That's flippant," said Molly.</p>
 
@@ -10336,12 +10336,12 @@ is the greatest thing in the world."</p>
 
 <p>"So I've heard," observed Molly drily.</p>
 
-<p>"Oh, I've heard it, too, but never thought what it meant&mdash;until
+<p>"Oh, I've heard it, too, but never thought what it meant—until
 recently. You see Truth, to me, was just telling it as often as
-possible. I never thought much about it&mdash;that it is the basis of
-everything worthy and beautiful&mdash;such as old pictures&mdash;" she added
-vaguely&mdash;"and those things that silversmiths like Benvenuto Cellini
-did&mdash;&mdash;"</p>
+possible. I never thought much about it—that it is the basis of
+everything worthy and beautiful—such as old pictures—" she added
+vaguely—"and those things that silversmiths like Benvenuto Cellini
+did——"</p>
 
 <p>"What?"</p>
 
@@ -10349,7 +10349,7 @@ did&mdash;&mdash;"</p>
 
 <p>"That sounds like Tupper or a copy-book," said<span class="pagenum" id="Page_440">[Pg 440]</span> Molly, laughing. "For
 surely those profound reflections never emanated originally from you or
-Rix&mdash;did they?"</p>
+Rix—did they?"</p>
 
 <p>Strelsa, much annoyed, picked up the field glasses and levelled them on
 the river.</p>
@@ -10360,11 +10360,11 @@ and Sir Charles baited her hook.</p>
 <p>"That's a touching sight," said Strelsa, laughing.</p>
 
 <p>Molly said crossly: "Well, if you don't want him, for goodness' sake say
-so!&mdash;and let me have some credit with the Lacys for engineering the
+so!—and let me have some credit with the Lacys for engineering the
 thing."</p>
 
 <p>"Take it, darling!" laughed the girl, "take the credit and let the cash
-go&mdash;to Chrysos!"</p>
+go—to Chrysos!"</p>
 
 <p>"How indelicate you <i>can</i> be, Strelsa!"</p>
 
@@ -10380,7 +10380,7 @@ knowing nothing worse can happen to you."</p>
 
 <p>The girl looked at her, surprised.</p>
 
-<p>"I don't," she said, "&mdash;really."</p>
+<p>"I don't," she said, "—really."</p>
 
 <p>"Of course you do."</p>
 
@@ -10390,11 +10390,11 @@ knowing nothing worse can happen to you."</p>
 hurry to go there."</p>
 
 <p>"I wasn't thinking of Heaven.... I was just curious to see what else
-there is&mdash;I'm in no hurry, but it has always interested me.... I've had
+there is—I'm in no hurry, but it has always interested me.... I've had
 a theory that perhaps to everybody worthy is given, hereafter, exactly
-the kind of heaven they expect&mdash;to Buddhist, Brahman, Mohammedan,
-Christian&mdash;to the Shinto priest<span class="pagenum" id="Page_441">[Pg 441]</span> as well as to the Sagamore.... There's
-plenty of time&mdash;I'm in no hurry, nor would it be too soon to-morrow for
+the kind of heaven they expect—to Buddhist, Brahman, Mohammedan,
+Christian—to the Shinto priest<span class="pagenum" id="Page_441">[Pg 441]</span> as well as to the Sagamore.... There's
+plenty of time—I'm in no hurry, nor would it be too soon to-morrow for
 me to find out how near I am to the truth."</p>
 
 <p>"You're morbid, child!"</p>
@@ -10521,7 +10521,7 @@ said.</p>
 
 <p>"Where are you going?"</p>
 
-<p>"I don't know&mdash;to the Acremont Inn for a few days. After that&mdash;I don't
+<p>"I don't know—to the Acremont Inn for a few days. After that—I don't
 know."</p>
 
 <p>Sprowl, perfectly aware that his footman was listening, walked out
@@ -10552,7 +10552,7 @@ exercise."</p>
 
 <p>"I've got to rest."</p>
 
-<p>"Well, then, what have you got to say?&mdash;because I'm going on. What's the
+<p>"Well, then, what have you got to say?—because I'm going on. What's the
 matter with you, anyway," he added sneeringly; "dope?"</p>
 
 <p>"Partly," said Ledwith without resentment.</p>
@@ -10571,14 +10571,14 @@ it?"</p>
 
 <p>"You'll get it; go on," said Sprowl contemptuously.</p>
 
-<p>"Then&mdash;my wife has returned."</p>
+<p>"Then—my wife has returned."</p>
 
 <p><span class="pagenum" id="Page_446">[Pg 446]</span></p>
 
 <p>"Your ex-wife," corrected Sprowl without a shade of expression in voice
 or features.</p>
 
-<p>"Yes," said Ledwith&mdash;"Mary. I left the house before she arrived, on my
+<p>"Yes," said Ledwith—"Mary. I left the house before she arrived, on my
 way to Acremont across country. She and your aunt drove up together. I
 saw them from the hill."</p>
 
@@ -10592,7 +10592,7 @@ looking down at the grass.</p>
 <p>"That," retorted Sprowl, "is none of your business."</p>
 
 <p>"Because," continued Ledwith, not heeding him, "that is the only thing
-possible. There is nothing else for her to do&mdash;for you to do. She knows
+possible. There is nothing else for her to do—for you to do. She knows
 it, you know it, and so do I."</p>
 
 <p>"I know all about it," said Sprowl coolly. "Is there anything else?"</p>
@@ -10618,7 +10618,7 @@ unclosing:</p>
 
 <p>"Is that all, Ledwith?"</p>
 
-<p>"That's all&mdash;when you have confirmed what I have<span class="pagenum" id="Page_447">[Pg 447]</span> said concerning the
+<p>"That's all—when you have confirmed what I have<span class="pagenum" id="Page_447">[Pg 447]</span> said concerning the
 necessity for your marriage with the woman you debauched."</p>
 
 <p>"You lie," said Langly.</p>
@@ -10632,7 +10632,7 @@ after a while, what she did to me. You made her yours, soul and body;
 she became only your creature, caring less and less for concealment as
 her infatuation grew from coquetry to imprudence, from recklessness to
 effrontery.... It's the women of our sort, who, once misled, stop at
-nothing&mdash;not the men. Prudence to the point of cowardice is the amatory
+nothing—not the men. Prudence to the point of cowardice is the amatory
 characteristic of your sort.... I don't mean physical cowardice," he
 added, lifting his sunken eyes and letting them rest on Sprowl's
 powerful frame.</p>
@@ -10645,7 +10645,7 @@ was; you see what I am. I'm not whining; it's all in a lifetime. And the
 man who is not fitted to take care of what is his, loses. That's all."</p>
 
 <p>Sprowl's head was averted after an involuntary glance at the man before
-him. His face was red&mdash;or it may have been the ruddy evening sun
+him. His face was red—or it may have been the ruddy evening sun
 striking flat across it.</p>
 
 <p>Ledwith said: "You will marry her, of course. But I merely wish to hear
@@ -10661,7 +10661,7 @@ you say so."</p>
 
 <p>"Do you think so?"</p>
 
-<p>"Yes. Or&mdash;I'll kill you," he said seriously.</p>
+<p>"Yes. Or—I'll kill you," he said seriously.</p>
 
 <p>Langly stared at him, every vein suddenly dark and swollen; then his
 bark of a laugh broke loose.</p>
@@ -10676,7 +10676,7 @@ took the revolver from him, and flung it into the woods.</p>
 heel, and sauntered off.</p>
 
 <p>Ledwith looked after him, one bloodless hand resting on the cheek which
-Sprowl had struck&mdash;watched him out of sight. Then, patiently, he started
+Sprowl had struck—watched him out of sight. Then, patiently, he started
 to search for the weapon, dropping on all-fours, crawling, peering,
 parting the ferns and bushes. But the sun was low and the woods dusky,
 and he could not find what he was looking for. So he sat up on the
@@ -10692,7 +10692,7 @@ his aunt was within driving distance of his own quarters.</p>
 
 <p>A dull hot anguish, partly rage, possessed him, tormenting brain and
 heart incessantly and giving him no rest. His own clumsy madness in
-destroying what he believed had been a certainty&mdash;his stupidity, his
+destroying what he believed had been a certainty—his stupidity, his
 loss of<span class="pagenum" id="Page_449">[Pg 449]</span> self-control, not only in betraying passion prematurely but in
 his subsequent violence and brutality, almost drove him insane.</p>
 
@@ -10703,19 +10703,19 @@ inertness when required. But above all and everything else he has been a
 master of patience, and so a master of himself; and so he had usually
 won.</p>
 
-<p>And now&mdash;now in this crisis&mdash;a crisis involving the loss of what he
-cared for enough to marry&mdash;if he must marry to have his way with
-her&mdash;what was to be done?</p>
+<p>And now—now in this crisis—a crisis involving the loss of what he
+cared for enough to marry—if he must marry to have his way with
+her—what was to be done?</p>
 
 <p>He tried to think coolly, but the cinders of rage and passion seemed to
 stir and move with every breath he drew awaking the wild fire within.</p>
 
-<p>He would try to reason and think clearly&mdash;try to retrace matters to the
+<p>He would try to reason and think clearly—try to retrace matters to the
 beginning and find out why he had blundered when everything was in his
 own hands.</p>
 
 <p>It was his aunt's sudden policy that betrayed him into a premature
-move&mdash;Mary Ledwith's return, and his aunt's visit. Mary Ledwith was
+move—Mary Ledwith's return, and his aunt's visit. Mary Ledwith was
 there to marry him; his aunt to make mischief unless he did what was
 expected of him.</p>
 
@@ -10759,7 +10759,7 @@ publicly to squirm out of the consequences. The town has stood for a
 good deal from you. When that girl at the Frivolity Theatre shot
 herself, leaving a letter directed to you, the limit of public patience
 was nearly reached. You had to go abroad, didn't you? Well, you can't go
-abroad this time. Neither London nor Paris nor Vienna nor Budapest&mdash;no,
+abroad this time. Neither London nor Paris nor Vienna nor Budapest—no,
 nor St. Petersburg nor even Constantinople would stand you! Your course
 is finished. If you've an ounce of brains remaining you know that you're
 done for this time. So go and dress and come over to dinner.... And
@@ -10780,7 +10780,7 @@ you'll go married first."</p>
 
 <p>He picked up a cigar, examined it, yawned, then glanced at her:</p>
 
-<p>"As I had&mdash;recently&mdash;occasion to tell Chester Ledwith, I'll marry whom I
+<p>"As I had—recently—occasion to tell Chester Ledwith, I'll marry whom I
 please. Now suppose you clear out."</p>
 
 <p>"Are you dining with us?"</p>
@@ -10803,20 +10803,20 @@ please. Now suppose you clear out."</p>
 
 <p>"Yes!" he shouted, partly rising from his chair, his narrow face
 distorted. "Yes, I do! Now you know, don't you! Is the matter settled at
-last? Do you understand clearly?&mdash;you fat-headed, meddlesome old fool!"</p>
+last? Do you understand clearly?—you fat-headed, meddlesome old fool!"</p>
 
 <p>He sprang to his feet in an access of fury and began loping up and down
 the room, gesticulating, almost mouthing out his hatred and
-abuse&mdash;rendered more furious still by the knowledge of his own weakness
-and disintegration&mdash;his<span class="pagenum" id="Page_452">[Pg 452]</span> downfall from that silent citadel of
+abuse—rendered more furious still by the knowledge of his own weakness
+and disintegration—his<span class="pagenum" id="Page_452">[Pg 452]</span> downfall from that silent citadel of
 self-control which had served him so many years as a stronghold for
 defiance or refuge.</p>
 
 <p>"You impertinent old woman!" he shouted, "if you don't keep your fat
 nose out of my affairs I'll set a thousand men tampering with the
 foundations of your investments! Keep your distance and mind your
-business&mdash;I warn you now and for the last time, or else&mdash;" He swung
-around on her, and the jaw muscles began to work&mdash;"or else I'll supply
+business—I warn you now and for the last time, or else—" He swung
+around on her, and the jaw muscles began to work—"or else I'll supply
 the Yellows with a few facts concerning that Englishman's late father
 and yourself!"</p>
 
@@ -10855,7 +10855,7 @@ Mrs. Leeds and I'd be awfully obliged to you."</p>
 moment this afternoon and she said that you are dining with her at Mrs.
 Ledwith's."</p>
 
-<p>"She was mistaken&mdash;" began Sprowl quietly, but Molly cut him short with
+<p>"She was mistaken—" began Sprowl quietly, but Molly cut him short with
 a laughing "good-bye," and hung up the receiver.</p>
 
 <p>"That was Langly," she remarked, turning to Strelsa who was already
@@ -10870,7 +10870,7 @@ the perfection of grooming from crown to toe.</p>
 <p>There was nobody in the music-room. Molly turned again to Strelsa as
 they entered:</p>
 
-<p>"What a brute he is!&mdash;asking me to invite him here for dinner when Mary
+<p>"What a brute he is!—asking me to invite him here for dinner when Mary
 Ledwith has just arrived."</p>
 
 <p>"Did he do that?"</p>
@@ -10881,8 +10881,8 @@ sneaking way of doing it!"</p>
 <p>Strelsa looked out of the dark window in silence.</p>
 
 <p>Molly said: "I wish he'd go away, I never can<span class="pagenum" id="Page_454">[Pg 454]</span> look at him without
-thinking of Chester Ledwith&mdash;and all that wretched affair.... Not that I
-am sniffy about Mary&mdash;the poor little fool.... Anyway," she added
+thinking of Chester Ledwith—and all that wretched affair.... Not that I
+am sniffy about Mary—the poor little fool.... Anyway," she added
 naïvely, "old lady Sprowl has fixed her status and now we all know how
 to behave toward her."</p>
 
@@ -10902,13 +10902,13 @@ may think of us. We don't seem to care what we think of each other."</p>
 
 <p>Molly, a trifle red, asked her warmly what she meant.</p>
 
-<p>"Oh, I was just realising what are the motives that govern us&mdash;the
-majority of us&mdash;and how primitive they are. So many among us seem to be
-moral throwbacks&mdash;types reappearing out of the mists of an ancient and
+<p>"Oh, I was just realising what are the motives that govern us—the
+majority of us—and how primitive they are. So many among us seem to be
+moral throwbacks—types reappearing out of the mists of an ancient and
 unmoral past.... Echoes of primitive ages when nobody knew any
-better&mdash;when life was new, and was merely life and nothing
-else&mdash;fighting, treacherous, cringing life which knew of nothing else to
-do except to eat, sleep, and reproduce itself&mdash;bully the weaker, fawn on
+better—when life was new, and was merely life and nothing
+else—fighting, treacherous, cringing life which knew of nothing else to
+do except to eat, sleep, and reproduce itself—bully the weaker, fawn on
 the stronger, lie, steal, and watch out that death should not interfere
 with the main chance."</p>
 
@@ -10930,7 +10930,7 @@ indoors with many people."</p>
 <p>"You're a good wife, Molly; and a good friend.... I wish you had a
 baby."</p>
 
-<p>"I'm&mdash;going to."</p>
+<p>"I'm—going to."</p>
 
 <p>They looked at each other a moment; then Strelsa caught her in her arms.</p>
 
@@ -10943,7 +10943,7 @@ baby."</p>
 <p>"He mustn't! He's got to stop! What can he be thinking of!" cried
 Strelsa indignantly.</p>
 
-<p>"But he&mdash;doesn't know."</p>
+<p>"But he—doesn't know."</p>
 
 <p>"You haven't <i>told</i> him?"</p>
 
@@ -10951,39 +10951,39 @@ Strelsa indignantly.</p>
 
 <p>"Why not?"</p>
 
-<p>"I&mdash;don't know how he'll take it."</p>
+<p>"I—don't know how he'll take it."</p>
 
 <p>"What?"</p>
 
 <p>Molly flushed: "We didn't want one. I don't know what he'll say. We
-didn't care for them&mdash;&mdash;"</p>
+didn't care for them——"</p>
 
 <p>Strelsa's angry beauty checked her with its silent scorn; suddenly her
 pretty head fell forward on Strelsa's breast:</p>
 
-<p>"Don't look that way at me! I was a fool. How was I to know&mdash;anything?
+<p>"Don't look that way at me! I was a fool. How was I to know—anything?
 I'd never had one.... You can't know whether you want a baby or not
 until you have one.... I know now. I'm crazy about it.... I think it
-would&mdash;would kill me if Jim is annoyed&mdash;&mdash;"</p>
+would—would kill me if Jim is annoyed——"</p>
 
 <p><span class="pagenum" id="Page_456">[Pg 456]</span></p>
 
 <p>"He won't be, darling!" whispered Strelsa. "Don't mind what he says
 anyway. He's only a man. He never even knew as much about it as you did.
-What do men know, anyway? Jim is a dear&mdash;just the regular sort of man
+What do men know, anyway? Jim is a dear—just the regular sort of man
 interested in business and sport and probably afraid that a baby might
 interfere with both. What does he know about it?... Besides he's too
-decent to be annoyed&mdash;&mdash;"</p>
+decent to be annoyed——"</p>
 
-<p>"I'm afraid&mdash;I can't stand&mdash;even his indifference&mdash;" whimpered Molly.</p>
+<p>"I'm afraid—I can't stand—even his indifference—" whimpered Molly.</p>
 
 <p>Strelsa, holding her clasped to her breast, started to speak, but a
-noise of men in the outer hall silenced her&mdash;the aviators returning from
+noise of men in the outer hall silenced her—the aviators returning from
 their hangars and gathering in the billiard-room for a long one before
 dressing.</p>
 
-<p>"Wait," whispered Strelsa, gently disengaging herself&mdash;"wait just a
-moment&mdash;&mdash;"</p>
+<p>"Wait," whispered Strelsa, gently disengaging herself—"wait just a
+moment——"</p>
 
 <p>And she was out in the hall in an instant, just in time to touch Jim on
 the arm as he closed the file toward the billiard-room.</p>
@@ -10999,8 +10999,8 @@ hands. "Are you coming in to try a cocktail with us?"</p>
 
 <p>"Tell me what?"</p>
 
-<p>"Ask her, Jim.... And, if you care one atom for her&mdash;be happy at what
-she tells you&mdash;and tell her that you are. Will you?"</p>
+<p>"Ask her, Jim.... And, if you care one atom for her—be happy at what
+she tells you—and tell her that you are. Will you?"</p>
 
 <p>He stared at her, then lost countenance. Then he<span class="pagenum" id="Page_457">[Pg 457]</span> looked at her in a
 panicky way and started to go, but she held on to him with
@@ -11008,7 +11008,7 @@ determination:</p>
 
 <p>"Smile first!"</p>
 
-<p>"Thunder! I&mdash;&mdash;"</p>
+<p>"Thunder! I——"</p>
 
 <p>"Smile. Oh, Jim, isn't there any decency in men?"</p>
 
@@ -11025,7 +11025,7 @@ over her shoulder.</p>
 
 <p>"Hello, ducky. Strelsa says you have something to tell me."</p>
 
-<p>"I&mdash;Jim?"</p>
+<p>"I—Jim?"</p>
 
 <p>"So she said. So I cut out a long one to find out what it is. What's up,
 ducky?"</p>
@@ -11042,7 +11042,7 @@ ducky?"</p>
 considering him for a while in silence. Then, dropping her arms with a
 helpless little gesture:</p>
 
-<p>"We are going to have a baby. Are you&mdash;annoyed?"</p>
+<p>"We are going to have a baby. Are you—annoyed?"</p>
 
 <p>For a second he sat as though paralysed, and the next second he had her
 in his arms, the grin breaking out from utter blankness.</p>
@@ -11053,49 +11053,49 @@ in his arms, the grin breaking out from utter blankness.</p>
 
 <p>"Jim!... Really?"</p>
 
-<p>"Surest thing you know! Which is it?&mdash;boy or&mdash;Oh, I beg your pardon,
-dear&mdash;I'm not accustomed to the etiquette. But I'm delighted, ducky,
+<p>"Surest thing you know! Which is it?—boy or—Oh, I beg your pardon,
+dear—I'm not accustomed to the etiquette. But I'm delighted, ducky,
 overwhelmed!"</p>
 
-<p>"Oh, Jim! I'm so glad. And I'm crazy about it&mdash;perfectly mad about
-it.... And you're a dear to care&mdash;&mdash;"</p>
+<p>"Oh, Jim! I'm so glad. And I'm crazy about it—perfectly mad about
+it.... And you're a dear to care——"</p>
 
-<p>"Certainly I care! What do you take me for&mdash;a wooden Indian!" he
-exclaimed virtuously. "Come on and we'll celebrate&mdash;&mdash;"</p>
+<p>"Certainly I care! What do you take me for—a wooden Indian!" he
+exclaimed virtuously. "Come on and we'll celebrate——"</p>
 
 <p>"But, Jim! We can't <i>tell</i> people."</p>
 
-<p>"Oh&mdash;that's the christening. I forgot, ducky. No, we can't talk about it
-of course. But I'll do anything you say&mdash;&mdash;"</p>
+<p>"Oh—that's the christening. I forgot, ducky. No, we can't talk about it
+of course. But I'll do anything you say——"</p>
 
 <p>"Will you?"</p>
 
 <p>"Will I? Watch me!"</p>
 
-<p>"Then&mdash;then <i>don't</i> take out the Stinger for a while. Do you mind,
+<p>"Then—then <i>don't</i> take out the Stinger for a while. Do you mind,
 dear?"</p>
 
 <p>"What!" he said, jaw dropping.</p>
 
 <p>"I can't bear it, Jim. I was a good sport before; you know I was. But my
-nerve has gone. I can't take chances now; I <i>want</i> you to see&mdash;it&mdash;&mdash;"</p>
+nerve has gone. I can't take chances now; I <i>want</i> you to see—it——"</p>
 
 <p>After a moment he nodded.</p>
 
 <p>"Sure," he said. "It's like Lent. You've got to offer up something....
-If you feel that way&mdash;" he sighed unconsciously&mdash;"I'll lock up the
-hangar until&mdash;&mdash;"</p>
+If you feel that way—" he sighed unconsciously—"I'll lock up the
+hangar until——"</p>
 
 <p>"Oh, darling! Will you?"</p>
 
 <p>"Yes," said that desolate young man, and kissed his wife without a
-scowl. He had behaved pretty well&mdash;about like the majority of husbands
+scowl. He had behaved pretty well—about like the majority of husbands
 outside of popular romances.</p>
 
 <p><span class="pagenum" id="Page_459">[Pg 459]</span></p>
 
 <p>The amateur aeronauts left in the morning before anybody was stirring
-except the servants&mdash;Vincent Wier, Lester Caldera, the Van Dynes and the
+except the servants—Vincent Wier, Lester Caldera, the Van Dynes and the
 rest, bag, baggage, and, later, two aeroplanes packed and destined for
 Barent Van Dyne's Long Island estate where there was to be some serious
 flying attempted over the flat and dusty plains of that salubrious
@@ -11104,7 +11104,7 @@ island.</p>
 <p>Sir Charles Mallison was leaving that same day, later; and there were to
 be no more of Jim's noisy parties; and now under the circumstances, no
 parties of Molly's, either; because Molly was becoming nervous and
-despondent and a mania for her husband possessed her&mdash;the pretty
+despondent and a mania for her husband possessed her—the pretty
 resurgence of earlier sentiment which, if not more than comfortably
 dormant, buds charmingly again at a time like this.</p>
 
@@ -11124,16 +11124,16 @@ lapel, tall, clear-skinned, nice to look upon.</p>
 
 <p>What he really thought of what he had seen in America, of the sort of
 people who had entertained him, of the grotesque imitation of exotic
-society&mdash;or of a certain sort of it&mdash;nobody really knew. Doubtless his<span class="pagenum" id="Page_460">[Pg 460]</span>
-estimate was inclined to be a kindly one, for he was essentially that&mdash;a
+society—or of a certain sort of it—nobody really knew. Doubtless his<span class="pagenum" id="Page_460">[Pg 460]</span>
+estimate was inclined to be a kindly one, for he was essentially that—a
 philosophical, chivalrous, and modest man; and if his lines had fallen
 in places where vulgarity, extravagance, and ostentation
-predominated&mdash;if he had encountered little real cultivation, less
+predominated—if he had encountered little real cultivation, less
 erudition, and almost nothing worthy of sympathetic interest, he never
 betrayed either impatience or contempt.</p>
 
-<p>He had come for one reason only&mdash;the same reason that had brought him to
-America for the first time&mdash;to ask Strelsa Leeds to marry him.</p>
+<p>He had come for one reason only—the same reason that had brought him to
+America for the first time—to ask Strelsa Leeds to marry him.</p>
 
 <p>He was man enough to understand that she did not care for him that way,
 soldier enough to face his fate, keen enough, long since, to understand
@@ -11159,12 +11159,12 @@ and he had caught a glimpse of the man's face; and that was enough.</p>
 <p><span class="pagenum" id="Page_461">[Pg 461]</span></p>
 
 <p>So there was really nothing to keep him in America any longer. He wanted
-to get back to his own kind&mdash;into real life again, among people of real
+to get back to his own kind—into real life again, among people of real
 position and real elegance, where live topics were discussed, where live
 things were attempted or accomplished, where whatever was done, material
 or immaterial, was done thoroughly and well.</p>
 
-<p>There was not one thing in America, now, to keep him there&mdash;except a
+<p>There was not one thing in America, now, to keep him there—except a
 warm and kindly affection for his little friend Chrysos Lacy with whom
 he had been thrown so constantly at Witch-Hollow.</p>
 
@@ -11175,9 +11175,9 @@ and delightful.</p>
 
 <p>The very perfection of comradeship it had been, full of charming
 surprises as well as a rest both mental and physical. For Chrysos made
-few demands on his intellect&mdash;that is, at first she had made very few.
-Later&mdash;within the past few weeks, he remembered now his surprise to find
-how much there really was to the young girl&mdash;and that perhaps her age
+few demands on his intellect—that is, at first she had made very few.
+Later—within the past few weeks, he remembered now his surprise to find
+how much there really was to the young girl—and that perhaps her age
 and inexperience alone marked any particular intellectual chasm between
 them.</p>
 
@@ -11196,7 +11196,7 @@ dressing-room done in pastel tints, and which hideously set forth the
 colouring and proportions of Mrs. Sprowl in lace bed-attire, bolstered
 up in a big cane-backed chair.</p>
 
-<p>"I'm ill," she said hoarsely; "I have been ill all night&mdash;sitting here
+<p>"I'm ill," she said hoarsely; "I have been ill all night—sitting here
 because I can't lie down. I'd strangle if I lay down."</p>
 
 <p>He held her hand in his firm, sun-tanned grasp, looking down
@@ -11231,15 +11231,15 @@ of mine?" she demanded.</p>
 
 <p>"No," he said.</p>
 
-<p>"Then&mdash;do you mean young Quarren?"</p>
+<p>"Then—do you mean young Quarren?"</p>
 
 <p>"I think I do," he said smiling.</p>
 
 <p>"I'm glad of it!" she said angrily. "If it was not to be you I'm glad
-that it may be Rix. It&mdash;it would have killed me to see her fall into
-Langly's hands....<span class="pagenum" id="Page_463">[Pg 463]</span> I'm ill on account of him&mdash;his shocking treatment of
-me last evening. It was a brutal scene&mdash;one of those terrible family
-scenes!&mdash;and he threatened me&mdash;cursed me&mdash;&mdash;"</p>
+that it may be Rix. It—it would have killed me to see her fall into
+Langly's hands....<span class="pagenum" id="Page_463">[Pg 463]</span> I'm ill on account of him—his shocking treatment of
+me last evening. It was a brutal scene—one of those terrible family
+scenes!—and he threatened me—cursed me——"</p>
 
 <p>She closed her eyes a moment, trembling all over her fat body; then they
 snapped open again with the old fire undiminished:</p>
@@ -11259,7 +11259,7 @@ But I'm not well. I'm going to Carlsbad. Shall I see you there?"</p>
 
 <p>"I do not wish to forget her. One prefers to think often of such a woman
 as Mrs. Leeds. There are not many like her. It is something of a
-privilege to have cared for her, and the memory is not&mdash;painful."</p>
+privilege to have cared for her, and the memory is not—painful."</p>
 
 <p>Mrs. Sprowl glared at him; and, as she thought of Langly, of Strelsa, of
 the collapse of her own schemes, the baffled rage began to smoulder in
@@ -11267,18 +11267,18 @@ her tiny green eyes till they dwindled and dwindled to a pair of
 phosphorescent sparks imbedded in fat.</p>
 
 <p>"I did my best," she said hoarsely. "I'm not defeated if you're not. Say
-the word and I'll start something&mdash;" And suddenly she remembered
+the word and I'll start something—" And suddenly she remembered
 Langly's threat involving the memory of a dead man whose only son now
 stood before her.</p>
 
 <p>She knew that her words were vain, her boast empty; she knew there was
-nothing more for her to do&mdash;nothing even that Sir Charles might do
+nothing more for her to do—nothing even that Sir Charles might do
 toward winning Strelsa without also doing the only thing in the world<span class="pagenum" id="Page_464">[Pg 464]</span>
 which could really terrify herself. Even at the mere thought of it she
 trembled again, and fear forced her to speech born of fear:</p>
 
 <p>"Perhaps it is best for you to go," she faltered. "Absence is a last
-resort.... It may be well to try it&mdash;&mdash;"</p>
+resort.... It may be well to try it——"</p>
 
 <p>He bent over and took her hand:</p>
 
@@ -11292,8 +11292,8 @@ own grew graver.</p>
 
 <p>"You are like your father," she said unsteadily. "It was my privilege to
 share his friendship.... And his friendship was of that
-kind&mdash;high-minded, generous, pure&mdash;asking no more than it gave&mdash;no more
-than it gave&mdash;&mdash;"</p>
+kind—high-minded, generous, pure—asking no more than it gave—no more
+than it gave——"</p>
 
 <p>She laid her cheek against Sir Charles's hands, let it rest there an
 instant, then averting her face motioned his dismissal.</p>
@@ -11320,7 +11320,7 @@ go back and aid him.</p>
 
 <p>But about that time one of Sprowl's young bulls came walking over toward
 him with such menacing observations and deportment that Sir Charles
-promptly looked about him for an advance to the rear-front&mdash;a manœuvre
+promptly looked about him for an advance to the rear-front—a manœuvre
 he had been obliged to learn in the late Transvaal unpleasantness.</p>
 
 <p>And at the same moment he saw Chrysos Lacy.</p>
@@ -11343,11 +11343,11 @@ blow across her cheek.</p>
 
 <p>[Illustration: "'And it is to be your last breakfast.'"]</p>
 
-<p>The girl laughed, then spying more wild strawberries&mdash;the quest of which
-had beguiled her into hostile territory&mdash;dropped on her knees and began
+<p>The girl laughed, then spying more wild strawberries—the quest of which
+had beguiled her into hostile territory—dropped on her knees and began
 to explore.</p>
 
-<p>The berries were big and ripe&mdash;huge drops of crimson honey hanging
+<p>The berries were big and ripe—huge drops of crimson honey hanging
 heavily, five to a stalk. The meadow-grass was red with them, and Sir
 Charles, without more ado, got down on all-fours and started to gather
 them with all the serious and thorough determination characteristic of
@@ -11389,7 +11389,7 @@ the features he could not notice it.</p>
 <p>"I suppose so."</p>
 
 <p>"That will be jolly," he said, sitting back on his heels to rest, and to
-watch her&mdash;to find pleasure in her youth and beauty as she moved
+watch her—to find pleasure in her youth and beauty as she moved
 gracefully amid the fragrant grasses, one little sun-tanned hand
 clasping a great bouquet of the crimson fruit which nodded heavily amid
 tufts of trefoil leaves.</p>
@@ -11430,19 +11430,19 @@ bronzed cheeks with a deeper colour.</p>
 <p>"If you will, Chrysos," he said in a still voice.</p>
 
 <p>She lifted her head and looked directly at him, and in her questioning
-gaze there was nothing of fear&mdash;merely the question.</p>
+gaze there was nothing of fear—merely the question.</p>
 
 <p>"I can't bear to have you go," she said.</p>
 
-<p>"I can't go&mdash;alone."</p>
+<p>"I can't go—alone."</p>
 
-<p>"Could you&mdash;care for me?"</p>
+<p>"Could you—care for me?"</p>
 
 <p>"I love you, Chrysos."</p>
 
 <p>Her eyes widened in wonder:</p>
 
-<p>"You&mdash;you don't <i>love</i> me&mdash;do you?"</p>
+<p>"You—you don't <i>love</i> me—do you?"</p>
 
 <p>"Yes," he said, "I do. Will you marry me, Chrysos?"</p>
 
@@ -11474,9 +11474,9 @@ it over, I cannot logically account for it.</p>
 
 <p>"Because, Rix, my worldly affairs seem to be going from bad to
 worse. I know it perfectly well, yet where is that deadly
-fear?&mdash;where is the dismay, the alternate hours of panic and dull
-lethargy&mdash;the shrinking from a future which only yesterday seemed
-to threaten me with more than I had strength to endure&mdash;menace me
+fear?—where is the dismay, the alternate hours of panic and dull
+lethargy—the shrinking from a future which only yesterday seemed
+to threaten me with more than I had strength to endure—menace me
 with what I had neither the will nor the desire to resist?</p>
 
 <p>"Gone, my friend! And I am either a fool or a philosopher, but
@@ -11492,14 +11492,14 @@ tell you what I've done. Will you laugh? I can't help it if you do;
 I've bought a house! What do you think of that?</p>
 
 <p>"The owner took back a mortgage, but I don't care. I paid so <i>very</i>
-little for it, and thirty acres of woods and fields&mdash;and it is a
-darling house!&mdash;built in the eighteenth century and not in good
-repair, but it's mine! mine! mine!&mdash;and it may need paint and
+little for it, and thirty acres of woods and fields—and it is a
+darling house!—built in the eighteenth century and not in good
+repair, but it's mine! mine! mine!—and it may need paint and
 plumbing and all sorts of things which perhaps make for human
 happiness and perhaps do not. But I tell you I really don't care.</p>
 
 <p>"And how I did it was this: I took what they offered for my laces
-and jewels&mdash;about a third of their value&mdash;but it paid every debt
+and jewels—about a third of their value—but it paid every debt
 and left me with enough to buy my sweet old house up here.</p>
 
 <p>"But that's not all! I've rented my town house furnished for a term
@@ -11515,23 +11515,23 @@ brain is humming with schemes, millions of them. Isn't it heavenly?</p>
 
 <p>"Besides, from my second-story windows I shall be able to see
 Molly's chimneys above the elms. And Molly is going to remain here
-all winter, because, Rix&mdash;and this is a close secret&mdash;a little heir
+all winter, because, Rix—and this is a close secret—a little heir
 or heiress is<span class="pagenum" id="Page_475">[Pg 475]</span> coming to make <i>this</i> House of Wycherly 'an
-habitation enforced'&mdash;and a happier habitation than it has been
+habitation enforced'—and a happier habitation than it has been
 since they bought it.</p>
 
-<p>"So you see I shall have neighbours all winter&mdash;two neighbours, for
+<p>"So you see I shall have neighbours all winter—two neighbours, for
 Mrs. Ledwith is wretchedly ill and her physicians have advised her
-to remain here all winter. Poor child&mdash;for she is nothing else,
-Rix&mdash;I met her for the first time when I went to call on Mrs.
+to remain here all winter. Poor child—for she is nothing else,
+Rix—I met her for the first time when I went to call on Mrs.
 Sprowl. She's so young and so empty-headed, just a shallow,
 hare-brained, little thing who had no more moral idea of sin than a
-humming-bird&mdash;nor perhaps has she any now except that the world has
+humming-bird—nor perhaps has she any now except that the world has
 hurt her and broken her wings and damaged her plumage; and the
 sunlight in which she sparkled for a summer has faded to a chill
-gray twilight!&mdash;Oh, Rix, it is really pitiful; and somehow I can't
+gray twilight!—Oh, Rix, it is really pitiful; and somehow I can't
 seem to remember whether she was guilty or not, because she's so
-ill, so broken&mdash;lying here amid the splendour of her huge house&mdash;&mdash;</p>
+ill, so broken—lying here amid the splendour of her huge house——</p>
 
 <p>"You know Mrs. Sprowl is on her way to Carlsbad. You haven't
 written me what took place in your last interview with her; and
@@ -11561,9 +11561,9 @@ and not one line to you and the exciting success you and Lord
 Dankmere are making of your new business.</p>
 
 <p>"Oh, Rix, I am not indifferent; all the time I have been writing to
-you, that has been surging and laughing in my heart&mdash;like some
+you, that has been surging and laughing in my heart—like some
 delicious aria that charmingly occupies your mind while you go
-happily about other matters&mdash;happy because the ceaseless melody
+happily about other matters—happy because the ceaseless melody
 that enchants you makes you so.</p>
 
 <p>"I have read your letter so many times, over and over; and always
@@ -11576,7 +11576,7 @@ not? Is it possible that all these years none of Dankmere's people
 suspected what was hidden under the aged paint and varnish of that
 tiresome old British landscape?</p>
 
-<p>"And it remained for you to suspect it!&mdash;for <i>you</i> to discover it?
+<p>"And it remained for you to suspect it!—for <i>you</i> to discover it?
 Oh, Rix, I am proud of you!</p>
 
 <p>"And how perfectly wonderful it is that now you know its history,
@@ -11585,38 +11585,38 @@ ever since under its ignoble integument of foolish paint.</p>
 
 <p>"No, I promise not to say one word about it until I have your
 permission. I understand quite well why you desire to keep the
-matter from the newspapers for the present. But&mdash;won't it make you
-and Lord Dankmere<span class="pagenum" id="Page_479">[Pg 479]</span> rich? Tell me&mdash;please tell me. I don't want
+matter from the newspapers for the present. But—won't it make you
+and Lord Dankmere<span class="pagenum" id="Page_479">[Pg 479]</span> rich? Tell me—please tell me. I don't want
 money for myself any more, but I do want it for you. You need it;
 you can do so much with it, use it so intelligently, so gloriously,
-make the world better with it,&mdash;make it more beautiful, and people
+make the world better with it,—make it more beautiful, and people
 happier.</p>
 
 <p>"What a chasm, Rix, between what we were a year ago, and what we
-care to be&mdash;what we are trying to be to-day! Sometimes I think of
+care to be—what we are trying to be to-day! Sometimes I think of
 it, not unhappily, merely wondering.</p>
 
 <p>"Toward what goal were we moving a year ago? What was there to be
-of such lives?&mdash;what at the end? Why, there was, for us, no more
-significance in living than there is to any overfed animal!&mdash;not as
+of such lives?—what at the end? Why, there was, for us, no more
+significance in living than there is to any overfed animal!—not as
 much!</p>
 
-<p>"Oh, this glorious country of high clouds and far horizons!&mdash;and
+<p>"Oh, this glorious country of high clouds and far horizons!—and
 alas! for the Streets of Ascalon where such as I once was go to and
-fro&mdash;'clad delicately in scarlet and ornaments of gold.'</p>
+fro—'clad delicately in scarlet and ornaments of gold.'</p>
 
 <p>"'Tell it not in Gath, publish it not in the Streets of
-Ascalon'&mdash;that the pavements of the Philistines have bruised my
+Ascalon'—that the pavements of the Philistines have bruised my
 feet, and their Five Cities weary me, and Philistia's high towers
 are become a burden to my soul. For their gods are too many and too
-strange for me. So I am decided to remain here&mdash;ere 'they that look
+strange for me. So I am decided to remain here—ere 'they that look
 out of their windows be darkened' and 'the doors be shut in the
-Streets'&mdash;'and all the daughters of music shall be brought low.'</p>
+Streets'—'and all the daughters of music shall be brought low.'</p>
 
 <p>"My poor comrade! Must you remain a prisoner in the Streets of
 Ascalon? Yet, through your soul I know as free and fresh a breeze
-is blowing as stirs the curtains at my open window!&mdash;You wonderful
-man to evoke in imagery&mdash;to visualise and conceive all that<span class="pagenum" id="Page_480">[Pg 480]</span> had to
+is blowing as stirs the curtains at my open window!—You wonderful
+man to evoke in imagery—to visualise and conceive all that<span class="pagenum" id="Page_480">[Pg 480]</span> had to
 be concrete to cure me soul and body of my hurts!</p>
 
 <hr class="tb" />
@@ -11645,11 +11645,11 @@ If it's gossip, make me stop.</p>
 
 <hr class="tb" />
 
-<p>"And now&mdash;when are you coming to see me? I am still at Molly's, you
+<p>"And now—when are you coming to see me? I am still at Molly's, you
 know. My house is being cleaned and sweetened and papered and
 chintzed and made livable and lovable.</p>
 
-<p>"When?&mdash;please.</p>
+<p>"When?—please.</p>
 
 <p>"Your friend and comrade,
 <span class="smcap">Strelsa</span>."</p>
@@ -11669,7 +11669,7 @@ follows."</p>
 went to lunch and when Dankmere got onto his little legs and strolled
 out, also. There was no need to arouse anybody's suspicions by hurrying,
 so Dankmere waited until he turned the corner before his little legs
-began to trot. Miss Vining would be at her usual table, anyway&mdash;and
+began to trot. Miss Vining would be at her usual table, anyway—and
 probably as calmly surprised to see him as she always was. For the
 repeated accident of their encountering at the same restaurant seemed to
 furnish an endless source of astonishment to them both. Apparently
@@ -11722,16 +11722,16 @@ my natural inclination is to like people. Come on downstairs."</p>
 visitor, then, without further excuse, went smilingly about his work,
 explaining it as it progressed:</p>
 
-<p>"Here's an old picture by some Italian gink&mdash;impossible to tell by whom
+<p>"Here's an old picture by some Italian gink—impossible to tell by whom
 it was painted, but not difficult to assign it to a certain date and
 school.... See what I'm doing, Ledwith?</p>
 
 <p>"That's what we call 'rabbit glue' because it's made out of rabbits'
-bones&mdash;or that's the belief, anyway. It's gilder's glue.</p>
+bones—or that's the belief, anyway. It's gilder's glue.</p>
 
-<p>"Now I dissolve this much of it in hot water&mdash;then I glue over the face
+<p>"Now I dissolve this much of it in hot water—then I glue over the face
 of the picture three layers of tissue-paper, one on top of the
-other&mdash;so!</p>
+other—so!</p>
 
 <p><span class="pagenum" id="Page_483">[Pg 483]</span></p>
 
@@ -11740,15 +11740,15 @@ new linen canvas. Yesterday I sponged it as a tailor sponges cloth; and
 now it's dry and tight.</p>
 
 <p>"Now I'm going to reline this battered old Italian canvas. It's already
-been relined&mdash;perhaps a hundred years ago. So first I take off the old
-relining canvas&mdash;with hot water&mdash;this way&mdash;cleaning off all the old
+been relined—perhaps a hundred years ago. So first I take off the old
+relining canvas—with hot water—this way—cleaning off all the old
 paste or glue from it with alcohol....</p>
 
 <p>"Now here's a pot of paste in which there is also glue and whitening;
 and I spread it over the back of this old painting, and then, very
 gingerly, glue it over the new linen canvas on the stretcher.</p>
 
-<p>"Now I smooth it with this polished wooden block, and then&mdash;just watch
+<p>"Now I smooth it with this polished wooden block, and then—just watch
 me do laundry work!"</p>
 
 <p>He picked up a flat-iron which was moderately warm, reversed the relined
@@ -11779,7 +11779,7 @@ very cautiously but steadily to rub the varnished surface with my
 fingers and thumb. And do you know what will happen? The new varnish has
 partly united with the old yellow and opaque coating of varnish and
 dust, and it all will turn to a fine gray powder under the friction and
-will come away leaving the old paint underneath almost as fresh&mdash;very
+will come away leaving the old paint underneath almost as fresh—very
 often quite as fresh and delicate as when the picture was first painted.</p>
 
 <p>"Sometimes I have to use three or more coats of new varnish before I can
@@ -11789,19 +11789,19 @@ sooner or later I get it clean.</p>
 <p>"Then I dig out any old patches or restorations and fill in with a
 composition of putty, white lead, and a drier, and smooth this with a
 cork. Then when it is sunned for an hour a day for three weeks or
-more&mdash;or less, sometimes&mdash;I'm ready to grind my pure colours, mix them,
+more—or less, sometimes—I'm ready to grind my pure colours, mix them,
 set my palette, and do as honest a piece of restoring as a study of that
 particular master's methods permits. And that, Ledwith, is only a little
 part of my fascinating profession.</p>
 
-<p>"Sometimes I lift the entire skin of paint from a canvas&mdash;picking out
-the ancient threads from the rotten texture&mdash;and transfer it to a new
+<p>"Sometimes I lift the entire skin of paint from a canvas—picking out
+the ancient threads from the rotten texture—and transfer it to a new
 canvas or panel. Sometimes I cross-saw a panel, then chisel to the
 plaster that lies beneath the painting, and so transfer it to a<span class="pagenum" id="Page_485">[Pg 485]</span> new and
-sound support. Sometimes&mdash;" he laughed&mdash;"but there are a hundred
-delicate and interesting surgical operations which I attempt&mdash;a thousand
-exciting problems to solve&mdash;experiments without end that tempt me,
-innovations that allure me&mdash;&mdash;"</p>
+sound support. Sometimes—" he laughed—"but there are a hundred
+delicate and interesting surgical operations which I attempt—a thousand
+exciting problems to solve—experiments without end that tempt me,
+innovations that allure me——"</p>
 
 <p>He laughed again:</p>
 
@@ -11810,17 +11810,17 @@ of it!"</p>
 
 <p>"I?" said Ledwith, dully.</p>
 
-<p>"Why not? Man, you're young yet, if&mdash;if&mdash;&mdash;"</p>
+<p>"Why not? Man, you're young yet, if—if——"</p>
 
-<p>"Yes, I know, Quarren.... But my mind is too old&mdash;very old and very
-infirm&mdash;dying in me of age&mdash;the age that comes through those centuries
+<p>"Yes, I know, Quarren.... But my mind is too old—very old and very
+infirm—dying in me of age—the age that comes through those centuries
 of pain that men sometimes live through in a few months."</p>
 
 <p>Quarren looked at him hopelessly.</p>
 
 <p>"Yet," he said, "if only a man wills it, the world is new again."</p>
 
-<p>"But&mdash;if the will fails?"</p>
+<p>"But—if the will fails?"</p>
 
 <p>"I don't know, Ledwith."</p>
 
@@ -11846,8 +11846,8 @@ me."</p>
 
 <p><span class="pagenum" id="Page_486">[Pg 486]</span></p>
 
-<p>"I didn't make mine. They dug the pit and I fell into it&mdash;Hell's own
-pit, Quarren&mdash;&mdash;"</p>
+<p>"I didn't make mine. They dug the pit and I fell into it—Hell's own
+pit, Quarren——"</p>
 
 <p>"You are wrong! You fell into a pit which hurt so much that you supposed
 it was the pit of hell. And, taking it for granted, you burrowed deeper
@@ -11867,7 +11867,7 @@ He considered the man for a few moments, then, coolly:</p>
 
 <p>"Why not?"</p>
 
-<p>"He isn't worth it&mdash;even as company in hell."</p>
+<p>"He isn't worth it—even as company in hell."</p>
 
 <p>"Do you think I'm going to let him live on?"</p>
 
@@ -11879,21 +11879,21 @@ He considered the man for a few moments, then, coolly:</p>
 
 <p>"Easily, if you commit murder."</p>
 
-<p>"That isn't murder&mdash;&mdash;"</p>
+<p>"That isn't murder——"</p>
 
 <p>But Quarren cut him short continuing:</p>
 
-<p>"Sink lower, you ask? What have you done, anyway&mdash;except to commit this
-crime against yourself?"&mdash;touching him on the wrist. "I'm not aware of
+<p>"Sink lower, you ask? What have you done, anyway—except to commit this
+crime against yourself?"—touching him on the wrist. "I'm not aware of
 any other crime committed by you, Ledwith. You're clean as you
-stand&mdash;except for this damnable insult and injury you offer yourself!
+stand—except for this damnable insult and injury you offer yourself!
 Can't you reason? A bullet-stung animal sometimes turns and bites
-itself. Is that why you are doing it?&mdash;to arouse the amusement and
+itself. Is that why you are doing it?—to arouse the amusement and
 contempt of your hunter?"</p>
 
 <p><span class="pagenum" id="Page_487">[Pg 487]</span></p>
 
-<p>"Quarren! By God you shall not say that to me&mdash;&mdash;"</p>
+<p>"Quarren! By God you shall not say that to me——"</p>
 
 <p>"Why not? Have you ever considered what that man must think of you to
 see you turn and tear at the body he has crippled?"</p>
@@ -11910,8 +11910,8 @@ vitals?"</p>
 
 <p>"If you say the word <i>I'll</i> stand by you, Ledwith. If all you want to do
 is to punish him, murder isn't the way. What does a dead man care? Cut
-your own throat and the crime might haunt him&mdash;and might not. But
-<i>kill</i>!&mdash;Nonsense. It's all over then&mdash;except for the murderer."</p>
+your own throat and the crime might haunt him—and might not. But
+<i>kill</i>!—Nonsense. It's all over then—except for the murderer."</p>
 
 <p>He slid his hand quietly to Ledwith's arm, patted it.</p>
 
@@ -11923,22 +11923,22 @@ nerve and muscle and common sense."</p>
 
 <p>"Then? Oh, anything that you fancy. It's according to a man's personal
 taste. You can take him by the neck and beat him up in public if you
-like&mdash;or knock him down in the club as often as he gets up. It all
+like—or knock him down in the club as often as he gets up. It all
 depends, Ledwith. Some of us maintain self-respect<span class="pagenum" id="Page_488">[Pg 488]</span> without violence;
 some of us seem to require it. It's up to you."</p>
 
 <p>"Yes."</p>
 
 <p>Quarren said carelessly: "If I were you, I think that I'd face the world
-as soon as I was physically and mentally well enough&mdash;the real world I
-mean, Ledwith&mdash;either here or abroad, just as I felt about it.</p>
+as soon as I was physically and mentally well enough—the real world I
+mean, Ledwith—either here or abroad, just as I felt about it.</p>
 
 <p>"A man can get over anything except the stigma of dishonesty.
-And&mdash;personally I think he ought to have another chance even after that.
+And—personally I think he ought to have another chance even after that.
 But men's ideas differ. As for you, what you become and show that you
 are, will go ultimately with the world. Beat him up if you like; but,
 personally, I never even wished to kick a cur. Some men kick 'em to
-their satisfaction; it's a matter of taste I tell you. Besides&mdash;&mdash;"</p>
+their satisfaction; it's a matter of taste I tell you. Besides——"</p>
 
 <p>He stopped short; and presently Ledwith looked up.</p>
 
@@ -11946,7 +11946,7 @@ their satisfaction; it's a matter of taste I tell you. Besides&mdash;&mdash;"</p
 
 <p>"Yes. You are kind to me, always."</p>
 
-<p>"Then&mdash;Ledwith, I don't know exactly how matters stand. I can only try
+<p>"Then—Ledwith, I don't know exactly how matters stand. I can only try
 to put myself in your present place and imagine what I ought to do,
 having arrived where you have landed.... And, do you know, if I were
 you, and if I listened to my better self, I don't think that I'd lay a
@@ -11954,7 +11954,7 @@ finger on Langly Sprowl."</p>
 
 <p>"Why?"</p>
 
-<p>"For the sake of the woman who betrayed me&mdash;and who is now betrayed in
+<p>"For the sake of the woman who betrayed me—and who is now betrayed in
 turn by the man who betrayed us both."</p>
 
 <p>Ledwith said through his set teeth: "Do you think I care for her? If I
@@ -11970,7 +11970,7 @@ her?"</p>
 <p>"Then why do you care whether or not he keeps his word to her and shares
 with her a coat of social whitewash?"</p>
 
-<p>"I&mdash;she is only a little fool&mdash;alone to face the world now&mdash;&mdash;"</p>
+<p>"I—she is only a little fool—alone to face the world now——"</p>
 
 <p>"You're quite right, Ledwith. She ought to have another chance. First
 offenders are given it by law.... But even if that chance lay in his
@@ -12002,14 +12002,14 @@ and clung to it. He was trembling like a leaf when they entered the cab,
 whimpering when they left it in front of a wide brown-stone<span class="pagenum" id="Page_490">[Pg 490]</span> building
 composed of several old-time private residences thrown together.</p>
 
-<p>"Stand by me, Quarren," he whispered brokenly&mdash;"you won't go away, will
-you? You wouldn't leave me to face this all&mdash;all alone. You've been kind
-to me. I&mdash;I can do it&mdash;I can try to do it just at this moment&mdash;if you'll
-stay close to me&mdash;if you'll let me keep hold of you&mdash;&mdash;"</p>
+<p>"Stand by me, Quarren," he whispered brokenly—"you won't go away, will
+you? You wouldn't leave me to face this all—all alone. You've been kind
+to me. I—I can do it—I can try to do it just at this moment—if you'll
+stay close to me—if you'll let me keep hold of you——"</p>
 
 <p>"Sure thing!" said Quarren cheerfully. "I'll stay as long as you like.
 Don't worry about your clothes; I'll send for plenty of linen and things
-for us both. You're all right, Ledwith&mdash;you've got the nerve. I&mdash;&mdash;"</p>
+for us both. You're all right, Ledwith—you've got the nerve. I——"</p>
 
 <p>The door opened to his ring; a pleasant-faced nurse in white ushered
 them in.</p>
@@ -12054,16 +12054,16 @@ and came back to find her at her desk, laughing.</p>
 
 <p>For a moment he remained red and disconcerted, but the memory of the
 fact that he and Miss Vining were to occupy the galleries all
-alone&mdash;exclusive of intrusive customers&mdash;for a day or more, assuaged a
+alone—exclusive of intrusive customers—for a day or more, assuaged a
 slight chagrin.</p>
 
 <p>"At any rate," he said, "it is just as well that you should know me as I
-am, Miss Vining&mdash;with all my faults and frivolous imperfections, isn't
+am, Miss Vining—with all my faults and frivolous imperfections, isn't
 it?"</p>
 
 <p>"Why?" asked Miss Vining.</p>
 
-<p>"Why&mdash;what?" repeated the Earl, confused.</p>
+<p>"Why—what?" repeated the Earl, confused.</p>
 
 <p>"Why <i>should</i> I know all your imperfections?"</p>
 
@@ -12083,21 +12083,21 @@ himself and take his eyes elsewhere.</p>
 
 <p>"I am not going to take one."</p>
 
-<p>"Oh, but you ought! You'll go stale, fade, droop&mdash;er&mdash;and all that, you
+<p>"Oh, but you ought! You'll go stale, fade, droop—er—and all that, you
 know!"</p>
 
 <p>"It is very kind of you to feel interested," she said, smiling, "but I
-don't expect to droop&mdash;er&mdash;and all that, you know."</p>
+don't expect to droop—er—and all that, you know."</p>
 
-<p>He laughed, after a moment, and so did she&mdash;a sweet, fearless, little
-laugh most complimentary to his lordship if he only knew it&mdash;a pretty,
-frank tribute to what had become a friendship&mdash;an accord born of
+<p>He laughed, after a moment, and so did she—a sweet, fearless, little
+laugh most complimentary to his lordship if he only knew it—a pretty,
+frank tribute to what had become a friendship—an accord born of
 confidence on her part, and of several other things on the part of Lord
 Dankmere.</p>
 
-<p>It had been of slow growth at first&mdash;imperceptibly their relations had
+<p>It had been of slow growth at first—imperceptibly their relations had
 grown from a footing of distant civility to a companionship almost
-cordial&mdash;but not quite; for she was still shy with him at times, and he
+cordial—but not quite; for she was still shy with him at times, and he
 with her; and she had her moods of unresponsive reserve, and he was
 moody, too, at intervals.</p>
 
@@ -12106,26 +12106,26 @@ moody, too, at intervals.</p>
 <p>"Don't I laugh as though I like it?"</p>
 
 <p>She knitted her pretty brows: "I don't quite know. You see you're a
-British peer&mdash;which is really a very wonderful thing&mdash;&mdash;"</p>
+British peer—which is really a very wonderful thing——"</p>
 
 <p>"Oh, come," he said: "it really <i>is</i> rather a wonderful thing, but you
 don't believe it."</p>
 
 <p>"Yes, I do. I stand in awe of you. When you come into the room I seem to
-hear trumpets sounding in the far distance&mdash;&mdash;"</p>
+hear trumpets sounding in the far distance——"</p>
 
 <p><span class="pagenum" id="Page_493">[Pg 493]</span></p>
 
-<p>"My boots squeak&mdash;&mdash;"</p>
+<p>"My boots squeak——"</p>
 
 <p>"Nonsense! I <i>do</i> hear a sort of a fairy fanfare playing 'Hail to the
 Belted Earl!'"</p>
 
-<p>"I wear braces&mdash;&mdash;"</p>
+<p>"I wear braces——"</p>
 
 <p>"How common of you to distort my meaning! I don't care, you may do as
-you like&mdash;dance break-downs and hammer the piano, but to me you will
-ever remain a British peer&mdash;poor but noble&mdash;&mdash;"</p>
+you like—dance break-downs and hammer the piano, but to me you will
+ever remain a British peer—poor but noble——"</p>
 
 <p>"Wait until we hear from that Van Dyck! You can't call me poor then!"</p>
 
@@ -12139,17 +12139,17 @@ sigh.</p>
 
 <p>"I? Why shouldn't I be!" she said indignantly. "I'm so proud that our
 gallery has such a picture. I'm so proud of Mr. Quarren for discovering
-it&mdash;and&mdash;" she laughed&mdash;"I'm proud of you for possessing it. You see I
+it—and—" she laughed—"I'm proud of you for possessing it. You see I
 am very impartial; I'm proud of the gallery, of everybody connected with
 it including myself. Shouldn't I be?"</p>
 
 <p>"We are three very perfect people," he said gravely.</p>
 
 <p>"Do you know that we really are? Mr. Quarren is wonderful, and you
-are&mdash;agreeable, and as for me, why when I rise in the morning and look
+are—agreeable, and as for me, why when I rise in the morning and look
 into the glass I say to myself, 'Who is that rather clever-looking girl
 who smiles at me every morning in such friendly fashion?' And, would you
-believe it!&mdash;she turns out to be Jessie Vining every time!"</p>
+believe it!—she turns out to be Jessie Vining every time!"</p>
 
 <p>She was in a gay mood; she rattled away at her machine, glancing over it
 mischievously at him from time<span class="pagenum" id="Page_494">[Pg 494]</span> to time. He, having nothing to do except
@@ -12164,7 +12164,7 @@ is to British fiction. A microscopic examination of any novel made by a
 British subject will show traces of tea-leaves and curates although, as
 the text-books on chemistry have it, otherwise the substance of the work
 may be colourless, tasteless, odourless, and gaseous to the verge of the
-fourth dimension&mdash;&mdash;"</p>
+fourth dimension——"</p>
 
 <p>"If you don't cease making game of things British and sacred," he
 threatened, "I'll try to stop you in a way that will astonish you."</p>
@@ -12207,7 +12207,7 @@ with a friendly nod to him in silent adieu.</p>
 
 <p>"Will you let me walk home with you?" he said.</p>
 
-<p>"I&mdash;think&mdash;not, this evening."</p>
+<p>"I—think—not, this evening."</p>
 
 <p>"Were you going anywhere?"</p>
 
@@ -12217,11 +12217,11 @@ with a friendly nod to him in silent adieu.</p>
 
 <p>"No."</p>
 
-<p>"Then&mdash;don't you care to let me walk with you?"</p>
+<p>"Then—don't you care to let me walk with you?"</p>
 
 <p>She seemed to be thinking; her head was a trifle lowered.</p>
 
-<p>He said: "Before you go there is something I wanted to tell you"&mdash;she
+<p>He said: "Before you go there is something I wanted to tell you"—she
 made an involuntary movement and the door opened and hung ajar letting
 in the lively music of a street-organ. Then he leaned over and quietly
 closed the door.</p>
@@ -12263,20 +12263,20 @@ shall have to explain about Miss Vining to Mr. Sprowl.'"</p>
 
 <p>"That's where I interfered, Miss Vining. And the footman looked
 doubtful, too, but he signalled the chauffeur.... And so I went to the
-Café Cammargue&mdash;&mdash;"</p>
+Café Cammargue——"</p>
 
 <p>He hesitated, looking at her white and distressed face, then continued
 coolly:</p>
 
 <p>"Sprowl seemed surprised to see me. He was waiting in a private room....
-He's looking rather badly these days.... We talked a few minutes&mdash;&mdash;"</p>
+He's looking rather badly these days.... We talked a few minutes——"</p>
 
 <p>Pale, angry, every sense of modesty and reserve outraged, the girl faced
 him, small head erect:</p>
 
 <p><span class="pagenum" id="Page_497">[Pg 497]</span></p>
 
-<p>"You went there to&mdash;to discuss <i>me</i> with <i>that</i> man!"</p>
+<p>"You went there to—to discuss <i>me</i> with <i>that</i> man!"</p>
 
 <p>He was silent. She turned suddenly and tried to open the door, but he
 held it closed.</p>
@@ -12284,8 +12284,8 @@ held it closed.</p>
 <p>"I did it because I cared for you enough to do it," he said. "Don't you
 understand? Don't you suppose I know that kind of man?"</p>
 
-<p>"It&mdash;it was not your business&mdash;" she faltered, twisting blindly at the
-door-knob. "Let me go&mdash;please&mdash;&mdash;"</p>
+<p>"It—it was not your business—" she faltered, twisting blindly at the
+door-knob. "Let me go—please——"</p>
 
 <p>"I made it my business.... And that man understood that I was making it
 my business. And he won't attempt to annoy you again.... Can you forgive
@@ -12295,9 +12295,9 @@ me?"</p>
 impetuous words of protest died on her lips as her eyes encountered his.</p>
 
 <p>"It was because I love you," he said. And, as he spoke, there was about
-the man a quiet dignity and distinction that silenced her&mdash;something of
+the man a quiet dignity and distinction that silenced her—something of
 which she may have had vague glimpses at wide intervals in their
-acquaintances&mdash;something which at times she suspected might lie latent
+acquaintances—something which at times she suspected might lie latent
 in unknown corners of his character. Now it suddenly confronted her; and
 she recognised it and stood before him without a word to say.</p>
 
@@ -12308,20 +12308,20 @@ holding them, looking into her eyes.</p>
 
 <p>"You know what I am," he said. "I have nothing to say about myself. But
 I love you very dearly.... I loved before, once, and married. And she
-died.... After that I didn't behave very well&mdash;until I knew you.... It<span class="pagenum" id="Page_498">[Pg 498]</span>
-is really in me to be a decent husband&mdash;if you can care for me.... And I
-don't think we're likely to starve&mdash;&mdash;"</p>
+died.... After that I didn't behave very well—until I knew you.... It<span class="pagenum" id="Page_498">[Pg 498]</span>
+is really in me to be a decent husband—if you can care for me.... And I
+don't think we're likely to starve——"</p>
 
-<p>"I&mdash;it isn't that," she said, flushing scarlet.</p>
+<p>"I—it isn't that," she said, flushing scarlet.</p>
 
 <p>"What?"</p>
 
-<p>"What you <i>have</i> ... I could only care for&mdash;what you are."</p>
+<p>"What you <i>have</i> ... I could only care for—what you are."</p>
 
 <p>"Can you do that?"</p>
 
 <p>But her calm had vanished, and, head bent and averted, she was
-attempting to withdraw her hands&mdash;and might have freed herself entirely
+attempting to withdraw her hands—and might have freed herself entirely
 if it had not been for his arm around her.</p>
 
 <p>This new and disconcerting phase of the case brought her so suddenly
@@ -12356,7 +12356,7 @@ streets of Ascalon.</p>
 still-bait within reach is interesting. But the slightest movement in
 his vicinity of anything helpless instantly rivets his attention; any
 creature apparently in distress arouses him to direct and lightning
-action whether he be gorged or not&mdash;even, perhaps, while he is still
+action whether he be gorged or not—even, perhaps, while he is still
 gashed raw with the punishment for his last attempt.</p>
 
 <p>So it was with Langly Sprowl. He had come into town, sullen, restless,
@@ -12393,7 +12393,7 @@ presently woke up with a most amazing eye to find the terrified
 proprietor and staff playing Samaritan.</p>
 
 <p>In various papers annoying paragraphs concerning him had begun to
-appear&mdash;hints of how matters stood between him and Mary Ledwith, ugly
+appear—hints of how matters stood between him and Mary Ledwith, ugly
 innuendo, veiled rumours of the breach between him and his aunt
 consequent upon his untenable position <i>vis-à-vis</i> Mrs. Ledwith.</p>
 
@@ -12422,7 +12422,7 @@ that."</p>
 <p>Too surprised and annoyed to reply she merely gazed at him. And,
 because, for the first time in his life, perhaps, he really felt every
 word he uttered, he spoke now with a certain simplicity and self-control
-that sounded unusual to her ears&mdash;so noticeably unlike what she knew of
+that sounded unusual to her ears—so noticeably unlike what she knew of
 him that it commanded her unwilling attention.</p>
 
 <p>For his unpardonable brutality and violence he asked forgiveness,
@@ -12431,7 +12431,7 @@ attempting to win back her respect and regard. He asked only that.</p>
 
 <p>He said that he scarcely knew what to do with his life without the hope
 of recovering her respect and esteem; he asked for a beggar's chance,
-begged for it with a candour and naïveté almost boyish&mdash;so directly to
+begged for it with a candour and naïveté almost boyish—so directly to
 the point tended every instinct in him to recover through caution and
 patience what he had lost through carelessness and a violence which
 still astonished him.</p>
@@ -12439,26 +12439,26 @@ still astonished him.</p>
 <p>The Bermuda lilies were in bloom and Strelsa stood near them, listening
 to him, touching the tall stalks absently at intervals. And while she
 listened she became more conscious still of the great change in
-herself&mdash;of<span class="pagenum" id="Page_502">[Pg 502]</span> her altered attitude toward so much in life that once had
+herself—of<span class="pagenum" id="Page_502">[Pg 502]</span> her altered attitude toward so much in life that once had
 seemed to her important. After he had ceased she still stood pensively
 among the lilies, gray eyes brooding. At length, looking up, she said
 very quietly:</p>
 
 <p>"Why do you care for my friendship, Langly? I am not the kind of woman
-you think me&mdash;not even the kind I once thought myself. To me friendship
+you think me—not even the kind I once thought myself. To me friendship
 is no light thing either to ask for or to give. It means more to me than
 it once did; and I give it very seldom, and sparingly, and to very, very
-few. But toward everybody I am gently disposed&mdash;because, I am much
+few. But toward everybody I am gently disposed—because, I am much
 happier than I ever have been in all my life.... Is not my good will
 sufficient for any possible relation between you and me?"</p>
 
 <p>"Then you are no longer angry with me?"</p>
 
-<p>"No&mdash;no longer angry."</p>
+<p>"No—no longer angry."</p>
 
 <p>"Can we be friends again? Can you really forgive me, Strelsa?"</p>
 
-<p>"Why&mdash;yes, I could do that.... But, Langly, what have you and I in
+<p>"Why—yes, I could do that.... But, Langly, what have you and I in
 common as a basis for friendship? What have we ever had in common?
 Except when we encounter each other by hazard, why should we ever meet
 at all?"</p>
@@ -12477,7 +12477,7 @@ low voice.</p>
 
 <p><span class="pagenum" id="Page_503">[Pg 503]</span></p>
 
-<p>"Because I am wretchedly unhappy. And I care for you&mdash;more than you
+<p>"Because I am wretchedly unhappy. And I care for you—more than you
 realise."</p>
 
 <p>She said seriously: "You have no right to speak that way to me, Langly."</p>
@@ -12487,47 +12487,47 @@ realise."</p>
 <p>A quick flush of displeasure touched her cheeks; he saw it in the dusk
 of the garden, and mistook it utterly:</p>
 
-<p>"Strelsa&mdash;listen to me, dear! I have not slept since our quarrel. I must
+<p>"Strelsa—listen to me, dear! I have not slept since our quarrel. I must
 have been stark mad to say and do what I did.... Don't leave me! Don't
-go! I beg you to listen a moment&mdash;&mdash;"</p>
+go! I beg you to listen a moment——"</p>
 
 <p>She had started to move away from him and his first forward step broke a
 blossom from its stalk where it hung white in the dusk.</p>
 
-<p>"I ask you to go," she said under her breath. "There are people here&mdash;on
-the veranda&mdash;&mdash;"</p>
+<p>"I ask you to go," she said under her breath. "There are people here—on
+the veranda——"</p>
 
 <p>Every sense within him told him to go, pretending resignation. That was
 his policy. He had come here for martyrdom, cuirassed in patience. Every
 atom of common sense warned him to go.</p>
 
-<p>But also every physical sense in him was now fully aroused&mdash;the silvery
-star-dusk, the scent of lilies, a slender woman within arm's reach&mdash;this
-woman who had once been so nearly his&mdash;who was still rightfully
-his!&mdash;these circumstances were arousing him once more to a temerity
+<p>But also every physical sense in him was now fully aroused—the silvery
+star-dusk, the scent of lilies, a slender woman within arm's reach—this
+woman who had once been so nearly his—who was still rightfully
+his!—these circumstances were arousing him once more to a temerity
 which his better senses warned him to subdue. Yet if he could only get
-nearer to her&mdash;if he could once get her into his arms&mdash;overwhelm her
+nearer to her—if he could once get her into his arms—overwhelm her
 with the storm of passion rising so swiftly within him, almost choking
-him&mdash;so that his voice and limbs already trembled in its furious
-surge&mdash;&mdash;</p>
+him—so that his voice and limbs already trembled in its furious
+surge——</p>
 
-<p>"Strelsa&mdash;I love you! For God's sake show me some<span class="pagenum" id="Page_504">[Pg 504]</span> mercy!" he stammered.
+<p>"Strelsa—I love you! For God's sake show me some<span class="pagenum" id="Page_504">[Pg 504]</span> mercy!" he stammered.
 "I come to you half crazed by the solitude to which your anger has
-consigned me. I cannot endure it&mdash;I need you&mdash;I want you&mdash;I ask for your
-compassion&mdash;&mdash;"</p>
+consigned me. I cannot endure it—I need you—I want you—I ask for your
+compassion——"</p>
 
 <p>"Hush!" she pleaded, hastily retreating before him through the snowy
-banks of rockets&mdash;"I have asked you not to speak to me that way! I ask
-you to go&mdash;to go now!&mdash;because&mdash;&mdash;"</p>
+banks of rockets—"I have asked you not to speak to me that way! I ask
+you to go—to go now!—because——"</p>
 
 <p>"Will you listen to me! Will you wait a moment! I am only trying to tell
-you that I love you, dear&mdash;&mdash;"</p>
+you that I love you, dear——"</p>
 
 <p>He almost caught her, but she sprang aside, frightened, still retreating
 before him.</p>
 
-<p>"I cannot go until you listen to me!&mdash;" he said thickly, trampling
-through the flowers to intercept her. "You've got to listen!&mdash;do you
+<p>"I cannot go until you listen to me!—" he said thickly, trampling
+through the flowers to intercept her. "You've got to listen!—do you
 hear?"</p>
 
 <p>She had almost reached the terrace; the shadowy veranda opened widely
@@ -12538,7 +12538,7 @@ choking voice; but he only advanced, and she fell back before him to the
 very edge of the porch lattice.</p>
 
 <p>"Now listen to me!" he said between his teeth. "I love you and I'll
-never give you up&mdash;&mdash;"</p>
+never give you up——"</p>
 
 <p>Suddenly she turned on him, hands tightly clenched:</p>
 
@@ -12552,15 +12552,15 @@ forward.</p>
 
 <p>Ghostlike as it was he knew it instantly, stood rooted in his tracks
 while Strelsa stole away from him through the star-lit gloom, farther,
-farther, slipping forever<span class="pagenum" id="Page_505">[Pg 505]</span> from him now&mdash;he knew that as he stood there
+farther, slipping forever<span class="pagenum" id="Page_505">[Pg 505]</span> from him now—he knew that as he stood there
 staring like a damned man upon that other dim shape in the darkness
 beyond.</p>
 
 <p>It was his first glimpse of her since her return from Reno. And now,
 unbidden, memories half strangled were already in full resurrection,
-gasping in his ears of things that had been&mdash;of forgotten passion, of
+gasping in his ears of things that had been—of forgotten passion, of
 pleasure promised; and, because never tasted, it had been the true and
-only pleasure for such a man as he&mdash;the pleasure of anticipation. But
+only pleasure for such a man as he—the pleasure of anticipation. But
 the world had never, would never believe that. Only he, and the phantom
 there in the dusk before him, knew it to be true.</p>
 
@@ -12577,22 +12577,22 @@ courts decreed it legal.</p>
 
 <p>Now as he swung along under the high stars he was thinking of these
 things. And he felt that he had not tried her enough, had not really
-exerted himself&mdash;that women who are fools require closer watching than
+exerted himself—that women who are fools require closer watching than
 clever ones; that he could have overcome her scruples with any real
 effort and saved her from giving him the slip and sowing a wind in Reno
 which already had become enough of a breeze to bother him.</p>
 
 <p>With her, for a while, he might be able to distract his mind from this
 recent obsession tormenting him. To<span class="pagenum" id="Page_506">[Pg 506]</span> overcome her would interest him;
-and he had no doubt it could be done&mdash;for she was a little fool&mdash;silly
+and he had no doubt it could be done—for she was a little fool—silly
 enough to slap the world in the face and brave public opinion at Reno.
-No&mdash;it was not necessary to marry such a woman. She might think so, but
+No—it was not necessary to marry such a woman. She might think so, but
 it wasn't.</p>
 
 <p>He had behaved unwisely, too. Why should he not have gone to see her
 when she returned? By doing so, and acting cleverly, he could have
 avoided trouble with his aunt, and also these annoying newspaper
-paragraphs. Also he could have avoided the scene with Ledwith&mdash;and the
+paragraphs. Also he could have avoided the scene with Ledwith—and the
 aborted reconciliation just now with Strelsa, where he had stood staring
 at the apparition of Mary Ledwith as lost souls stand transfixed before
 the pallid shades of those whom they have destroyed.</p>
@@ -12608,14 +12608,14 @@ was distraction from the present torment. Mary Ledwith could give that
 to him. What a fool she had been ever to imagine that she could be
 anything more than his temporary mistress.</p>
 
-<p>"The damned little idiot," he mused&mdash;"cutting away to Reno before I knew
-what she was up to&mdash;and involving us both in all that talk! What did she
+<p>"The damned little idiot," he mused—"cutting away to Reno before I knew
+what she was up to—and involving us both in all that talk! What did she
 flatter herself I wanted, anyway.... But I ought to have called on her
 at once; now it's going to be difficult."</p>
 
-<p>Yet he sullenly welcomed the difficulty&mdash;hoped that she'd hold out. That
+<p>Yet he sullenly welcomed the difficulty—hoped that she'd hold out. That
 was what he wanted, the excitement of it to take his mind from
-Strelsa&mdash;keep him interested and employed until the moment arrived once<span class="pagenum" id="Page_507">[Pg 507]</span>
+Strelsa—keep him interested and employed until the moment arrived once<span class="pagenum" id="Page_507">[Pg 507]</span>
 more when he might venture to see her again. He was, by habit, a patient
 man. Only in the case of Strelsa Leeds had passion ever prematurely
 betrayed him; and, pacing his porch there in the darkness, he set his
@@ -12657,15 +12657,15 @@ yet turned, although, here and there on wooded hills, single discoloured
 branches broke the green monotony.</p>
 
 <p>No buckwheat had yet been cut, but above the ruddy fields of stalks the
-snow of the blossoms had become tarnished in promise of maturity&mdash;the
+snow of the blossoms had become tarnished in promise of maturity—the
 first premonition of autumn except for a few harvest apples yellow amid
 green leaves.</p>
 
 <p>He had started without any definite plan, a confident but patient
 opportunist; and as he approached the Ledwith property and finally
-sighted the chimneys of the house above the trees, something&mdash;some
+sighted the chimneys of the house above the trees, something—some
 errant thought seemed to amuse him, for he smiled slightly. His smile
-was as rare as his laughter&mdash;and as brief; and there remained no trace
+was as rare as his laughter—and as brief; and there remained no trace
 of it as he swung up the last hill and stood there gazing ahead.</p>
 
 <p>The sun had set. A delicate purple haze already dimmed distances; and
@@ -12711,7 +12711,7 @@ matter."</p>
 
 <p>"Where?"</p>
 
-<p>"I don't know, sir&mdash;&mdash;"</p>
+<p>"I don't know, sir——"</p>
 
 <p>"Yes, you do. Mrs. Ledwith is at home but has given you instructions
 concerning me. Isn't that so?"</p>
@@ -12721,10 +12721,10 @@ her into the drawing-room.</p>
 
 <p>"Light up here," he said.</p>
 
-<p>"Please, sir&mdash;&mdash;"</p>
+<p>"Please, sir——"</p>
 
-<p>"Do as I tell you, my good girl. Here&mdash;where's that button?&mdash;there!&mdash;"
-as the pretty room sprang<span class="pagenum" id="Page_510">[Pg 510]</span> into light&mdash;"Now never mind your instructions
+<p>"Do as I tell you, my good girl. Here—where's that button?—there!—"
+as the pretty room sprang<span class="pagenum" id="Page_510">[Pg 510]</span> into light—"Now never mind your instructions
 but go and say to Mrs. Ledwith that I <i>must</i> see her."</p>
 
 <p>He calmly unfolded a flat packet of fresh bank-notes, selected one,
@@ -12743,19 +12743,19 @@ the room he strolled into the farther room. It was unlighted and suited
 him to sit in; and he installed himself in a comfortable chair and,
 throwing his cigarette into the fire-place, lighted a cigar.</p>
 
-<p>This was a game he understood&mdash;a waiting game. The game was traditional
+<p>This was a game he understood—a waiting game. The game was traditional
 with his forefathers; every one of them had played it; their endless
 patience had made a fortune to which each in turn had added before he
-died. Patience and courage&mdash;courage of the sort known as personal
-bravery&mdash;had distinguished all his race. He himself had inherited
+died. Patience and courage—courage of the sort known as personal
+bravery—had distinguished all his race. He himself had inherited
 patience, and had used it wisely except in that one inexplicable
-case!&mdash;and personal courage in him had never been lacking, nor had what
+case!—and personal courage in him had never been lacking, nor had what
 often accompanies it, coolness, obstinacy, and effrontery.</p>
 
 <p>He had decided to wait until his cigar had been leisurely finished.
-Then, other measures&mdash;perhaps walking upstairs, unannounced, perhaps an
+Then, other measures—perhaps walking upstairs, unannounced, perhaps an
 unresentful withdrawal,<span class="pagenum" id="Page_511">[Pg 511]</span> a note by messenger, and another attempt to see
-her to-morrow&mdash;he did not yet know&mdash;had arrived at no conclusion&mdash;but
+her to-morrow—he did not yet know—had arrived at no conclusion—but
 would make up his mind when he finished his cigar and then do whatever
 caution dictated.</p>
 
@@ -12783,29 +12783,29 @@ hold of Ledwith's arm and tried to draw him out of the room. Then
 Ledwith caught sight of Sprowl and started toward him, but Quarren again
 seized his companion by the shoulder and dragged him back.</p>
 
-<p>"I tell you to keep quiet," he said in a low voice&mdash;"Keep out of
-this!&mdash;go out of the house!"</p>
+<p>"I tell you to keep quiet," he said in a low voice—"Keep out of
+this!—go out of the house!"</p>
 
-<p>"I can't, Quarren! I&mdash;&mdash;"</p>
+<p>"I can't, Quarren! I——"</p>
 
 <p><span class="pagenum" id="Page_512">[Pg 512]</span></p>
 
-<p>"You promised not to come in until that man had left&mdash;&mdash;"</p>
+<p>"You promised not to come in until that man had left——"</p>
 
-<p>"I know it. I meant to&mdash;but, good God! Quarren! I can't stand there&mdash;&mdash;"</p>
+<p>"I know it. I meant to—but, good God! Quarren! I can't stand there——"</p>
 
 <p>He was struggling toward Sprowl and Quarren was trying to push him back
 into the hall.</p>
 
 <p>"You said that you had given up any idea of personal vengeance!" he
-panted. "Let me deal with him quietly&mdash;&mdash;"</p>
+panted. "Let me deal with him quietly——"</p>
 
 <p>"I didn't know what I was saying," retorted Ledwith, straining away from
 the man who held him, his eyes fixed on Sprowl. "I tell you I can't
-remain quiet and see that blackguard in this house&mdash;&mdash;"</p>
+remain quiet and see that blackguard in this house——"</p>
 
-<p>"But he's going I tell you! He's going without a row&mdash;without any noise.
-Can't you let me manage it&mdash;&mdash;"</p>
+<p>"But he's going I tell you! He's going without a row—without any noise.
+Can't you let me manage it——"</p>
 
 <p>He could not drag Ledwith to the door, so he forced him into a chair and
 stood guard, glancing back across his shoulder at Sprowl.</p>
@@ -12816,7 +12816,7 @@ stood guard, glancing back across his shoulder at Sprowl.</p>
 drawing-room.</p>
 
 <p>"I suppose you are armed," he said contemptuously. "If you threaten me
-I'll take away your guns and slap both your faces&mdash;ask the other pup how
+I'll take away your guns and slap both your faces—ask the other pup how
 it feels, Quarren."</p>
 
 <p>Ledwith struggled to rise but Quarren had him fast.</p>
@@ -12833,8 +12833,8 @@ gets away from me."</p>
 <p>"It would be a mistake," panted Quarren. "Can't you go while there's
 time, Sprowl! I tell you he'll kill you in this room if you don't."</p>
 
-<p>"I won't&mdash;<i>kill</i> him!&mdash;Let go of me, Quarren," gasped Ledwith. "I&mdash;I
-won't do murder; I've promised you that&mdash;for <i>her</i> sake&mdash;&mdash;"</p>
+<p>"I won't—<i>kill</i> him!—Let go of me, Quarren," gasped Ledwith. "I—I
+won't do murder; I've promised you that—for <i>her</i> sake——"</p>
 
 <p>"Let him loose, Quarren," said Sprowl.</p>
 
@@ -12844,7 +12844,7 @@ his hat, picked up his stick, opened the door, and sauntered out into
 the darkness.</p>
 
 <p>"Now," breathed Quarren fiercely, "you play the man or I'm through with
-you! He's gone and he won't come back&mdash;I'll see to that! And it's up to
+you! He's gone and he won't come back—I'll see to that! And it's up to
 you to show what you're made of!"</p>
 
 <p>Ledwith, freed, stood white and breathing hard for a few moments. Then a
@@ -12881,7 +12881,7 @@ him, halted.</p>
 
 <p>Sprowl shrugged:</p>
 
-<p>"That's what that kind of a man is made for&mdash;to marry what others don't
+<p>"That's what that kind of a man is made for—to marry what others don't
 have to marry."</p>
 
 <p>"You lie," said Quarren quietly.</p>
@@ -12892,7 +12892,7 @@ violence.</p>
 
 <p>"You know," he said, measuring his words, "that you're the same kind of
 a man, too. And some day, if you're good, you can marry what I don't
-have to marry&mdash;&mdash;"</p>
+have to marry——"</p>
 
 <p>He reeled under Quarren's blow, then struck at him blindly with his
 walking-stick, leaping at him savagely but recoiling, dizzy, half
@@ -12900,7 +12900,7 @@ senseless under another blow so terrific that it almost nauseated him.</p>
 
 <p>He stood for a time, supporting himself against a tree; then as his wits
 returned he lifted his bruised face and stared murderously about him.
-Quarren was walking toward Witch-Hollow&mdash;half way there already and out
+Quarren was walking toward Witch-Hollow—half way there already and out
 of earshot as well as sight.</p>
 
 <p><span class="pagenum" id="Page_517">[Pg 517]</span></p>
@@ -12979,10 +12979,10 @@ he?"</p>
 
 <p>"Yes, he did."</p>
 
-<p>"But where is he? You&mdash;you don't mean to say&mdash;&mdash;"</p>
+<p>"But where is he? You—you don't mean to say——"</p>
 
 <p>"Yes, I do. He went upstairs and didn't return....<span class="pagenum" id="Page_519">[Pg 519]</span> So I waited for a
-while and then&mdash;came back."</p>
+while and then—came back."</p>
 
 <p>They sat silent for a while, then Molly lifted her eyes to his and they
 were brimming with curiosity.</p>
@@ -12996,7 +12996,7 @@ Rix?"</p>
 
 <p>"Some."</p>
 
-<p>"But then&mdash;&mdash;"</p>
+<p>"But then——"</p>
 
 <p>"Oh, Molly, Molly," he said, smiling, "there are more important things
 than what a few people are likely to think or say. The girl made a fool
@@ -13004,18 +13004,18 @@ of herself, and the man weakened and nearly went to pieces. He's found
 himself again; he's disposed to help her find herself. It was only one
 of those messes that the papers report every day. Few get out of such
 pickles, but I believe these two are going to.... And somehow, do you
-know&mdash;from something Sprowl said to-night, I don't believe that she went
-the entire limit&mdash;took the last ditch."</p>
+know—from something Sprowl said to-night, I don't believe that she went
+the entire limit—took the last ditch."</p>
 
 <p>Molly reddened: "Why?"</p>
 
 <p>"Because, although they do it in popular fiction, men like Sprowl never
-really boast of their successes. His sort keep silent&mdash;when there's
+really boast of their successes. His sort keep silent—when there's
 anything to conceal."</p>
 
 <p>"Did he boast?"</p>
 
-<p>"He did. I was sure he was lying, and I&mdash;" he shrugged.</p>
+<p>"He did. I was sure he was lying, and I—" he shrugged.</p>
 
 <p>"Told him so?"</p>
 
@@ -13025,7 +13025,7 @@ anything to conceal."</p>
 fool to run off to Reno after nothing worse than the imprudence of
 infatuation. I've<span class="pagenum" id="Page_520">[Pg 520]</span> known her a long while, Rix. She's too shallow for
 real passion, too selfish to indulge it anyway. His name and fortune did
-the business for her&mdash;little idiot. Really she annoys me."</p>
+the business for her—little idiot. Really she annoys me."</p>
 
 <p>Quarren smiled: "Her late husband seems to like her. Fools feminine have
 made many a man happy. You'll be nice to her I'm sure."</p>
@@ -13039,13 +13039,13 @@ over the telephone," he said.</p>
 
 <p>"Oh, Rix! You <i>said</i> you were going to surprise her in the morning!"</p>
 
-<p>"But I want to see her, Molly. I don't want to wait&mdash;&mdash;"</p>
+<p>"But I want to see her, Molly. I don't want to wait——"</p>
 
 <p>"It's after ten and Strelsa has probably retired. She's a perfect
-farmer, I tell you&mdash;yawns horribly every evening at nine. Why, I can't
+farmer, I tell you—yawns horribly every evening at nine. Why, I can't
 keep her awake long enough to play a hand at Chinese Khan! Be
 reasonable, Rix. You had planned to surprise her in the morning....
-And&mdash;I'm lonely without Jim.... Besides, if you are clever enough to
+And—I'm lonely without Jim.... Besides, if you are clever enough to
 burst upon Strelsa's view in the morning when the day is young and all
 before her, and when she's looking her very best, nobody can tell what
 might happen.... And I'll whisper in your ear that the child has really
@@ -13097,13 +13097,13 @@ laughing in her excitement and surprise. They met midway, and she
 whipped off her glove and gave him her hand in a firm, cool clasp.</p>
 
 <p>"Why the dickens didn't you wire!" she said. "You're a fraud, Rix! I
-might easily have been away!&mdash;You might have missed me&mdash;we might have<span class="pagenum" id="Page_523">[Pg 523]</span>
-missed each other.... Is <i>that</i> all you care about seeing me?&mdash;after all
+might easily have been away!—You might have missed me—we might have<span class="pagenum" id="Page_523">[Pg 523]</span>
+missed each other.... Is <i>that</i> all you care about seeing me?—after all
 these weeks!"</p>
 
 <p>"I wanted to surprise you," he explained feebly.</p>
 
-<p>"Well, you didn't! That is&mdash;not much. I'd been thinking of you&mdash;and I
+<p>"Well, you didn't! That is—not much. I'd been thinking of you—and I
 glanced up and saw you. You're stopping at Molly's I suppose."</p>
 
 <p>"Yes."</p>
@@ -13144,7 +13144,7 @@ well," she added earnestly. "Why are you so white?"</p>
 
 <p>"I'm in fine shape, thank you."</p>
 
-<p>"I didn't mean your figure," she laughed&mdash;"Oh, that <i>was</i> a common kind
+<p>"I didn't mean your figure," she laughed—"Oh, that <i>was</i> a common kind
 of a joke, wasn't it? But I'm only a farmer, Rix. You must expect the
 ruder and simpler forms of speech from a lady of the woodshed!... Why
 are you so pale?"</p>
@@ -13166,12 +13166,12 @@ as she answered:</p>
 
 <p>"I want you to stay always, of course. Don't pretend that you don't know
 it, because you are perfectly aware that I never tire of you. But if you
-can stay only two days don't let us waste any time&mdash;&mdash;"</p>
+can stay only two days don't let us waste any time——"</p>
 
 <p>"We're not wasting it here together, are we?"</p>
 
 <p>"Don't you want to walk? I haven't a horse yet, except for agricultural
-purposes. I'll rinse my hands and take off this apron&mdash;" She stood
+purposes. I'll rinse my hands and take off this apron—" She stood
 unpinning and untying it, her gray eyes never leaving him in their
 unabashed delight in him.</p>
 
@@ -13180,7 +13180,7 @@ of stout little shoes and carrying<span class="pagenum" id="Page_529">[Pg 529]</
 used in rough country.</p>
 
 <p>And first they visited her garden where all the old-fashioned autumn
-flowers were in riotous bloom&mdash;scarlet sage, rockets, thickets of
+flowers were in riotous bloom—scarlet sage, rockets, thickets of
 gladiolus, heavy borders of asters, marigolds, and coreopsis; and here
 she gave a few verbal directions to the yokel who gaped toothlessly in
 reply.</p>
@@ -13195,7 +13195,7 @@ sweet concern halted, reproaching herself for setting too hot a pace for
 a city-worn and work-worn man.</p>
 
 <p>But the cool shadows of the woods were near, and she made him rest on
-the little footbridge&mdash;the same bridge where he had encountered Ledwith
+the little footbridge—the same bridge where he had encountered Ledwith
 for the first time in years. He recognised the spot.</p>
 
 <p>After they had seated themselves and Strelsa, resting on the back of the
@@ -13204,40 +13204,40 @@ Quarren said, slowly:</p>
 
 <p>"Shall I tell you why I did not disturb you last night, Strelsa?"</p>
 
-<p>"You can't excuse it&mdash;&mdash;"</p>
+<p>"You can't excuse it——"</p>
 
-<p>"You shall be judge and jury. It's rather a long story, though&mdash;&mdash;"</p>
+<p>"You shall be judge and jury. It's rather a long story, though——"</p>
 
 <p>"I am listening."</p>
 
 <p>"Then, it has to do with Ledwith. He's not very well but he's better
 than he was. You see he wanted to take a course of treatment to regain
-his health, and<span class="pagenum" id="Page_530">[Pg 530]</span> there seemed to be nobody else, so&mdash;I offered to see
+his health, and<span class="pagenum" id="Page_530">[Pg 530]</span> there seemed to be nobody else, so—I offered to see
 him through."</p>
 
 <p>"That's like you, Rix," she said, looking at him.</p>
 
-<p>"Oh, it wasn't anything&mdash;I had nothing to do&mdash;&mdash;"</p>
+<p>"Oh, it wasn't anything—I had nothing to do——"</p>
 
 <p>"That's like you, too. Did you pull him through?"</p>
 
 <p>"He pulled himself through.... It was strenuous for two or three
-days&mdash;and hot as the devil in that sanitarium." ... He laughed. "We both
-were wrecks when we came out two weeks later&mdash;oh, a bit groggy, that's
-really all.... And he had no place to go&mdash;and seemed to be inclined to
-keep hold of my sleeve&mdash;so I telephoned Molly. And she said to bring him
+days—and hot as the devil in that sanitarium." ... He laughed. "We both
+were wrecks when we came out two weeks later—oh, a bit groggy, that's
+really all.... And he had no place to go—and seemed to be inclined to
+keep hold of my sleeve—so I telephoned Molly. And she said to bring him
 up. That was nice of her, wasn't it?"</p>
 
 <p>"Everybody is wonderful except you," she said.</p>
 
 <p>"Nonsense," he said, "it wasn't I who went through a modified hell. He's
 got a lot of backbone, Ledwith.... And so we came up last night....
-And&mdash;now here's the interesting part, Strelsa! We strolled over to call
-on Mrs. Ledwith&mdash;&mdash;"</p>
+And—now here's the interesting part, Strelsa! We strolled over to call
+on Mrs. Ledwith——"</p>
 
 <p>"What!"</p>
 
-<p>"Certainly. I myself didn't see her but&mdash;" he laughed&mdash;"she seemed to be
+<p>"Certainly. I myself didn't see her but—" he laughed—"she seemed to be
 at home to her ex-husband."</p>
 
 <p>"Rix!"</p>
@@ -13245,10 +13245,10 @@ at home to her ex-husband."</p>
 <p>"It's a fact. He went back there for breakfast this morning after he'd
 changed his clothes."</p>
 
-<p>"After&mdash;<i>what</i>?"</p>
+<p>"After—<i>what</i>?"</p>
 
 <p>"Yes. It seems that they started out in a canoe about midnight and he
-didn't turn up at Witch-Hollow until just before breakfast&mdash;and then he
+didn't turn up at Witch-Hollow until just before breakfast—and then he
 only stayed long enough to change to boating flannels.... You should see
 him; he's twenty years younger.... I fancy they'll get along together in
 future."</p>
@@ -13256,30 +13256,30 @@ future."</p>
 <p><span class="pagenum" id="Page_531">[Pg 531]</span></p>
 
 <p>"Oh, Rix!" she said, "that was darling of you! You <i>are</i> wonderful even
-if you don't seem to know it!... And to think&mdash;to <i>think</i> that Mary
+if you don't seem to know it!... And to think—to <i>think</i> that Mary
 Ledwith is going to be happy again!... Oh, you don't know how it has
-been with her&mdash;the silly, unhappy little thing!</p>
+been with her—the silly, unhappy little thing!</p>
 
 <p>"Why, after Mrs. Sprowl left, the girl went all to pieces. Molly and I
-did what we could&mdash;but Molly isn't strong and Mrs. Ledwith was at my
-house almost all the time&mdash;Oh, it was quite dreadful, and I'm sure she
-was really losing her senses&mdash;because&mdash;I think I'll tell you&mdash;I tell you
-everything&mdash;" She hesitated, and then, lowering her voice:</p>
+did what we could—but Molly isn't strong and Mrs. Ledwith was at my
+house almost all the time—Oh, it was quite dreadful, and I'm sure she
+was really losing her senses—because—I think I'll tell you—I tell you
+everything—" She hesitated, and then, lowering her voice:</p>
 
 <p>"She had come to see me, and she was lying on the lounge in my
 dressing-room, crying; and I was doing my hair. And first I knew she
 sobbed out that she had killed her husband and wanted to die, and she
 caught up that pistol that Sir Charles gave me at the Bazaar last
-winter&mdash;it looked like a real one&mdash;and the next thing I knew she had
+winter—it looked like a real one—and the next thing I knew she had
 fired a charge of Japanese perfume at her temple, and it was all over
 her face and hair!... Don't laugh, Rix; she thought she had killed
 herself, and I had a horrid, messy time of it reviving her."</p>
 
-<p>"You poor child," he exclaimed trying not to laugh&mdash;"she had no brains
+<p>"You poor child," he exclaimed trying not to laugh—"she had no brains
 to blow out anyway.... That's a low thing to say. Ledwith likes her....
 I really believe she's been scared into life-long good behaviour."</p>
 
-<p>"She wasn't&mdash;really&mdash;horrid," said Strelsa in a low voice. "She told me
+<p>"She wasn't—really—horrid," said Strelsa in a low voice. "She told me
 so."</p>
 
 <p>"I don't doubt it," he said. "But one way or the other you might as well
@@ -13315,7 +13315,7 @@ me."</p>
 
 <p>"Never," she repeated.</p>
 
-<p>"Why&mdash;why, I got in wrong the very first time!" he said.</p>
+<p>"Why—why, I got in wrong the very first time!" he said.</p>
 
 <p>"You mean that wager we made?"</p>
 
@@ -13349,23 +13349,23 @@ said:</p>
 <p>"The honour of offering you such a man as I was," he said with smiling
 bitterness.</p>
 
-<p>"Rix! <i>I</i> was the fool&mdash;the silly little prig! I have blushed and
-blushed to remember how I behaved; how I snubbed you and&mdash;good
-heavens!&mdash;even lectured and admonished you!&mdash;How I ran away from you
+<p>"Rix! <i>I</i> was the fool—the silly little prig! I have blushed and
+blushed to remember how I behaved; how I snubbed you and—good
+heavens!—even lectured and admonished you!—How I ran away from you
 with all the self-possession and <i>savoir-faire</i> of a country schoolgirl!
-What on earth you thought of me in those days I dread to surmise&mdash;&mdash;"</p>
+What on earth you thought of me in those days I dread to surmise——"</p>
 
 <p>"But Strelsa, what was there to do except what you did?"</p>
 
 <p>"If I'd known anything I could have thanked you for caring that way for
 me and dismissed you as a friend instead of fleeing as though you had
-affronted me&mdash;&mdash;"</p>
+affronted me——"</p>
 
 <p>"I <i>did</i> affront you."</p>
 
 <p>"You didn't intend to.... It would have been easy enough to tell you
-that I liked you&mdash;but not that way.... And all those miserable, lonely,
-unhappy months could have been spared me&mdash;&mdash;"</p>
+that I liked you—but not that way.... And all those miserable, lonely,
+unhappy months could have been spared me——"</p>
 
 <p>"Were <i>you</i> unhappy?"</p>
 
@@ -13373,33 +13373,33 @@ unhappy months could have been spared me&mdash;&mdash;"</p>
 
 <p>"I never dreamed you were."</p>
 
-<p>"Well, I was&mdash;thinking of what I had done to you.... And all those men
+<p>"Well, I was—thinking of what I had done to you.... And all those men
 bothering me, every moment, and everybody at me to marry everybody
-else&mdash;and all I<span class="pagenum" id="Page_534">[Pg 534]</span> wanted was to be friends with <i>you</i>!... I wasn't sure
+else—and all I<span class="pagenum" id="Page_534">[Pg 534]</span> wanted was to be friends with <i>you</i>!... I wasn't sure
 of what I wanted from the very beginning, of course, but I knew it as
-soon as I saw you at the Bazaar again.... I was <i>so</i> lonely, Rix&mdash;&mdash;"</p>
+soon as I saw you at the Bazaar again.... I was <i>so</i> lonely, Rix——"</p>
 
 <p>She looked up out of clear, fearless eyes; he leaned forward and took
 her hands in his.</p>
 
 <p>"I know what you want," he said quietly. "You want my friendship and you
-have it&mdash;every atom of it, Strelsa. I will never overstep the borders
+have it—every atom of it, Strelsa. I will never overstep the borders
 again; I understand you thoroughly.... You know what you have done for
-me&mdash;what I was when you came into my life. My gratitude is a living
-thing. Through you, because of you, the whole unknown world&mdash;all of real
-life&mdash;has opened before me. You did it for me, Strelsa."</p>
+me—what I was when you came into my life. My gratitude is a living
+thing. Through you, because of you, the whole unknown world—all of real
+life—has opened before me. You did it for me, Strelsa."</p>
 
 <p>"You did it for yourself and for me," she said in a low voice. "What are
 you trying to tell me, Rix? That <i>I</i> did this for <i>you</i>? When it is
-you&mdash;it was you from the first&mdash;it has always been you who led, who
+you—it was you from the first—it has always been you who led, who
 awakened first, who showed courage and common sense and patience and the
-cheerful wisdom which&mdash;which saved me&mdash;&mdash;"</p>
+cheerful wisdom which—which saved me——"</p>
 
 <p>The emotion in her voice stirred him thrillingly; her hands lay
 confidently in his; her gray eyes met his so sweetly, so honestly, that
 hope awoke for a moment.</p>
 
-<p>"Strelsa," he said, "however it was with us&mdash;however it is now, I think
+<p>"Strelsa," he said, "however it was with us—however it is now, I think
 that together we amount to more than we ever could have amounted to
 apart."</p>
 
@@ -13410,8 +13410,8 @@ comprehend you."</p>
 
 <p>"A man neglecting his nobler self.... But it could not have lasted; your
 real self could not have long<span class="pagenum" id="Page_535">[Pg 535]</span> endured that harlequinade we once thought
-was real life.... I'm glad if you think that I&mdash;something about
-me&mdash;aroused you.... But if I had not, somebody or some circumstance
+was real life.... I'm glad if you think that I—something about
+me—aroused you.... But if I had not, somebody or some circumstance
 would have very soon served the same purpose."</p>
 
 <p>"Do you think so?" he said, stooping to kiss her hands. She looked at
@@ -13450,7 +13450,7 @@ of the Dankmeres have married in many a generation."</p>
 <p>Strelsa's lip curled: "I don't doubt that. They<span class="pagenum" id="Page_536">[Pg 536]</span> were always a horrid
 cock-fighting, prize-fighting, dissolute lot, weren't they?"</p>
 
-<p>"Something like that. But the present Dankmere is a good sort&mdash;really he
+<p>"Something like that. But the present Dankmere is a good sort—really he
 is, Strelsa. And as for Jessie Vining, she's sweet. You'll be nice to
 them, won't you?"</p>
 
@@ -13467,7 +13467,7 @@ her voice. "And by the way, how is Mr. Westguard?"</p>
 <p>They both laughed.</p>
 
 <p>"Speaking of sentiment," said Quarren, "Karl now exudes it daily. He and
-Bleecker De Groot and Mrs. Caldera&mdash;to Lester's rage&mdash;have started a
+Bleecker De Groot and Mrs. Caldera—to Lester's rage—have started a
 weekly paper called <i>Brotherhood</i>, consisting of pabulum for the
 horny-handed.</p>
 
@@ -13495,13 +13495,13 @@ stop the hemorrhage."</p>
 <p>"Rich men do good, Rix," she said thoughtfully.</p>
 
 <p>"But not by teaching or practising the thrift of celestial
-insurance&mdash;not by admonition to orthodoxy and exhortation to worship a
+insurance—not by admonition to orthodoxy and exhortation to worship a
 Creator who sees to it that no two people are created equal. There is
 only one thing the rich can give to the poor for Christ's sake; and even
 that will always be taken with suspicion and distrust. No; there are
 only two ways to live: one is the life of self-discipline; the other is
 to actually imitate the militant Son of Man whose faith we pretend to
-profess&mdash;but whose life-history we merely parody, turning His crusade
+profess—but whose life-history we merely parody, turning His crusade
 into a grotesque carnival. I know of no third course consistent."</p>
 
 <p>"To lead an upright life within bounds where your lines have fallen, or
@@ -13513,8 +13513,8 @@ sort of person?"</p>
 
 <p>"It's just because we have something to do, isn't it?"</p>
 
-<p>"That&mdash;and the leisure which the idle never have. It seems like a
-paradox, doesn't it?&mdash;to say that the idle never have any time to
+<p>"That—and the leisure which the idle never have. It seems like a
+paradox, doesn't it?—to say that the idle never have any time to
 themselves."</p>
 
 <p>"I know what you mean. I expect to work rather hard the rest of my
@@ -13530,8 +13530,8 @@ delicious leisure awaiting me."</p>
 <p>"Well, for example, you will be alone here all winter."</p>
 
 <p>"Do you mean loneliness?" she asked, smiling. "I don't expect to suffer
-from that. Molly will be here all winter and&mdash;you will write to me&mdash;"
-she turned to him&mdash;"won't you, Rix?"</p>
+from that. Molly will be here all winter and—you will write to me—"
+she turned to him—"won't you, Rix?"</p>
 
 <p>"Certainly. Besides I'm coming up to see you every week."</p>
 
@@ -13544,15 +13544,15 @@ confused smile. "Do you realise what you are so gaily engaging to do?"</p>
 
 <p>"Of course."</p>
 
-<p>"A&mdash;a house?"</p>
+<p>"A—a house?"</p>
 
 <p>He looked at her, hesitated, then looking away:</p>
 
-<p>"Either a house or&mdash;an addition."</p>
+<p>"Either a house or—an addition."</p>
 
 <p>"An <i>addition</i>?"</p>
 
-<p>"If you'll let me, Strelsa&mdash;some day."</p>
+<p>"If you'll let me, Strelsa—some day."</p>
 
 <p>She understood him then. The painful colour stole into her cheeks,
 faintly burning, and she closed her eyes for a moment to endure it,
@@ -13566,7 +13566,7 @@ steadily.</p>
 
 <p>"Our relations are to remain what you desire them to be, dear."</p>
 
-<p>"I desire them to be what they are&mdash;<i>always</i>."</p>
+<p>"I desire them to be what they are—<i>always</i>."</p>
 
 <p><span class="pagenum" id="Page_539">[Pg 539]</span></p>
 
@@ -13575,7 +13575,7 @@ that, a little confused by his acquiescence, her own response was slow.
 But presently her smile dawned, a little tremulous and uncertain, and
 her gray eyes remained wistful though the lips curled deliciously.</p>
 
-<p>"I would do anything in the world for you, Rix, except&mdash;that," she said
+<p>"I would do anything in the world for you, Rix, except—that," she said
 in a low voice.</p>
 
 <p>"I know you would, you dear girl."</p>
@@ -13584,11 +13584,11 @@ in a low voice.</p>
 
 <p>"Of course I do!"</p>
 
-<p>"But&mdash;I <i>can't</i> do that&mdash;<i>ever</i>. It would&mdash;would spoil you for me....
+<p>"But—I <i>can't</i> do that—<i>ever</i>. It would—would spoil you for me....
 What in the world would I do if you were spoiled for me, Rix? I haven't
-anybody else.... What would I do here&mdash;all alone? I couldn't stay&mdash;I
-wouldn't know what to do&mdash;where to go in the world.... It would be
-lonely&mdash;lonely&mdash;&mdash;"</p>
+anybody else.... What would I do here—all alone? I couldn't stay—I
+wouldn't know what to do—where to go in the world.... It would be
+lonely—lonely——"</p>
 
 <p>She bent her head, and remained so, gray eyes fixed on her clasped
 fingers. For a long while she sat bowed over, thinking; once or twice
@@ -13615,11 +13615,11 @@ range of hills beyond.</p>
 <p>"Isn't it wonderful about Chrysos," she said.</p>
 
 <p>"The quaint little thing," he said almost tenderly. "She told Molly what
-happened&mdash;how she sat down under a fence to tie wild strawberries for
+happened—how she sat down under a fence to tie wild strawberries for
 Sir Charles, and how, all at once, she realised what his going out of
-her life meant to her&mdash;and how the tears choked her to silence until she
+her life meant to her—and how the tears choked her to silence until she
 suddenly found herself in his arms.... Can you see it as it happened,
-Strelsa?&mdash;as pretty a pastoral as ever the older poets&mdash;" He broke off
+Strelsa?—as pretty a pastoral as ever the older poets—" He broke off
 abruptly, and she looked up, but he was still smiling as though the
 scene of another man's happiness, so lightly evoked, were a
 visualisation of his own. And again her gray eyes grew wistful as though
@@ -13644,23 +13644,23 @@ in the smoking-room.</p>
 <p>"If you don't marry that delectable young man," she said, "I'll take a
 stick and beat you, Strelsa."</p>
 
-<p>"I don't want to&mdash;I don't <i>want</i> to!" protested the girl, getting
+<p>"I don't want to—I don't <i>want</i> to!" protested the girl, getting
 possession of Molly's hands and covering them with caresses. And,
 resting her soft lips on Molly's fingers, she looked at her; and the
 young matron saw tears glimmering under the soft, dark lashes.</p>
 
-<p>"I <i>can't</i> love him&mdash;that way," whispered the girl. "I would if I
-could.... I couldn't care for him more than I do.... And&mdash;and it
+<p>"I <i>can't</i> love him—that way," whispered the girl. "I would if I
+could.... I couldn't care for him more than I do.... And—and it
 terrifies me to think of losing him."</p>
 
 <p>"Losing him?"</p>
 
-<p>"Yes&mdash;by doing what you&mdash;what he&mdash;wishes."</p>
+<p>"Yes—by doing what you—what he—wishes."</p>
 
 <p>"You think you'll lose him if you marry him?"</p>
 
-<p>"I&mdash;yes. It would spoil him for me&mdash;spoil everything for me in the
-world&mdash;&mdash;"</p>
+<p>"I—yes. It would spoil him for me—spoil everything for me in the
+world——"</p>
 
 <p>"Well, you listen to me," said Molly, exasperated. "When he has stood a
 certain amount of this silliness from you he'll really and actually turn
@@ -13669,11 +13669,11 @@ a mate. There are plenty suitable in the world. If you'd never been born
 there would have been another for him. If you passed out of his life
 there would some day be another.</p>
 
-<p>"Will we women never learn the truth?&mdash;that at best we are incidental to
+<p>"Will we women never learn the truth?—that at best we are incidental to
 man, but that, when we love, man is the whole bally thing to us?</p>
 
 <p>"Let him escape and you'll see, Strelsa. You'll get, perhaps, what
-you're asking for now, but he'll get what he is asking for, too&mdash;if not
+you're asking for now, but he'll get what he is asking for, too—if not
 from you, from some girl of whom you and I and he perhaps have never
 heard.</p>
 
@@ -13687,15 +13687,15 @@ unshed tears had dried. The pretty matron slowly shook her head:</p>
 
 <p>"Because you once bit into tainted fruit you laid the axe to the entire
 orchard. What nonsense! Rottenness is the exception; soundness the rule.
-But you concluded that the hazard of bad fortune&mdash;that the unhappy
-chance of your first and only experience&mdash;was not an exception but the
+But you concluded that the hazard of bad fortune—that the unhappy
+chance of your first and only experience—was not an exception but the
 universal rule.... Very well; think it! He'll get over it some time, but
 you never will, Strelsa. You'll remember it all your life.</p>
 
 <p>"For I tell you that we women who go to our graves without having missed
-a single pang&mdash;we who die having known happiness and its shadow which is
-sorrow&mdash;the happiness and sorrow which come through love of man
-alone&mdash;die as we should die, in deep content of destiny fulfilled&mdash;which
+a single pang—we who die having known happiness and its shadow which is
+sorrow—the happiness and sorrow which come through love of man
+alone—die as we should die, in deep content of destiny fulfilled—which
 is the only peace beyond all understanding."</p>
 
 <p>The girl lowered her head and, resting her cheek on Molly's shoulder,
@@ -13704,7 +13704,7 @@ looked down at the baby garment on her knees.</p>
 <p>"That also?" she whispered.</p>
 
 <p>"Yes.... Unless we pass that way, also, we can never die content.... But
-until a month ago I did not know it.... Strelsa&mdash;Strelsa! Are you never
+until a month ago I did not know it.... Strelsa—Strelsa! Are you never
 going to know what love can be?"</p>
 
 <p>The girl rose slowly, flushing and whitening by turns, and stood a
@@ -13712,11 +13712,11 @@ moment, her hands covering her eyes.</p>
 
 <p>And standing so:</p>
 
-<p>"Do you think he will go away&mdash;from me&mdash;some day?"</p>
+<p>"Do you think he will go away—from me—some day?"</p>
 
-<p>"Yes; he will go&mdash;unless&mdash;&mdash;"</p>
+<p>"Yes; he will go—unless——"</p>
 
-<p>"Must it be&mdash;that way?"</p>
+<p>"Must it be—that way?"</p>
 
 <p><span class="pagenum" id="Page_543">[Pg 543]</span></p>
 
@@ -13725,11 +13725,11 @@ moment, her hands covering her eyes.</p>
 <p>"I had never thought of that."</p>
 
 <p>"Think of it as the truth. It will be so unless you love him in his own
-fashion&mdash;and for his own sake. Try&mdash;if you care for him enough to
+fashion—and for his own sake. Try—if you care for him enough to
 try.... And if you do, you will love him for your own sake, too."</p>
 
-<p>"I&mdash;I had thought of&mdash;of giving myself&mdash;for his sake&mdash;because he wishes
-it.... I don't believe I'll be&mdash;much afraid&mdash;of him. Do you?"</p>
+<p>"I—I had thought of—of giving myself—for his sake—because he wishes
+it.... I don't believe I'll be—much afraid—of him. Do you?"</p>
 
 <p>Molly's wise sweet eyes sparkled with silent laughter. Then without
 another glance at the tall, young girl before her she picked up her
@@ -13753,29 +13753,29 @@ know, Strelsa?"</p>
 
 <p>"You poor boy!" she exclaimed laughingly, "have you been searching all
 this time? The wonder is that you haven't perished. Why didn't you ask
-me for one when we were at&mdash;our house?"</p>
+me for one when we were at—our house?"</p>
 
 <p>"<i>Your</i> house?" he corrected, smiling.</p>
 
 <p>Her gray eyes met his with a frightened sort of courage.</p>
 
-<p>"<i>Our house</i>&mdash;if you wish&mdash;" But her lips had begun<span class="pagenum" id="Page_544">[Pg 544]</span> to tremble and she
+<p>"<i>Our house</i>—if you wish—" But her lips had begun<span class="pagenum" id="Page_544">[Pg 544]</span> to tremble and she
 could not control them or force from them another word for all her
 courage.</p>
 
 <p>He came over to where she stood, one slim hand resting against the wall;
-and she looked back bravely into his keen eyes&mdash;the clear, direct,
+and she looked back bravely into his keen eyes—the clear, direct,
 questioning eyes of a boy.</p>
 
-<p>"I&mdash;I will&mdash;marry you," she said.</p>
+<p>"I—I will—marry you," she said.</p>
 
 <p>A swift flush touched his face to the temples.</p>
 
-<p>"Don't you&mdash;want me?" she said, tremulously.</p>
+<p>"Don't you—want me?" she said, tremulously.</p>
 
 <p>"If you love me, Strelsa."</p>
 
-<p>"Isn't it enough&mdash;that you&mdash;love&mdash;&mdash;"</p>
+<p>"Isn't it enough—that you—love——"</p>
 
 <p>"No, dear."</p>
 
@@ -13788,8 +13788,8 @@ questioning eyes of a boy.</p>
 <p>She drew a long unsteady breath. Suddenly the tears sprang to her eyes,
 and she held out both hands to him, blindly.</p>
 
-<p>"I&mdash;do love you," she whispered.... "I'll give what you give.... Only
-you must teach me&mdash;not to be&mdash;afraid."</p>
+<p>"I—do love you," she whispered.... "I'll give what you give.... Only
+you must teach me—not to be—afraid."</p>
 
 <p>Her cheek lay close to his shoulder; his arms drew her nearer. And,
 after he had waited a long while, her gray eyes, which had been watching

--- a/tests/testhtml4baseline.html
+++ b/tests/testhtml4baseline.html
@@ -2,7 +2,7 @@
 <h1>MASTERPIECES
 IN COLOUR</h1>
 
-<p class="center">EDITED BY&mdash;
+<p class="center">EDITED BY—
 M. HENRY ROUJON
 </p>
 
@@ -43,7 +43,7 @@ BURNE-JONES        BASTIEN-LEPAGE
 LE BRUN            GOYA
 </pre>
 
-<p>[Illustration: PLATE I.&mdash;THE SONG OF SPRINGTIME</p>
+<p>[Illustration: PLATE I.—THE SONG OF SPRINGTIME</p>
 
 <p>(Museum at Verdun)</p>
 
@@ -71,7 +71,7 @@ REPRODUCTIONS IN COLOUR<br />
 [Illustration: IN SEMPITERNUM.]<br />
 <br />
 FREDERICK A. STOKES COMPANY<br />
-NEW YORK&mdash;PUBLISHERS<br />
+NEW YORK—PUBLISHERS<br />
 <br />
 COPYRIGHT, 1914, BY<br />
 FREDERICK A. STOKES COMPANY<br />
@@ -134,7 +134,7 @@ Museum of the Luxembourg</p>
 <p class="center">V. Portrait of M. Hayem                                            40
 Museum of the Luxembourg</p>
 
-<p class="center">VI. Portrait of M. X&mdash;&mdash;                                           50
+<p class="center">VI. Portrait of M. X——                                           50
 Museum at Verdun</p>
 
 <p class="center">VII. The Little Boatman                                            60
@@ -205,7 +205,7 @@ his model to his canvas. It made no difference
 how handsome or how homely a given subject
 might be, Bastien-Lepage would always render
 him precisely as nature, in a grudging or indulgent
-mood, had made him,&mdash;that is to say, truly
+mood, had made him,—that is to say, truly
 and sincerely, with a precision that would be
 almost photographic, if the minuteness of his
 technique were not ennobled by the high quality
@@ -219,7 +219,7 @@ most interesting and vigorous artists of our epoch.</p>
 
 <p>[Illustration:</p>
 
-<p>PLATE II.&mdash;PORTRAIT OF M. WALLON</p>
+<p>PLATE II.—PORTRAIT OF M. WALLON</p>
 
 <p>(Museum of the Louvre)</p>
 
@@ -365,7 +365,7 @@ also possessed the temperament of a painter, and
 little by little he witnessed the unfolding of his
 artist's soul.</p>
 
-<p>[Illustration: PLATE III.&mdash;THE ARTIST'S MOTHER</p>
+<p>[Illustration: PLATE III.—THE ARTIST'S MOTHER</p>
 
 <p>(Collection of É. Bastien-Lepage)</p>
 
@@ -571,7 +571,7 @@ charm pervades this face, with its deeply graven
 lines, and an infinite tenderness, a true mother's
 tenderness, hovers over the thin, pale lips.</p>
 
-<p>[Illustration: PLATE IV&mdash;HAY-MAKING</p>
+<p>[Illustration: PLATE IV—HAY-MAKING</p>
 
 <p>(Museum of the Luxembourg)</p>
 
@@ -660,7 +660,7 @@ developed in the familiar setting of his native
 village, Damvillers. And how he loved it! How
 he enjoyed the warm atmosphere of affection</p>
 
-<p>[Illustration: PLATE V.&mdash;PORTRAIT OF M. HAYEM</p>
+<p>[Illustration: PLATE V.—PORTRAIT OF M. HAYEM</p>
 
 <p>(Museum of the Luxembourg)</p>
 
@@ -849,7 +849,7 @@ while to examine with a lens the marvellous process
 which, by the aid of imperceptible half-tones, has
 softened the modelling of the face and hands."</p>
 
-<p>[Illustration: PLATE VI.&mdash;PORTRAIT OF M. X&mdash;&mdash;</p>
+<p>[Illustration: PLATE VI.—PORTRAIT OF M. X——</p>
 
 <p>(Museum at Verdun)</p>
 
@@ -858,8 +858,8 @@ bestow the same superior skill upon every part of a portrait. Being
 sincere before all else, he never tried to shirk any difficulty; this is
 seen in the care he took in painting the hands of all his various
 sitters, showing something akin to vanity in the marvellous talent
-he displayed in rendering them. In this portrait&mdash;just as in all
-the others&mdash;the hands are quite as truly a miracle of execution
+he displayed in rendering them. In this portrait—just as in all
+the others—the hands are quite as truly a miracle of execution
 as the face itself.]</p>
 
 <p>These two pictures earned Bastien-Lepage the
@@ -1036,7 +1036,7 @@ picture known as <i>Jeanne d'Arc listening to the
 Voices</i>. Lorraine in heart and soul, Bastien-Lepage
 desired to pay his tribute, as so many had done</p>
 
-<p>[Illustration: PLATE VII.&mdash;THE LITTLE CHIMNEY-SWEEP</p>
+<p>[Illustration: PLATE VII.—THE LITTLE CHIMNEY-SWEEP</p>
 
 <p>(Collection of É. Bastien-Lepage)</p>
 
@@ -1206,7 +1206,7 @@ he had no fear of death. The previous year he
 had painted <i>Gambetta on his Death-bed</i>; and
 his frequent visits to Ville-d'Avray led him to
 discuss the inevitable end of life. "I am not
-afraid of death," he said, "dying is nothing,&mdash;the
+afraid of death," he said, "dying is nothing,—the
 important thing is to survive oneself,
 and who can be sure of establishing a claim
 upon posterity? But there! I am talking nonsense!
@@ -1229,7 +1229,7 @@ and poignant letters, in which could be read in
 every line the loss of hope and the sure prevision
 of the now inevitable end.</p>
 
-<p>[Illustration: PLATE VIII.&mdash;THE ARTIST'S UNCLE</p>
+<p>[Illustration: PLATE VIII.—THE ARTIST'S UNCLE</p>
 
 <p>(Museum at Verdun)</p>
 

--- a/tests/testhtml5baseline.html
+++ b/tests/testhtml5baseline.html
@@ -23,21 +23,21 @@ DETECTIVES.</h1>
 </p>
 
 <pre>
- 1.&mdash;MOLLIE MAGUIRES AND DETECTIVES.
- 2.&mdash;STRIKERS, COMMUNISTS, AND DETECTIVES.
- 3.&mdash;CRIMINAL REMINISCENCES AND DETECTIVES.
- 4.&mdash;THE MODEL TOWN AND DETECTIVES.
- 5.&mdash;SPIRITUALISTS AND DETECTIVES.
- 6.&mdash;EXPRESSMEN AND DETECTIVES.
- 7.&mdash;THE SOMNAMBULIST AND DETECTIVES.
- 8.&mdash;CLAUDE MELNOTTE AS A DETECTIVE.
- 9.&mdash;MISSISSIPPI OUTLAWS AND DETECTIVES.
- 10.&mdash;GYPSIES AND DETECTIVES.
- 11.&mdash;BUCHOLZ AND DETECTIVES.
- 12.&mdash;THE RAILROAD FORGER AND DETECTIVES.
- 13.&mdash;BANK ROBBERS AND DETECTIVES.
- 14.&mdash;BURGLAR'S FATE AND DETECTIVES.
- 15.&mdash;A DOUBLE LIFE AND DETECTIVES.
+ 1.—MOLLIE MAGUIRES AND DETECTIVES.
+ 2.—STRIKERS, COMMUNISTS, AND DETECTIVES.
+ 3.—CRIMINAL REMINISCENCES AND DETECTIVES.
+ 4.—THE MODEL TOWN AND DETECTIVES.
+ 5.—SPIRITUALISTS AND DETECTIVES.
+ 6.—EXPRESSMEN AND DETECTIVES.
+ 7.—THE SOMNAMBULIST AND DETECTIVES.
+ 8.—CLAUDE MELNOTTE AS A DETECTIVE.
+ 9.—MISSISSIPPI OUTLAWS AND DETECTIVES.
+ 10.—GYPSIES AND DETECTIVES.
+ 11.—BUCHOLZ AND DETECTIVES.
+ 12.—THE RAILROAD FORGER AND DETECTIVES.
+ 13.—BANK ROBBERS AND DETECTIVES.
+ 14.—BURGLAR'S FATE AND DETECTIVES.
+ 15.—A DOUBLE LIFE AND DETECTIVES.
 </pre>
 
 <pre>
@@ -122,8 +122,8 @@ N. Y.
 
 <div class="blockquot">
 
-<p>A daring Express Robbery.&mdash;Mr. Pinkerton appealed to.&mdash;Cane-brakes and
-cane-fed People.&mdash;Annoying delays and Amateur Detectives.                          9</p>
+<p>A daring Express Robbery.—Mr. Pinkerton appealed to.—Cane-brakes and
+cane-fed People.—Annoying delays and Amateur Detectives.                          9</p>
 </div>
 
 <p class="center">CHAPTER II.
@@ -131,7 +131,7 @@ cane-fed People.&mdash;Annoying delays and Amateur Detectives.                  
 
 <div class="blockquot">
 
-<p>Difficulties.&mdash;Blind Trails and False Scents.&mdash;A Series of Illustrations showing
+<p>Difficulties.—Blind Trails and False Scents.—A Series of Illustrations showing
 the Number of Officious People and Confidence Men that often seek
 Notoriety and Profit through important Detective Operations.                      21</p>
 </div>
@@ -141,9 +141,9 @@ Notoriety and Profit through important Detective Operations.                    
 
 <div class="blockquot">
 
-<p>"Old Hicks," a drunken Planter, is entertained by a Hunting-Party.&mdash;Lester's
-Landing.&mdash;Its Grocery-Store and Mysterious Merchants.&mdash;A dangerous
-Situation.&mdash;The unfortunate Escape of Two of the Robbers.                         32</p>
+<p>"Old Hicks," a drunken Planter, is entertained by a Hunting-Party.—Lester's
+Landing.—Its Grocery-Store and Mysterious Merchants.—A dangerous
+Situation.—The unfortunate Escape of Two of the Robbers.                         32</p>
 </div>
 
 <p class="center">CHAPTER IV.
@@ -152,8 +152,8 @@ Situation.&mdash;The unfortunate Escape of Two of the Robbers.                  
 <div class="blockquot">
 
 <p>The Captured Ruffians are desired for Guides, but dare not join in the
-Search for the Outlaws.&mdash;One of the Robbers is Taken, but subsequently
-Escapes from the Amateur Detectives.&mdash;Another Clue suddenly fails.                44</p>
+Search for the Outlaws.—One of the Robbers is Taken, but subsequently
+Escapes from the Amateur Detectives.—Another Clue suddenly fails.                44</p>
 </div>
 
 <p class="center">CHAPTER V.
@@ -170,10 +170,10 @@ Escapes from the Amateur Detectives.&mdash;Another Clue suddenly fails.         
 <div class="blockquot">
 
 <p>The Mother of the Farringtons, being arrested, boasts that her Sons "Will
-never be taken Alive."&mdash;Another Unfortunate Blunder by Amateur Detectives.&mdash;An
-interesting Fate intended for the Detectives.&mdash;William A.
+never be taken Alive."—Another Unfortunate Blunder by Amateur Detectives.—An
+interesting Fate intended for the Detectives.—William A.
 Pinkerton captures the Murderer of a Negro in Union City, proving "a
-very good Fellow&mdash;for a Yankee."                                                  56</p>
+very good Fellow—for a Yankee."                                                  56</p>
 </div>
 
 <p class="center">CHAPTER VII.
@@ -181,7 +181,7 @@ very good Fellow&mdash;for a Yankee."                                           
 
 <div class="blockquot">
 
-<p>The Scene of Action transferred to Missouri.&mdash;The Chase becoming Hot.             68</p>
+<p>The Scene of Action transferred to Missouri.—The Chase becoming Hot.             68</p>
 </div>
 
 <p class="center">CHAPTER VIII.
@@ -189,8 +189,8 @@ very good Fellow&mdash;for a Yankee."                                           
 
 <div class="blockquot">
 
-<p>A determined Party of Horsemen.&mdash;The Outlaws surrounded and the Birds
-caged.&mdash;A Parley.&mdash;The burning Cabin.&mdash;Its Occupants finally surrender.           80</p>
+<p>A determined Party of Horsemen.—The Outlaws surrounded and the Birds
+caged.—A Parley.—The burning Cabin.—Its Occupants finally surrender.           80</p>
 </div>
 
 <p class="center">CHAPTER IX.
@@ -198,8 +198,8 @@ caged.&mdash;A Parley.&mdash;The burning Cabin.&mdash;Its Occupants finally surr
 
 <div class="blockquot">
 
-<p>Barton's Confession.&mdash;The Express Robberies, and the Outlaw's subsequent
-Experiences fully set forth therein.&mdash;A Clue that had been suddenly
+<p>Barton's Confession.—The Express Robberies, and the Outlaw's subsequent
+Experiences fully set forth therein.—A Clue that had been suddenly
 dropped taken up with so much Profit.                                             91</p>
 </div>
 
@@ -208,8 +208,8 @@ dropped taken up with so much Profit.                                           
 
 <div class="blockquot">
 
-<p>A terrible Struggle for Life or Death upon the Transfer-boat "Illinois."&mdash;"Overboard!"&mdash;One
-less Desperado.&mdash;Fourth and Last Robber taken.                                   104</p>
+<p>A terrible Struggle for Life or Death upon the Transfer-boat "Illinois."—"Overboard!"—One
+less Desperado.—Fourth and Last Robber taken.                                   104</p>
 </div>
 
 <p class="center">CHAPTER XI.
@@ -217,9 +217,9 @@ less Desperado.&mdash;Fourth and Last Robber taken.                             
 
 <div class="blockquot">
 
-<p>The last Scene in the Drama approaching.&mdash;A new Character appears.&mdash;The
+<p>The last Scene in the Drama approaching.—A new Character appears.—The
 Citizens of Union City suddenly seem to have important business on
-hand.&mdash;The Vigilantes and their Work.&mdash;The End.                                  114</p>
+hand.—The Vigilantes and their Work.—The End.                                  114</p>
 </div>
 
 
@@ -230,8 +230,8 @@ hand.&mdash;The Vigilantes and their Work.&mdash;The End.                       
 
 <div class="blockquot">
 
-<p>A fraudulent Scheme contemplated.&mdash;A dashing Peruvian Don and Donna.&mdash;A
-regal Forger.&mdash;Mr. Pinkerton engaged by Senator Muirhead to unveil
+<p>A fraudulent Scheme contemplated.—A dashing Peruvian Don and Donna.—A
+regal Forger.—Mr. Pinkerton engaged by Senator Muirhead to unveil
 the mystery of his Life.                                                         125</p>
 </div>
 
@@ -241,7 +241,7 @@ the mystery of his Life.                                                        
 <div class="blockquot">
 
 <p>Madame Sevier, Widow, of Chicago, and Monsieur Lesparre, of Bordeaux,
-also arrive at Gloster.&mdash;Mr. Pinkerton, as a Laborer, anxious for a Job,
+also arrive at Gloster.—Mr. Pinkerton, as a Laborer, anxious for a Job,
 inspects the Morita Mansion.                                                     143</p>
 
 <p><span class="pagenum" id="Page_5">[Pg 5]</span></p>
@@ -253,8 +253,8 @@ inspects the Morita Mansion.                                                    
 <div class="blockquot">
 
 <p>Monsieur Lesparre, having a retentive memory, becomes serviceable to Don
-Pedro.&mdash;Diamond fields and droll Americans.&mdash;A pompous Judge in an
-unfortunate Predicament.&mdash;The grand Reception closes with a happy
+Pedro.—Diamond fields and droll Americans.—A pompous Judge in an
+unfortunate Predicament.—The grand Reception closes with a happy
 Arrangement that the gay Señor and Señora shall dine with Mr. Pinkerton's
 Detectives on the next evening.                                                  159</p>
 </div>
@@ -264,8 +264,8 @@ Detectives on the next evening.                                                 
 
 <div class="blockquot">
 
-<p>Madame Sevier and Her Work.&mdash;Unaccountable Coquettishness between
-Man and Wife.&mdash;A Startling Scheme, Illustrating the Rashness of
+<p>Madame Sevier and Her Work.—Unaccountable Coquettishness between
+Man and Wife.—A Startling Scheme, Illustrating the Rashness of
 American Business Men and the Supreme Assurance of Don Pedro.                    170</p>
 </div>
 
@@ -274,8 +274,8 @@ American Business Men and the Supreme Assurance of Don Pedro.                   
 
 <div class="blockquot">
 
-<p>The third Detective is made welcome at Don Pedro's.&mdash;The Señor is paid the
-first half-million dollars from the great Diamond Company.&mdash;How Don
+<p>The third Detective is made welcome at Don Pedro's.—The Señor is paid the
+first half-million dollars from the great Diamond Company.—How Don
 Pedro is "working" his diamond mines.                                            189</p>
 </div>
 
@@ -294,7 +294,7 @@ Attention upon Pietro Bernardi.                                                 
 
 <div class="blockquot">
 
-<p>Pietro Bernardi and the Detective become warm Friends.&mdash;A Tête-à-tête
+<p>Pietro Bernardi and the Detective become warm Friends.—A Tête-à-tête
 worth one thousand dollars.                                                      219</p>
 </div>
 
@@ -303,8 +303,8 @@ worth one thousand dollars.                                                     
 
 <div class="blockquot">
 
-<p>Don Pedro anxious for Pietro Bernardi's absence.&mdash;"Coppering the Jack
-and playing the Ace and Queen open."&mdash;Bernardi Quieted, and he subsequently
+<p>Don Pedro anxious for Pietro Bernardi's absence.—"Coppering the Jack
+and playing the Ace and Queen open."—Bernardi Quieted, and he subsequently
 departs richer by five thousand dollars.                                         232</p>
 </div>
 
@@ -313,10 +313,10 @@ departs richer by five thousand dollars.                                        
 
 <div class="blockquot">
 
-<p>Important Information from the Peruvian Government.&mdash;Arrival In Gloster
-of the Peruvian Minister and Consul.&mdash;In Consultation.&mdash;"Robbing Peter
-to pay Paul."&mdash;Mr. Pinkerton's Card is presented.&mdash;Juan Sanchez, I arrest
-you, and you are my Prisoner.&mdash;Mr. Pinkerton not "For Sale."                     249</p>
+<p>Important Information from the Peruvian Government.—Arrival In Gloster
+of the Peruvian Minister and Consul.—In Consultation.—"Robbing Peter
+to pay Paul."—Mr. Pinkerton's Card is presented.—Juan Sanchez, I arrest
+you, and you are my Prisoner.—Mr. Pinkerton not "For Sale."                     249</p>
 </div>
 
 <p class="center">CHAPTER X.
@@ -324,8 +324,8 @@ you, and you are my Prisoner.&mdash;Mr. Pinkerton not "For Sale."               
 
 <div class="blockquot">
 
-<p>The Fête Champêtre.&mdash;A grand Carnival.&mdash;The disappointed married Lover.&mdash;A
-vain Request.&mdash;Unmasked!&mdash;An indignant Deacon.&mdash;Don Pedro taken
+<p>The Fête Champêtre.—A grand Carnival.—The disappointed married Lover.—A
+vain Request.—Unmasked!—An indignant Deacon.—Don Pedro taken
 to Peru in a man-of-war, where he is convicted and sentenced to fifteen
 years Imprisonment.                                                              265</p>
 </div>
@@ -340,8 +340,8 @@ years Imprisonment.                                                             
 
 <p>Mr. Pinkerton at a Water-cure becomes interested in a Couple, one of whom
 subsequently causes the Detective Operation from which this Story is
-written.&mdash;A wealthy ship-owner and his son.&mdash;The son "Found dead."&mdash;Mr.
-Pinkerton secured to solve the Mystery.&mdash;Chicago after the Fire.                 283</p>
+written.—A wealthy ship-owner and his son.—The son "Found dead."—Mr.
+Pinkerton secured to solve the Mystery.—Chicago after the Fire.                 283</p>
 </div>
 
 <p class="center">CHAPTER II.
@@ -349,9 +349,9 @@ Pinkerton secured to solve the Mystery.&mdash;Chicago after the Fire.           
 
 <div class="blockquot">
 
-<p>The Detectives at work.&mdash;Mrs. Sanford described.&mdash;Charlie, the Policeman.&mdash;Mrs.
-Sanford develops Interest in Government Bonds.&mdash;Chicago Relief
-and Aid Benefits.&mdash;Mrs. Sanford's Story of Trafton's Death.                      298</p>
+<p>The Detectives at work.—Mrs. Sanford described.—Charlie, the Policeman.—Mrs.
+Sanford develops Interest in Government Bonds.—Chicago Relief
+and Aid Benefits.—Mrs. Sanford's Story of Trafton's Death.                      298</p>
 </div>
 
 <p class="center">CHAPTER III.
@@ -359,9 +359,9 @@ and Aid Benefits.&mdash;Mrs. Sanford's Story of Trafton's Death.                
 
 <div class="blockquot">
 
-<p>The dangerous Side of the Woman's Character.&mdash;Robert A. Pinkerton as
+<p>The dangerous Side of the Woman's Character.—Robert A. Pinkerton as
 Adamson, the drunken, but wealthy Stranger, has a violent Struggle to
-escape from Mrs. Sanford, and is afterwards robbed.&mdash;Detective Ingham
+escape from Mrs. Sanford, and is afterwards robbed.—Detective Ingham
 arrested, but very shortly liberated.                                            319</p>
 </div>
 
@@ -370,8 +370,8 @@ arrested, but very shortly liberated.                                           
 
 <div class="blockquot">
 
-<p>Connecting Links.&mdash;Mrs. Sanford's Ability as an Imitator of Actors.&mdash;One
-Detective tears himself away from her, and another takes his Place.&mdash;Mrs.
+<p>Connecting Links.—Mrs. Sanford's Ability as an Imitator of Actors.—One
+Detective tears himself away from her, and another takes his Place.—Mrs.
 Sanford's mind frequently burdened with the subject of Murder.                   340</p>
 </div>
 
@@ -380,10 +380,10 @@ Sanford's mind frequently burdened with the subject of Murder.                  
 
 <div class="blockquot">
 
-<p>A moneyed young Texan becomes one of Mrs. Sanford's Lodgers.&mdash;The bonds
-are seen and their Numbers taken by the Detectives.&mdash;Mrs. Sanford arrested.&mdash;She
+<p>A moneyed young Texan becomes one of Mrs. Sanford's Lodgers.—The bonds
+are seen and their Numbers taken by the Detectives.—Mrs. Sanford arrested.—She
 is found guilty of "Involuntary Manslaughter," and sentenced
-to the Illinois Penitentiary for five years.&mdash;Mr. Pinkerton's
+to the Illinois Penitentiary for five years.—Mr. Pinkerton's
 Theory of the Manner in which Trafton was murdered                               356</p>
 </div>
 
@@ -403,8 +403,8 @@ facts and incidents which have come under my own
 observation, or been worked up by officers acting directly
 under my instructions.</p>
 
-<p>The Mississippi River has for many years&mdash;more
-especially since the close of the war&mdash;been infested by
+<p>The Mississippi River has for many years—more
+especially since the close of the war—been infested by
 a class of men who never would try to get an honest
 living, but would prey upon their neighbors or attack
 the property of southern railroads and express companies;
@@ -466,8 +466,8 @@ F/</p>
 
 <div class="blockquot">
 
-<p><i>A daring Express Robbery.&mdash;Mr. Pinkerton appealed
-to.&mdash;Cane-brakes and cane-fed People.&mdash;Annoying
+<p><i>A daring Express Robbery.—Mr. Pinkerton appealed
+to.—Cane-brakes and cane-fed People.—Annoying
 Delays and Amateur Detectives.</i></p>
 </div>
 
@@ -617,7 +617,7 @@ thousand dollars in currency.</p>
 <p>Although the robbery was at once reported to Mr.
 M. J. O'Brien, the General Superintendent, by telegraph,
 no action seems to have been taken until
-the following Wednesday&mdash;four days later&mdash;when
+the following Wednesday—four days later—when
 Mr. O'Brien sent me a brief telegram announcing
 the robbery, and requesting me to come to Union
 City in person, if possible, and if not, to send my<span class="pagenum" id="Page_13">[Pg 13]</span>
@@ -756,7 +756,7 @@ hunters that they seem to have been born
 shot-gun or rifle in hand. Accomplishments they
 have none, except the rare instances where a few
 tunes upon the banjo have been learned from the<span class="pagenum" id="Page_17">[Pg 17]</span>
-negroes. Their tastes are few and simple,&mdash;whisky,
+negroes. Their tastes are few and simple,—whisky,
 snuff, hog, and hominy being the necessities and
 luxuries of life; that is, whisky and snuff are the
 necessities, all other things being secondary considerations.
@@ -862,7 +862,7 @@ interference.</p>
 
 <div class="blockquot">
 
-<p><i>Difficulties.&mdash;Blind Trails and False Scents.&mdash;A Series
+<p><i>Difficulties.—Blind Trails and False Scents.—A Series
 of Illustrations showing the Number of Officious
 People and Confidence Men that often seek Notoriety
 and Profit through important Detective Operations.</i></p>
@@ -932,7 +932,7 @@ show how wide is the range of the detective's
 inquiries, and also the annoying delays to which
 he is often subjected by the inconsiderate zeal
 and interference of outside parties. These latter
-may be&mdash;indeed, they generally are&mdash;well meaning
+may be—indeed, they generally are—well meaning
 people, anxious to serve the cause of justice;
 though, on the other hand, they are sometimes
 spiteful meddlers, striving to fix suspicion upon
@@ -1107,7 +1107,7 @@ and none of them were represented as over thirty-five
 years of age; yet Santon said that his man
 was over fifty years old, and that he had been a
 pilot on the Mississippi for years. This was a
-case&mdash;not an infrequent one, either&mdash;where people
+case—not an infrequent one, either—where people
 talk and lie about a crime for the sole purpose
 of getting a little temporary notoriety. Owing to
 various accidents and railway detentions, William
@@ -1250,9 +1250,9 @@ were always a source of great annoyance and embarrassment.</p>
 <div class="blockquot">
 
 <p><i>"Old Hicks," a drunken Planter, is entertained by a
-Hunting-party.&mdash;Lester's Landing.&mdash;Its Grocery-store
-and Mysterious Merchants.&mdash;A dangerous
-Situation and a desperate Encounter.&mdash;The unfortunate
+Hunting-party.—Lester's Landing.—Its Grocery-store
+and Mysterious Merchants.—A dangerous
+Situation and a desperate Encounter.—The unfortunate
 Escape of Two of the Robbers.</i></p>
 </div>
 
@@ -1547,7 +1547,7 @@ stomach, and he fell backward. At this moment,
 <span class="pagenum" id="Page_42">[Pg 42]</span>the powerful ruffian, Burtine, seized William
 from behind and tried to drag him down, at the
 same time calling for a shot-gun "to finish the
-Yankee&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;." Turning suddenly upon
+Yankee——————." Turning suddenly upon
 his assailant, William raised his revolver, a heavy
 Tranter, and brought it down twice, with all his
 force, upon Burtine's head. The man staggered
@@ -1559,7 +1559,7 @@ over before Gordon and Bledsoe could reach the
 house, though they had sprung from their horses
 on hearing the first shot.</p>
 
-<p>[Illustration: <i>The fight at Lester's Landing.</i>&mdash;<i>Page</i>&mdash;]</p>
+<p>[Illustration: <i>The fight at Lester's Landing.</i>—<i>Page</i>—]</p>
 
 <p>The two men had escaped by this time into the
 dense cane-brake back of the house, and it was
@@ -1672,9 +1672,9 @@ clothes and grazed his flesh.</p>
 <div class="blockquot">
 
 <p><i>The Captured Ruffians are desired for Guides, but dare
-not join in the Search for the Outlaws.&mdash;One of
+not join in the Search for the Outlaws.—One of
 the Robbers is Taken, but subsequently Escapes from
-the Amateur Detectives.&mdash;Another Clue suddenly
+the Amateur Detectives.—Another Clue suddenly
 Fails.</i></p>
 </div>
 
@@ -1985,7 +1985,7 @@ on the eleventh of September, and who
 had then started, according to his own statement,
 for his home in Illinois. Mr. Pink also stated
 that the chief of police in Cairo claimed to know
-Russell, and to be able to find him&mdash;for a sufficient
+Russell, and to be able to find him—for a sufficient
 consideration. Not having any use for the
 services of this disinterested officer, his offer was
 politely declined.</p>
@@ -2024,7 +2024,7 @@ went to Gillem Station, where he learned that
 Mrs. Farrington, to whom Russell had sent eight
 hundred dollars from Cairo, lived on an old, worn-out
 farm, and passed for a rich widow. She had
-three sons&mdash;Hillary, Levi, and Peter, the latter
+three sons—Hillary, Levi, and Peter, the latter
 being quite young. Hillary and Levi Farrington
 bore a very bad reputation, having been mixed
 up in all kinds of fights and quarrels for a number
@@ -2076,12 +2076,12 @@ to be the Farrington brothers!"</p>
 <div class="blockquot">
 
 <p><i>The Mother of the Farringtons, being arrested, boasts
-that her Sons "Will never be taken Alive."&mdash;Another
-Unfortunate Blunder by Amateur Detectives.&mdash;An
-interesting Fate intended for the Detectives.&mdash;William
+that her Sons "Will never be taken Alive."—Another
+Unfortunate Blunder by Amateur Detectives.—An
+interesting Fate intended for the Detectives.—William
 A. Pinkerton captures the Murderer of a Negro
-in Union City, proving "a very good Fellow&mdash;for
-a Yankee."&mdash;An Unfortunate Publication.&mdash;Nigger-Wool
+in Union City, proving "a very good Fellow—for
+a Yankee."—An Unfortunate Publication.—Nigger-Wool
 Swamp and its Outlaws.</i></p>
 </div>
 
@@ -2315,7 +2315,7 @@ over the way in which William had
 brought the fellow to bay, and then compelled
 his surrender; and they even went so far as to
 say that he was "a good fellow, a very good fellow
-indeed&mdash;for a Yankee."</p>
+indeed—for a Yankee."</p>
 
 <p>On the twentieth of November an unfortunate
 publicity was given to our operations by the publication
@@ -2482,7 +2482,7 @@ sons in Nigger-Wool Swamp.</p>
 <p class="center">CHAPTER VII.
 </p>
 
-<p><i>The Scene of Action transferred to Missouri.&mdash;The
+<p><i>The Scene of Action transferred to Missouri.—The
 Chase becoming Hot.</i></p>
 
 
@@ -2513,7 +2513,7 @@ well as ever, as you say you have been doing very
 well. It must be a good thing if it could stay so.
 Sometimes it was well and sometimes it wasn't,
 but I hope it will stay so, as you say it is a soft
-thing&mdash;as soft as things gets to be. I would like
+thing—as soft as things gets to be. I would like
 to see something like that, you bet. You talk like
 it can't be beat. That is the thing to take in. I
 think, and I know you think it, for I saw your<span class="pagenum" id="Page_70">[Pg 70]</span>
@@ -2915,9 +2915,9 @@ was only delayed a day or two at most.</p>
 
 <div class="blockquot">
 
-<p><i>A determined Party of Horsemen.&mdash;The Outlaws surrounded
-and the Birds caged.&mdash;A Parley.&mdash;An
-affecting Scene.&mdash;The burning Cabin.&mdash;Its Occupants
+<p><i>A determined Party of Horsemen.—The Outlaws surrounded
+and the Birds caged.—A Parley.—An
+affecting Scene.—The burning Cabin.—Its Occupants
 finally surrender.</i></p>
 </div>
 
@@ -3048,7 +3048,7 @@ Durham out and searched him, finding nothing
 but a single-barreled pistol. He then sent Jim to
 the door of the house to summon the men inside
 to surrender, telling them that he was determined
-to have them&mdash;alive if possible, but if not, dead.</p>
+to have them—alive if possible, but if not, dead.</p>
 
 <p>They refused to surrender, saying that they
 would kill any man who should approach the
@@ -3173,7 +3173,7 @@ that they should be taken to Tennessee for trial.
 She soon returned with another revolver and a
 shot-gun, and said that the men would come out.
 Cottrell therefore removed the rails, opened the
-front door, and called them out&mdash;Barton coming
+front door, and called them out—Barton coming
 first, and then Farrington. The latter proved to
 be Hillary, not Levi, as he had called himself. It
 was not known why he had used his brother's
@@ -3294,8 +3294,8 @@ exactly as it was taken down from Barton's lips.</p>
 
 <div class="blockquot">
 
-<p><i>Barton's Confession.&mdash;The Express Robberies and the
-Outlaws' subsequent Experiences fully set forth therein.&mdash;A
+<p><i>Barton's Confession.—The Express Robberies and the
+Outlaws' subsequent Experiences fully set forth therein.—A
 Clue that had been suddenly dropped taken
 up with so much Profit, that, after a desperate Struggle,
 another Desperado is Captured.</i></p>
@@ -3633,8 +3633,8 @@ from the marshal, and then, springing at him,
 he pinioned the desperado's arms by clasping him
 tightly around the body just at the elbows.
 Farrington did not stop to question the cause of
-this proceeding&mdash;he knew the reason of his seizure
-well enough&mdash;but, gathering his whole
+this proceeding—he knew the reason of his seizure
+well enough—but, gathering his whole
 strength, he made one jump away from the
 two officers who were approaching in front, and
 landed nearly in the middle of the street, taking
@@ -3735,7 +3735,7 @@ for Cairo.</p>
 <div class="blockquot">
 
 <p><i>A terrible Struggle for Life or Death upon the Transfer-boat
-"Illinois."&mdash;"Overboard!"&mdash;One less Desperado.&mdash;The
+"Illinois."—"Overboard!"—One less Desperado.—The
 Fourth and Last Robber taken.</i></p>
 </div>
 
@@ -3952,8 +3952,8 @@ story:</p>
 of the wagons and stock, and for five hundred
 and fifty dollars in money, Cottrell endeavored to
 attach her property in a civil suit. She insisted
-that she had none of Barton's money&mdash;indeed,
-that she had no money at all&mdash;and she refused to
+that she had none of Barton's money—indeed,
+that she had no money at all—and she refused to
 give up anything. At last, finding that he could
 not legally attach her property, Cottrell took the
 bold step of arresting her for receiving stolen
@@ -4070,12 +4070,12 @@ that night, evidently.</p>
 
 <div class="blockquot">
 
-<p><i>The last Scene in the Drama approaching.&mdash;A new Character
-appears.&mdash;The Citizens of Union City suddenly
-seem to have important business on hand.&mdash;The
-Vigilantes and their Work.&mdash;Their Bullets and Judge
+<p><i>The last Scene in the Drama approaching.—A new Character
+appears.—The Citizens of Union City suddenly
+seem to have important business on hand.—The
+Vigilantes and their Work.—Their Bullets and Judge
 Lynch administer a quietus to Levi Farrington and
-David Towler.&mdash;The End.</i></p>
+David Towler.—The End.</i></p>
 </div>
 
 
@@ -4319,7 +4319,7 @@ and noise without even a start or restless
 movement, but Taylor was terribly frightened,
 and he fully expected to be lynched also.</p>
 
-<p>[Illustration: "<i>The work of the Vigilante's.</i>"&mdash;<i>Page</i>&mdash;]</p>
+<p>[Illustration: "<i>The work of the Vigilante's.</i>"—<i>Page</i>—]</p>
 
 <p>The next morning at breakfast, William was
 informed that the body of Towler had been found
@@ -4343,7 +4343,7 @@ preferred to take no risks of future robberies
 and murders by these desperadoes, and
 they therefore took the most effectual method of
 preventing their occurrence. Their action was
-illegal, it is true, but then it was just&mdash;which is a
+illegal, it is true, but then it was just—which is a
 more important consideration sometimes.</p>
 
 <p>On the following Friday, Barton and Taylor
@@ -4408,11 +4408,11 @@ of the Southwest.</p>
 
 <div class="blockquot">
 
-<p><i>A Fraudulent Scheme contemplated.&mdash;A Dashing Peruvian
-Don and Donna.&mdash;A Regal Forger.&mdash;Mr.
+<p><i>A Fraudulent Scheme contemplated.—A Dashing Peruvian
+Don and Donna.—A Regal Forger.—Mr.
 Pinkerton engaged by Senator Muirhead to unveil
-the Mystery of his Life.&mdash;The Don and Donna
-Morito arrive at Gloster.&mdash;"Personnel" of Gloster's
+the Mystery of his Life.—The Don and Donna
+Morito arrive at Gloster.—"Personnel" of Gloster's
 "First Families."</i></p>
 </div>
 
@@ -4696,7 +4696,7 @@ was installed as its mistress.</p>
 long lived in Gloster, where he owned the largest
 brewery in the West. He was of middle height,
 but being quite fleshy, his gait was a kind of
-waddle&mdash;the reverse of elegant or dignified. His
+waddle—the reverse of elegant or dignified. His
 smooth, round, jovial face was strongly expressive
 of an appreciation of the good things of this
 world, and he rarely denied himself any indulgence
@@ -4855,7 +4855,7 @@ wife was a pleasant, motherly woman, who gave
 liberally to charitable objects, and who regarded
 her husband as one of the saints of the earth.</p>
 
-<p>There were three children&mdash;a young man and
+<p>There were three children—a young man and
 two girls. The former gave no promise of either
 ability, probity, or ambition, and there was about
 him a noticeable air of deficiency in both mental
@@ -4967,7 +4967,7 @@ that people believed the adage about a poor lawyer
 making a good judge. He was quite wealthy,
 and his business was that of a money loaner and
 real estate speculator. He was considered to be
-very pious and charitable&mdash;on Sunday; during
+very pious and charitable—on Sunday; during
 the rest of the week no Shylock ever demanded
 his pound of flesh more relentlessly than he his
 three per cent a month.</p>
@@ -5022,10 +5022,10 @@ they deserved no consideration.</p>
 <div class="blockquot">
 
 <p><i>Madame Sevier, Widow, of Chicago, and Monsieur
-Lesparre, of Bordeaux, also arrive at Gloster.&mdash;Mr.
+Lesparre, of Bordeaux, also arrive at Gloster.—Mr.
 Pinkerton, as a Laborer, anxious for a Job,
-inspects the Morito Mansion.&mdash;A Tender Scene,
-resulting in Profit to the fascinating Señora.&mdash;Madame
+inspects the Morito Mansion.—A Tender Scene,
+resulting in Profit to the fascinating Señora.—Madame
 Sevier is installed as a Guest at Don
 Pedro's.</i></p>
 </div>
@@ -5325,7 +5325,7 @@ Mather was standing beside the Donna, bending<span class="pagenum" id="Page_157"
 over her and looking into her face, while she had
 her head half turned away, as if in coy indecision.</p>
 
-<p>"Well, Mr. Mather&mdash;&mdash;"</p>
+<p>"Well, Mr. Mather——"</p>
 
 <p>"Why do you address me always so formally?
 Can you not call me Henry?" asked Mather,
@@ -5360,7 +5360,7 @@ but my pleasure was so great that I was somewhat
 beside myself. Now tell me what it was
 that caused your troubles."</p>
 
-<p>"Well, Mr. Math&mdash;&mdash;"</p>
+<p>"Well, Mr. Math——"</p>
 
 <p><span class="pagenum" id="Page_158">[Pg 158]</span></p>
 
@@ -5586,9 +5586,9 @@ been the objects of suspicion.</p>
 <div class="blockquot">
 
 <p><i>Monsieur Lesparre, having a retentive memory, becomes
-serviceable to Don Pedro.&mdash;Diamond Fields and
-droll Americans.&mdash;A pompous Judge in an unfortunate
-Predicament.&mdash;The grand Reception closes
+serviceable to Don Pedro.—Diamond Fields and
+droll Americans.—A pompous Judge in an unfortunate
+Predicament.—The grand Reception closes
 with the happy Arrangement that the gay Señor
 and Señora shall dine with Mr. Pinkerton's Detectives
 on the next evening.</i></p>
@@ -5956,14 +5956,14 @@ that they should all meet at that hour.</p>
 
 <div class="blockquot">
 
-<p><i>Madame Sevier and Her Work.&mdash;Unaccountable Coquettishness
-between Man and Wife.&mdash;A Startling
+<p><i>Madame Sevier and Her Work.—Unaccountable Coquettishness
+between Man and Wife.—A Startling
 Scheme, illustrating the Rashness and Gullibility of
 American Business Men and the Supreme Assurance
-of Don Pedro.&mdash;Disaster approaching the
-Gloster Capitalists.&mdash;Other Suspicions Aroused.&mdash;The
+of Don Pedro.—Disaster approaching the
+Gloster Capitalists.—Other Suspicions Aroused.—The
 Story of Mr. Warne, English Diplomatic
-Agent.&mdash;A New Move.</i></p>
+Agent.—A New Move.</i></p>
 </div>
 
 
@@ -6356,7 +6356,7 @@ Ashley Warne, of London, England.</p>
 step into the club close by, and over a social glass
 of wine, Mr. Warne will tell you about a peculiar
 case of mistaken identity, or of consummate
-rascality&mdash;it is hard to know which. Possibly
+rascality—it is hard to know which. Possibly
 you may be able to understand some things
 which puzzle us, and to frustrate a fraudulent
 scheme, if our suspicions are correct. You both
@@ -6613,11 +6613,11 @@ result.</p>
 
 <div class="blockquot">
 
-<p><i>The third Detective is made welcome at Don Pedro's.&mdash;The
+<p><i>The third Detective is made welcome at Don Pedro's.—The
 Señor is paid the first half-million dollars from
-the great Diamond Company.&mdash;How Don Pedro is
-"working" his Diamond Mines.&mdash;Very suspicious
-preparations.&mdash;The Don describes his proposed Fête
+the great Diamond Company.—How Don Pedro is
+"working" his Diamond Mines.—Very suspicious
+preparations.—The Don describes his proposed Fête
 Champêtre.</i></p>
 </div>
 
@@ -7191,11 +7191,11 @@ could do nothing.</p>
 
 <div class="blockquot">
 
-<p><i>A Mysterious Stranger.&mdash;An unexpected Meeting and a
-startling Recognition.&mdash;An old Friend somewhat
-disturbs the Equanimity of Don Pedro.&mdash;The Detectives
-fix their Attention upon Pietro Bernardi.&mdash;Pietro
-and his unpalatable Reminiscences.&mdash;The
+<p><i>A Mysterious Stranger.—An unexpected Meeting and a
+startling Recognition.—An old Friend somewhat
+disturbs the Equanimity of Don Pedro.—The Detectives
+fix their Attention upon Pietro Bernardi.—Pietro
+and his unpalatable Reminiscences.—The
 Donna shows Spirit.</i></p>
 </div>
 
@@ -7267,7 +7267,7 @@ forward and said:</p>
 
 <p>"Ah! Don Juan, I am delighted to meet you
 again. I knew I was not mistaken when I saw
-you yesterday and recognized&mdash;&mdash;"</p>
+you yesterday and recognized——"</p>
 
 <p>"There, there!" interrupted the Don, giving
 the speaker a warning look, "I am glad to meet
@@ -7317,7 +7317,7 @@ gambling?"</p>
 
 <p>"No, Pietro; I gamble very little, except in an
 occasional game of cards with gentlemen of my
-acquaintance; but I made a good sum&mdash;that is,"
+acquaintance; but I made a good sum—that is,"
 continued the Don, checking himself a moment,
 "I made a wealthy marriage, and my wife's fortune
 is ample for us both. By the way, how did
@@ -7538,11 +7538,11 @@ Tell me how I can serve you, and how much
 money you need, and if I can help you, I will
 gladly do so."</p>
 
-<p>"That is fair enough, Don Juan&mdash;Pedro, I
-mean&mdash;I only want a start, and I shall get along
+<p>"That is fair enough, Don Juan—Pedro, I
+mean—I only want a start, and I shall get along
 without any difficulty; but to tell the truth, I
 don't know where to go. I could not return to
-Peru&mdash;neither could you, for that matter&mdash;and I
+Peru—neither could you, for that matter—and I
 know of only one place where I could succeed
 and be satisfied to stay. I have been thinking of
 going to Buenos Ayres, if I could have a fair sum
@@ -7732,7 +7732,7 @@ the island to receive the guests on the day of the
 <div class="blockquot">
 
 <p><i>Pietro Bernardi and the Detective become Warm
-Friends.&mdash;A "Tête-à-Tête" worth One Thousand
+Friends.—A "Tête-à-Tête" worth One Thousand
 Dollars.</i></p>
 </div>
 
@@ -7878,7 +7878,7 @@ and became moody, silent, and abstracted.</p>
 once in New Orleans," replied Newton, on a venture;
 "is she dead?"</p>
 
-<p>"No, &mdash;&mdash; &mdash;&mdash; her! I wish she was," replied
+<p>"No, —— —— her! I wish she was," replied
 Bernardi, savagely. "She started to come North
 with me, and I gave her everything she could ask;
 but when I had won a large sum of money at Natchez,
@@ -8206,10 +8206,10 @@ also.</p>
 
 <div class="blockquot">
 
-<p><i>Don Pedro anxious for Pietro Bernardi's Absence.&mdash;"Coppering
+<p><i>Don Pedro anxious for Pietro Bernardi's Absence.—"Coppering
 the Jack and Playing the Ace and
-Queen open."&mdash;A Gambler that could not be Bought.&mdash;Splendid
-Winnings.&mdash;Diamond cutting Diamond.&mdash;Bernardi
+Queen open."—A Gambler that could not be Bought.—Splendid
+Winnings.—Diamond cutting Diamond.—Bernardi
 quieted, and he subsequently departs
 richer by five thousand dollars.</i></p>
 </div>
@@ -8422,8 +8422,8 @@ more than that in a single evening."</p>
 been playing here recently, against whom I have
 a bitter grudge. He has about six hundred dollars
 now, most of which he has won here. He
-has one regular system of playing&mdash;'coppering'
-the jack and playing the ace and queen to win&mdash;and
+has one regular system of playing—'coppering'
+the jack and playing the ace and queen to win—and
 you can easily fix those cards so as to clean
 him out in one evening. The moment you have
 done that, I will give you five hundred dollars
@@ -8593,7 +8593,7 @@ after your long experience in gambling."</p>
 who had drunk a good deal of brandy before and
 after breakfast; "but I was thinking how lucky
 it was that I changed my mind last night about
-playing those three cards&mdash;the jack, ace, and
+playing those three cards—the jack, ace, and
 queen."</p>
 
 <p>"How so?" asked Morito.</p>
@@ -8693,7 +8693,7 @@ dollars be enough?"</p>
 
 <p>"Hardly; I have won some money here, to be
 sure, but it will cost a good deal to spread a handsome
-layout in New Orleans&mdash;as for this place,
+layout in New Orleans—as for this place,
 there are not enough gentlemen gamesters here;
 the gamblers are all trying to live on each other.
 If you will make it five thousand, I will start for
@@ -8829,13 +8829,13 @@ watering-places, and enjoy life to the full."</p>
 
 <div class="blockquot">
 
-<p><i>Important Information from the Peruvian Government.&mdash;Arrival
+<p><i>Important Information from the Peruvian Government.—Arrival
 in Gloster of the Peruvian Minister
-and Consul.&mdash;In Consultation.&mdash;"Robbing Peter
-to pay Paul."&mdash;Mr. Pinkerton's card is presented.&mdash;Juan
-Sanchez, I arrest you, and you are my Prisoner.&mdash;Mr.
-Pinkerton not "For Sale."&mdash;A Dramatic
-Scene.&mdash;The Bubble burst.</i></p>
+and Consul.—In Consultation.—"Robbing Peter
+to pay Paul."—Mr. Pinkerton's card is presented.—Juan
+Sanchez, I arrest you, and you are my Prisoner.—Mr.
+Pinkerton not "For Sale."—A Dramatic
+Scene.—The Bubble burst.</i></p>
 </div>
 
 
@@ -9419,12 +9419,12 @@ ten o'clock the train bore them from the city.</p>
 
 <div class="blockquot">
 
-<p><i>The Fête Champêtre.&mdash;A Grand Carnival.&mdash;The Disappointed
-Married Lover.&mdash;A Vain Request.&mdash;Unmasked!&mdash;A
+<p><i>The Fête Champêtre.—A Grand Carnival.—The Disappointed
+Married Lover.—A Vain Request.—Unmasked!—A
 Shrewd Caterer and his Humiliating
-Demands.&mdash;An Indignant Deacon.&mdash;Don Pedro
+Demands.—An Indignant Deacon.—Don Pedro
 taken to Peru in a Man-of-War, where he is Convicted
-and Sentenced to Fifteen Years' Imprisonment.&mdash;But
+and Sentenced to Fifteen Years' Imprisonment.—But
 the Donna manages to Satisfy her
 Affections in a quiet way in New York.</i></p>
 </div>
@@ -9481,7 +9481,7 @@ several persons were suspected of being the host
 and hostess, there was no sufficient way of identifying
 them.</p>
 
-<p>[Illustration: <i>The Fête Champêtre.&mdash;Page&mdash;</i>]</p>
+<p>[Illustration: <i>The Fête Champêtre.—Page—</i>]</p>
 
 <p>At length the island was reached, and the party
 disembarked. The scene, as they took possession
@@ -9925,7 +9925,7 @@ obliged to wait on board while their escorts went
 to the livery stables to order carriages to take
 them home.</p>
 
-<p>[Illustration: <i>"What do you mean by refusing to take us on board?" demanded Deacon Humphrey furiously.&mdash;Page&mdash;</i>]</p>
+<p>[Illustration: <i>"What do you mean by refusing to take us on board?" demanded Deacon Humphrey furiously.—Page—</i>]</p>
 
 <p>Thus ended the <i>fête champêtre</i> which had been
 anticipated so fondly as a new departure in the
@@ -10053,11 +10053,11 @@ de Morito.</p>
 
 <p><i>Mr. Pinkerton, at a Water-Cure, becomes interested in a
 Couple, one of whom subsequently causes the Detective
-Operation from which this Story is written.&mdash;A
-wealthy Ship-Owner and his Son.&mdash;The Son
-"found dead."&mdash;A Woman that knows too much
-and too little by turns.&mdash;Mr. Pinkerton secured to
-solve the Mystery.&mdash;Chicago after the Great Fire.</i></p>
+Operation from which this Story is written.—A
+wealthy Ship-Owner and his Son.—The Son
+"found dead."—A Woman that knows too much
+and too little by turns.—Mr. Pinkerton secured to
+solve the Mystery.—Chicago after the Great Fire.</i></p>
 </div>
 
 
@@ -10252,7 +10252,7 @@ room back, were used as offices, the rear portion
 <span class="pagenum" id="Page_308">[Pg 308]</span>was occupied by Mrs. Sanford, who rented most
 of her rooms as sleeping apartments.</p>
 
-<p>[Illustration: <i>"He was lying in bed with froth about his mouth and a ghastly look on his face."&mdash;Page&mdash;</i>]</p>
+<p>[Illustration: <i>"He was lying in bed with froth about his mouth and a ghastly look on his face."—Page—</i>]</p>
 
 <p>On stating their object in calling, the two
 gentlemen were admitted to Mrs. Sanford's sitting-room,
@@ -10575,13 +10575,13 @@ dark, we never despaired of our eventual success.</p>
 <p class="center">CHAPTER II.
 </p>
 
-<p><i>The Detectives at Work.&mdash;Mrs. Sanford Described.&mdash;Charlie,
-the Policeman.&mdash;Mrs. Sanford develops
-Interest in Government Bonds.&mdash;Chicago Relief
-and Aid Benefits.&mdash;Mrs. Sanford's Story of Trafton's
-Death.&mdash;A nice little Arrangement.&mdash;Mrs.
+<p><i>The Detectives at Work.—Mrs. Sanford Described.—Charlie,
+the Policeman.—Mrs. Sanford develops
+Interest in Government Bonds.—Chicago Relief
+and Aid Benefits.—Mrs. Sanford's Story of Trafton's
+Death.—A nice little Arrangement.—Mrs.
 Sanford explains to the Detective her method of
-"Quieting People."&mdash;Ingham "Makes a Raise."&mdash;Mrs.
+"Quieting People."—Ingham "Makes a Raise."—Mrs.
 Sanford fears being Haunted, but is not easily
 Frightened.</i></p>
 
@@ -10974,7 +10974,7 @@ answered, with great determination, but adding<span class="pagenum" id="Page_328
 suddenly, in a cautious tone, "that is, anything
 except murder, you know. I shouldn't like to do
 that. But I would protect you even if you should
-kill a man&mdash;not willfully&mdash;not willfully, you understand;
+kill a man—not willfully—not willfully, you understand;
 but if you should be obliged to do it to
 save yourself, I should not blame you very
 much."</p>
@@ -11032,7 +11032,7 @@ them go, and they soon went to bed.</p>
 <p>Ingham and Mrs. Sanford then talked together
 about their plans for getting money for some
 time. Her whole mind seemed bent upon one
-object,&mdash;to obtain money; and she seemed to
+object,—to obtain money; and she seemed to
 have no scruples whatever as to the means employed.</p>
 
 <p>"Don't you know of any wealthy fellow who
@@ -11268,7 +11268,7 @@ and he petted her so nicely that she said
 he was her best friend, and that she would do<span class="pagenum" id="Page_336">[Pg 336]</span>
 anything for him. He prepared a dressing for
 her black eye, and got some supper for her, telling
-her that on Monday&mdash;that day being Saturday&mdash;she
+her that on Monday—that day being Saturday—she
 ought to get out a warrant for the arrest
 of Mrs. Graves.</p>
 
@@ -11352,13 +11352,13 @@ to take charge of her rooms while she was away.</p>
 
 <div class="blockquot">
 
-<p><i>The Dangerous Side of the Woman's Character.&mdash;Mr.
-Pinkerton makes a new Move.&mdash;Robert A. Pinkerton
+<p><i>The Dangerous Side of the Woman's Character.—Mr.
+Pinkerton makes a new Move.—Robert A. Pinkerton
 as Adamson, the drunken, but wealthy,
-Stranger.&mdash;A "funny" Game of Cards.&mdash;The
+Stranger.—A "funny" Game of Cards.—The
 drunken Stranger has a violent Struggle to escape
-from Mrs. Sanford, and is afterwards robbed&mdash;according
-to the Papers.&mdash;Detective Ingham arrested,
+from Mrs. Sanford, and is afterwards robbed—according
+to the Papers.—Detective Ingham arrested,
 but very shortly liberated.</i></p>
 </div>
 
@@ -11473,7 +11473,7 @@ wished.</p>
 "I don't believe you can tell how it looks."</p>
 
 <p>"Tha's a lie. I know how to tell warrer's
-well's you. I (hic) can allus tell warrer&mdash;it looks
+well's you. I (hic) can allus tell warrer—it looks
 jus' like gin. Get us some gin."</p>
 
 <p>While Mrs. Sanford was gone, Ingham and
@@ -12171,7 +12171,7 @@ captain took him into a private room, where they
 remained some time. When they came out, the
 sergeant joined the captain for a few minutes,
 while the tall gentleman introduced himself to
-Ingham as Judge B&mdash;&mdash;, and said that the captain
+Ingham as Judge B——, and said that the captain
 would let him go. This proved true, for the
 captain very soon came out, and told Ingham
 that he was at liberty.</p>
@@ -12186,12 +12186,12 @@ that he was at liberty.</p>
 
 <div class="blockquot">
 
-<p><i>Connecting Links.&mdash;Mrs. Sanford's Ability as an Imitator
-of Actors.&mdash;One Detective tears himself away
-from her, and another takes his Place.&mdash;Mrs. Sanford's
+<p><i>Connecting Links.—Mrs. Sanford's Ability as an Imitator
+of Actors.—One Detective tears himself away
+from her, and another takes his Place.—Mrs. Sanford's
 mind frequently burdened with the Subject of
-Murder.&mdash;New Evidence appearing.&mdash;A Peep at the
-stolen Bonds.&mdash;The Shrewdness of the Murderess.</i></p>
+Murder.—New Evidence appearing.—A Peep at the
+stolen Bonds.—The Shrewdness of the Murderess.</i></p>
 </div>
 
 
@@ -12671,7 +12671,7 @@ in 1885, with about twenty or thirty coupons
 attached. He was so surprised and excited at
 seeing the bond, that he could hardly tell what to
 do, and so he failed to notice the most important
-point&mdash;the number. By the time she had opened
+point—the number. By the time she had opened
 the other bond, however, he had his wits a little
 more under command, and he was able to remember
 that the figures of the number were
@@ -12793,12 +12793,12 @@ bring the affair to a crisis without delay.</p>
 <div class="blockquot">
 
 <p><i>A moneyed young Texan becomes one of Mrs. Sanford's
-Lodgers.&mdash;The Bonds are seen, and their Numbers
-taken by the Detectives.&mdash;Mrs. Sanford Arrested.&mdash;Sudden
-and Shrewd Defense by the Prisoner.&mdash;She
+Lodgers.—The Bonds are seen, and their Numbers
+taken by the Detectives.—Mrs. Sanford Arrested.—Sudden
+and Shrewd Defense by the Prisoner.—She
 is found guilty of "Involuntary Manslaughter" and
-sentenced to the Illinois Penitentiary for five years.&mdash;Misdirected
-Philanthropy, and its Reward.&mdash;Mr.
+sentenced to the Illinois Penitentiary for five years.—Misdirected
+Philanthropy, and its Reward.—Mr.
 Pinkerton's Theory of the Manner in which Trafton
 was Murdered.</i></p>
 </div>
@@ -13076,7 +13076,7 @@ vigor and cunning that many persons believed her
 statement to be true. Thus, without consultation
 or legal advice, she invented in a moment
 the strongest possible defense against the charge
-of larceny,&mdash;the charge of murder had not then
+of larceny,—the charge of murder had not then
 been brought.</p>
 
 <p>When she was removed to the jail, she gave
@@ -13326,7 +13326,7 @@ clutch wildly at his assailant; having caught one
 of the bonds, he clung to it until it was torn in
 two pieces, the fragments plainly showing how
 they had been wrenched asunder in the clasp of
-two determined hands&mdash;those of the murderess
+two determined hands—those of the murderess
 and her victim. But she soon found that he was
 gaining his senses too rapidly, and that she
 would be foiled in her attempted robbery; hence,
@@ -13430,7 +13430,7 @@ the water could be handed to her.</p>
 <p>She was then removed to the jail to await the
 argument on a motion for a new trial. While
 there, she gave one of the most effectual evidences
-of her ruling passion&mdash;greed. She was
+of her ruling passion—greed. She was
 the object of considerable sympathy among a certain
 class of sentimentalists, and the amount of
 compassion wasted upon her was remarkable to


### PR DESCRIPTION
HTML autogenerate should create HTML5 files:

1. Always read/write utf8 files
2. Update default HTML header.txt for HTML5 (need to load it as utf8 now)
3. Do not write summary attribute in tables
4. Use numeric, not named, entities apart from a few permitted exceptions
5. Stop pphtml complaining about missing table summary
6. Update test suite to accept numeric emdash entities