### PR TITLE
Output error message when no project dictionary

### DIFF
--- a/src/lib/Guiguts/SpellCheck.pm
+++ b/src/lib/Guiguts/SpellCheck.pm
@@ -233,6 +233,16 @@ sub spellmyaddword {
         return;
     }
     getprojectdic();
+    if ( not defined $::lglobal{projectdictname} ) {
+        my $dialog = $::top->Dialog(
+            -text    => "File must be saved before words can be added to project dictionary.",
+            -bitmap  => 'warning',
+            -title   => 'No Project Dictionary',
+            -buttons => [qw/OK/],
+        );
+        $dialog->Show;
+        return;
+    }
     $::projectdict{$term} = '';
     open( my $dic, '>:bytes', "$::lglobal{projectdictname}" );
     my $section = "\%projectdict = (\n";


### PR DESCRIPTION
If attempt was made to add a word to the project dictionary when text file
had not been saved, the dictionary name was undefined, causing error
messages. Instead, tell user they need to save their file.

Fixes #878 