### PR TITLE
Ignore table summary warning from ebookmaker tidy

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2315,6 +2315,7 @@ sub ebookmaker {
         $warn++
           if $line  =~ "^WARNING:"
           and $line !~ "No gnu dbm support found"                         # ignore some warnings
+          and $line !~ '<table> lacks "summary" attribute'
           and $line !~ "elements having class .* have been rewritten.";
         adderror($line);                                                  # Send all ebookmaker output to message log
     }


### PR DESCRIPTION
Spurious warning due to the way tidy is run from within ebookmaker, so
safe to ignore. The message will still appear in the log but won't be a
countable warning.
Fixes #876 until permanent ebookmaker/tidy fix is implemented.