### PR TITLE
Catch footnote missing a colon error more gracefully

### DIFF
--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -769,11 +769,14 @@ sub footnotefixup {
           if $::lglobal{footpop};
         $::lglobal{footnotetotal}->configure( -text => "# $::lglobal{fnindex}/$::lglobal{fntotal}" )
           if $::lglobal{footpop};
-        $pointer =
-          $textwindow->get( $start,
-            ( $textwindow->search( '--', ':', $start, "$start lineend" ) ) );
-        $pointer =~ s/\[Footnote\s*//i;
-        $pointer =~ s/\s*:$//;
+
+        # Find the colon after the number - if none, then $pointer will be empty to flag the error
+        my $colonpos = $textwindow->search( '--', ':', $start, "$start lineend" );
+        if ($colonpos) {
+            $pointer = $textwindow->get( $start, $colonpos );
+            $pointer =~ s/\[Footnote\s*//i;
+            $pointer =~ s/\s*:$//;
+        }
 
         if ( length($pointer) > 20 ) {
             $pointer = '';


### PR DESCRIPTION
Instead of outputting uninitialized value errors, report the footnote format
error in the correct way, by highlighting in pink in the check footnote
dialog.
Fixes #885