### PR TITLE
Convert HTML4 header.txt to HTML5

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -33,13 +33,21 @@ steps below work for all operating systems.
      relevant ones to the new release. This will not apply to most users.
    * The file `headerdefault.txt` has had important changes made to it in this
      release. When you first run Guiguts, it copies this file to one named
-     `header.txt`. If you made changes to `header.txt`, or are unsure whether
-     you did or what they were:
+     `header.txt`. If you have customized your `header.txt` in a previous
+     release, you may want to retain those changes in the new release.
+     If you are upgrading from a 1.3.x release, you can copy `header.txt` from
+     the old release to the new one after you have run and exited Guiguts once.
+     If you are upgrading from an older release, e.g. 1.0.25, 1.1.x or 1.2.x,
+     you should follow the steps below to ensure you get all the updates:
      1. In the old directory compare `header.txt` with `headerdefault.txt`,
         making note of any differences.
      2. Run the newly installed Guiguts program to create the new `header.txt`
         then immediately exit.
      3. Edit `header.txt` in the new directory and make the changes you want
         to carry over from the old release.
+     If you were using `@media handheld` in your customized header file, please
+     note that it is now deprecated. The same effects can be achieved using
+     the `x-ebookmaker` class as described [here](https://www.pgdp.net/wiki/DP_Official_Documentation:PP_and_PPV/DP_HTML_Best_Practices/Case_Studies/Media_Types_and_Mobile_Formats).
+     Alternatively, ask in the [DP forum Help with: guiguts thread](https://www.pgdp.net/phpBB2/viewtopic.php?t=11466).
 
 You can now run Guiguts from the new installation directory.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -45,7 +45,8 @@ steps below work for all operating systems.
         then immediately exit.
      3. Edit `header.txt` in the new directory and make the changes you want
         to carry over from the old release.
-     If you were using `@media handheld` in your customized header file, please
+
+   * If you were using `@media handheld` in your customized header file, please
      note that it is now deprecated. The same effects can be achieved using
      the `x-ebookmaker` class as described [here](https://www.pgdp.net/wiki/DP_Official_Documentation:PP_and_PPV/DP_HTML_Best_Practices/Case_Studies/Media_Types_and_Mobile_Formats).
      Alternatively, ask in the [DP forum Help with: guiguts thread](https://www.pgdp.net/phpBB2/viewtopic.php?t=11466).

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1217,9 +1217,19 @@ sub html_parse_header {
         }
         open my $infile, '<:encoding(utf8)', 'header.txt'
           or warn "Could not open header file. $!\n";
-        while (<$infile>) {
-            $_ =~ s/\cM\cJ|\cM|\cJ/\n/g;
-            $headertext .= $_;
+        while ( my $line = <$infile> ) {
+            $line =~ s/\cM\cJ|\cM|\cJ/\n/g;
+
+            # Upgrade to HTML5 if old XHTML4 header
+            $line = "<!DOCTYPE html>\n" if $line =~ /<!DOCTYPE .* XHTML/;
+            next                        if $line =~ /DTD\/xhtml/;             # skip DTD line;
+            next                        if $line =~ /content="text\/css"/;    # skip content line
+            $line = "    <meta charset=\"UTF-8\" />\n" if $line =~ /charset=BOOKCHARSET/;
+            $line = "    <link rel=\"icon\" href=\"images/cover.jpg\" type=\"image/x-cover\" />\n"
+              if $line =~ /rel="coverpage"/;
+            $line = "    <style> /* <![CDATA[ */\n" if $line =~ /<style type="text\/css">/;
+            $line = "    /* ]]> */ </style>\n"      if $line =~ /<\/style>/;
+            $headertext .= $line;
         }
         close $infile;
     }


### PR DESCRIPTION
If user has copied a customized header.txt from a previous release, it will have
an (X)HTML4 header. As this is read, convert the few lines necessary to make
it valid HTML5.

This allows the user to upgrade fairly painlessly from a 1.3 (HTML4) release to
a 1.4 (HTML5) release.

Also, beef up the upgrade notes a bit to clarify procedure for retaining any
header.txt customizations.