### PR TITLE
Convert sub/superscripts correctly in block markup

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -28,15 +28,19 @@ sub html_convert_tb {
     return 0;
 }
 
+# Convert subscripts in the textwindow at this line
+# Also return modified line so remainder of HTML conversion acts on the edited version
 sub html_convert_subscripts {
     my ( $textwindow, $selection, $step ) = @_;
     if ( $selection =~ s/_\{([^}]+?)\}/<sub>$1<\/sub>/g ) {
         $textwindow->ntdelete( "$step.0", "$step.end" );
         $textwindow->ntinsert( "$step.0", $selection );
     }
-    return;
+    return $selection;
 }
 
+# Convert superscripts in the textwindow at this line
+# Also return modified line so remainder of HTML conversion acts on the edited version
 # Doesn't convert Gen^rl; workaround Gen^{rl} - correct behaviour, not a bug, cf. the guidelines
 sub html_convert_superscripts {
     my ( $textwindow, $selection, $step ) = @_;
@@ -50,7 +54,7 @@ sub html_convert_superscripts {
         $textwindow->ntdelete( "$step.0", "$step.end" );
         $textwindow->ntinsert( "$step.0", $selection );
     }
-    return;
+    return $selection;
 }
 
 sub html_convert_simple_tag {
@@ -285,8 +289,8 @@ sub html_convert_body {
           if ( ( $step < 100 )
             && ( $selection =~ /contents/i )
             && ( $incontents eq '1.0' ) );
-        html_convert_subscripts( $textwindow, $selection, $step );
-        html_convert_superscripts( $textwindow, $selection, $step );
+        $selection = html_convert_subscripts( $textwindow, $selection, $step );
+        $selection = html_convert_superscripts( $textwindow, $selection, $step );
         next if html_convert_tb( $textwindow, $selection, $step );
 
         # /x|/X gets <pre>


### PR DESCRIPTION
During HTML generation, the routines to convert sub/superscripts were called
for each line of the file near the beginning of the conversion.
They edited the file directly to add the sub/sup markup.
The calling routine ignored this change and continued to work with the line
it had extracted from the file before the sub/sup conversion. This meant that
if further work was done on the line, e.g. adding a span to indent it for a table,
the sub/sup edit was lost.

Fixed by returning the modified line to the calling routine - it didn't seem
worth trying to restructure, since that would open a can of worms regarding
the structure of the HTML conversion with its massive outer loop.

Fixes #892 

This has been a bug since 1.0.25 at least; very surprising it hasn't been
reported/fixed before. Possibly HTML files have been posted with the
`^` or `_` markup still in where sub/sups occur inside block markup, since
it would be easily overlooked by the PPer post-conversion.