### PR TITLE
Use CRLF line endings when saving main text file

### DIFF
--- a/src/lib/Guiguts/TextUnicode.pm
+++ b/src/lib/Guiguts/TextUnicode.pm
@@ -78,7 +78,7 @@ sub SaveUTF {
         my $end  = $w->index("$index lineend +1c");
         my $line = $w->get( $index, $end );
         $line =~ s/[\t \xA0]+$//;
-        $line =~ s/\cM\cJ|\cM|\cJ/\cM\cJ/g if (OS_Win);
+        $line =~ s/\cM\cJ|\cM|\cJ/\cM\cJ/g;    # Ensure DP-style (CRLF) line endings
         utf8::encode($line);
         $w->BackTrace("Cannot write to temp file:$!\n") and return
           unless print $tempfh $line;


### PR DESCRIPTION
DP text files use CRLF line endings, and some tools expect this.
Guiguts already forced this for Windows when saving the main text file.
Mac/Linux users have said it would be easier if it did the same for them.

A variety of line endings are accepted when loading a file.

Fixes #894