### PR TITLE
Add TIA OCR import feature

### DIFF
--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -123,6 +123,9 @@ sub menu_file_content_providing {
             'E~xport One File with Page Sep. Markup...',
             -command => sub { ::file_export_pagemarkup(); }
         ],
+        [
+            'command', 'Import ~TIA Abbyy OCR File...', -command => sub { ::file_import_ocr(); }
+        ],
         [ 'separator', '' ],
         [
             Checkbutton => '~Highlight WF Characters Not in Selected Suites',
@@ -136,7 +139,7 @@ sub menu_file_content_providing {
         ],
         [ 'separator', '' ],
         [
-            'command', 'CP Character Substitutions', -command => sub { ::cpcharactersubs(); },
+            'command', 'CP Character S~ubstitutions', -command => sub { ::cpcharactersubs(); },
         ],
     ];
 }


### PR DESCRIPTION
Accept either a zipped or unzipped Abbyy.gz file from TIA.
If file is zipped (extension .gz) then user must have gzip on their PATH.

Code was written to cope with importing several different types, and a new
type could be easily added. Hopefully this doesn't make it look too odd now
there is only one type of import that turned out to be successful.

Thanks to @srjfoo for coming up with the idea, investigations and testing.
