### PR TITLE
Set zero text-indent on pagenum spans

### DIFF
--- a/src/headerdefault.txt
+++ b/src/headerdefault.txt
@@ -97,6 +97,7 @@ table.autotable th { padding: 4px; }
     font-style: normal;
     font-weight: normal;
     font-variant: normal;
+    text-indent: 0;
 } /* page numbers */
 
 .linenum {


### PR DESCRIPTION
Some PPers have a default text-indent on their paragraphs, but have a zero
text-indent on the first paragraph of a chapter, or where there is a dropcap.
Negative text-indents are also possible from hanging indent paragraphs.

Since the text-indent is inherited by the child pagenum span, the page
numbers can end up misaligned between different paragraphs. So force
the text-indent to zero for the pagenum span.