### PR TITLE
Make Replace All replace adjacent matches

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -50,6 +50,7 @@ sub searchtext {
 
     # to avoid next search finding same match
     my $stepforward = '+1c';
+    $stepforward = '' if $silentmode and $silentmode == 1;    # Don't step when doing a Replace All
 
     # this is starting a search within a selection
     if ( $range_total > 0 ) {


### PR DESCRIPTION
There are two versions of Replace All - a built-in Perl/Tk one, and a coded one.
The latter is used to enable Guiguts regex extensions, and to avoid an
infinite loop in the built-in one.
There was a bug in the coded one that failed to replace an expression if it
immediately followed the previous match, e.g. replacing `ss` with `tt` would
change `abcssssdef` to `abcttssdef` rather than `abcttttdef`. This only
occurred when the coded one was used, i.e. when a regex was being used
or when the replacement string contained the search string.
To make Replace All consistent, the coded version now replaces adjacent
matches.

Note: Manually Searching and Replacing (not Replace All) still has issues
with adjacent matches, but the complexities of the code due to its history
mean that fixing that would be hard/dangerous, so I'm not going to
tackle it. At least the user notices when doing it one Replace at a time,
unlike Replace All, and of course the bug has been there, unaddressed
for 10+ years without complaint from the users.