### PR TITLE
Revert "Make Replace All replace adjacent matches"

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -50,7 +50,6 @@ sub searchtext {
 
     # to avoid next search finding same match
     my $stepforward = '+1c';
-    $stepforward = '' if $silentmode and $silentmode == 1;    # Don't step when doing a Replace All
 
     # this is starting a search within a selection
     if ( $range_total > 0 ) {


### PR DESCRIPTION
This reverts commit 8ef975e427058de2f5e0229174eb3e4dfccfb011.

The previous commit caused the bug reported in issue #904 

I didn't feel totally confident with the fix, and should have heeded my own concerns. I don't want to try other fixes to that part of the code - it really needs a rewrite (but probably retaining some behaviour which is not obvious)

Since the original bug wasn't reported for 10 years, and it is not catastrophic, I suggest we live with it.
