### PR TITLE
Improve text fraction conversion

### DIFF
--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -1080,7 +1080,7 @@ sub fractionconvert {
         $start = $textwindow->search(
             '-regexp',
             '-count' => \$length,
-            '--', '-?\d+' . $anyslash . '\d+', $start, $finish
+            '--', '-?\d+' . $anyslash . '\d+(?!,\d)', $start, $finish    # Negative lookahead to avoid converting 1/2 in 1/2,000
         )
     ) {
         my $end        = "$start+${length}c";


### PR DESCRIPTION
Previously, `1/2,000` would be converted to `½,000`

Beefed up the regex to include a negative lookahead for `,\d` so conversion
will not be attempted in this case.

Fixes #913