### PR TITLE
Allow blocks to be marked as right or center aligned

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -98,7 +98,7 @@ use Guiguts::Utilities;
 use Guiguts::WordFrequency;
 
 ### Constants
-our $allblocktypes        = quotemeta '#$*FfIiLlPpXx';
+our $allblocktypes        = quotemeta '#$*FfIiLlPpXxCcRr';
 our $urlprojectpage       = 'https://www.pgdp.net/c/project.php?id=';
 our $urlprojectdiscussion = 'https://www.pgdp.net/c/tools/proofers/project_topic.php?project=';
 

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1835,25 +1835,37 @@ sub orphanedbrackets {
             -selectcolor => $::lglobal{checkcolor},
             -value       => '^\/[Xx]|[Xx]\/',
             -text        => '/X X/',
-        )->grid( -row => 2, -column => 1 );
+        )->grid( -row => 1, -column => 5 );
         $frame1->Radiobutton(
             -variable    => \$::lglobal{brsel},
             -selectcolor => $::lglobal{checkcolor},
             -value       => '^\/[Ff]|[Ff]\/',
             -text        => '/F F/',
-        )->grid( -row => 2, -column => 2 );
+        )->grid( -row => 2, -column => 1 );
         $frame1->Radiobutton(
             -variable    => \$::lglobal{brsel},
             -selectcolor => $::lglobal{checkcolor},
             -value       => '^\/[Ll]|[Ll]\/',
             -text        => '/L L/',
-        )->grid( -row => 2, -column => 3 );
+        )->grid( -row => 2, -column => 2 );
         $frame1->Radiobutton(
             -variable    => \$::lglobal{brsel},
             -selectcolor => $::lglobal{checkcolor},
             -value       => '^\/[Ii]|[Ii]\/',
             -text        => '/I I/',
+        )->grid( -row => 2, -column => 3 );
+        $frame1->Radiobutton(
+            -variable    => \$::lglobal{brsel},
+            -selectcolor => $::lglobal{checkcolor},
+            -value       => '^\/[Cc]|[Cc]\/',
+            -text        => '/C C/',
         )->grid( -row => 2, -column => 4 );
+        $frame1->Radiobutton(
+            -variable    => \$::lglobal{brsel},
+            -selectcolor => $::lglobal{checkcolor},
+            -value       => '^\/[Rr]|[Rr]\/',
+            -text        => '/R R/',
+        )->grid( -row => 2, -column => 5 );
         my $frame3 = $::lglobal{brkpop}->Frame->pack;
         $frame3->Radiobutton(
             -variable    => \$::lglobal{brsel},
@@ -2031,6 +2043,10 @@ sub orphanedbrackets {
                         && ( $::lglobal{brbrackets}[1] =~ m{^l/}i ) )
                     || (   ( $::lglobal{brbrackets}[0] =~ m{^/i}i )
                         && ( $::lglobal{brbrackets}[1] =~ m{^i/}i ) )
+                    || (   ( $::lglobal{brbrackets}[0] =~ m{^/c}i )
+                        && ( $::lglobal{brbrackets}[1] =~ m{^c/}i ) )
+                    || (   ( $::lglobal{brbrackets}[0] =~ m{^/r}i )
+                        && ( $::lglobal{brbrackets}[1] =~ m{^r/}i ) )
                   );
             }
             shift @{ $::lglobal{brbrackets} };


### PR DESCRIPTION
1. Add new `/c` and `/r` markup processing
2. In HTML, `/c` causes its lines to be centered using CSS class
3. In text `/c` cause its lines to be individually centered using spaces
4. In HTML `/r` causes the whole block to be right aligned, using CSS class, and
individual right-padding to maintain right alignments within the block
5. In text `/r` causes the whole block to move right, using spaces, until the longest line
touches the right margin
6. The new markups can be nested inside `/#` blockquote markup, since a key
use is for addresses, dates, signatures, etc. within correspondence
7. New markup added to the orphaned markup check dialog

Fixes #912