### PR TITLE
Remove "View in Browser" from HTML generation dialog

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -2392,14 +2392,6 @@ sub htmlgenpopup {
             -text    => 'Autogenerate HTML',
             -width   => 16
         )->grid( -row => 1, -column => 1, -padx => 5, -pady => 1 );
-        $f2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
-                ::runner( ::cmdinterp( $::extops[0]{command} ) );
-            },
-            -text  => 'View in Browser',
-            -width => 16,
-        )->grid( -row => 1, -column => 2, -padx => 5, -pady => 1 );
 
         ::initialize_popup_with_deletebinding('htmlgenpop');
     }


### PR DESCRIPTION
It is confusing to have "View in Browser" adjacent to "Autogenerate HTML"
because if autogenerate then immediately press "View in Browser", it doesn't
show the generated HTML since it hasn't been saved yet.

Since "View in Browser" is hardwired into the Custom Menu, there's no need
to have it in this dialog anyway.

Fixes #915