### PR TITLE
Remove `Find Next/Previous ... Block` entries from Search Menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - New `/R...R/` markup shifts block of lines to right margin (preserving
   indentation) during rewrapping and HTML generation
 - PPVimage checks against the new recommended cover image size (1600x2560)
+- `Find Next/Previous ... Block` entries removed from Search menu
 
 ### Bug Fixes
 

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -291,43 +291,6 @@ sub menu_search {
             -command => [ \&::find_proofer_comment, 'reverse' ]
         ],
         [ 'separator', '' ],
-        [
-            'command', 'Find Next /*..*/ Block', -command => [ \&::nextblock, 'default', 'forward' ]
-        ],
-        [
-            'command',
-            'Find Previous /*..*/ Block',
-            -command => [ \&::nextblock, 'default', 'reverse' ]
-        ],
-        [ 'command', 'Find Next /#..#/ Block', -command => [ \&::nextblock, 'block', 'forward' ] ],
-        [
-            'command',
-            'Find Previous /#..#/ Block',
-            -command => [ \&::nextblock, 'block', 'reverse' ]
-        ],
-        [ 'command', 'Find Next /$..$/ Block', -command => [ \&::nextblock, 'stet', 'forward' ] ],
-        [
-            'command',
-            'Find Previous /$..$/ Block',
-            -command => [ \&::nextblock, 'stet', 'reverse' ]
-        ],
-        [ 'command', 'Find Next /p..p/ Block', -command => [ \&::nextblock, 'poetry', 'forward' ] ],
-        [
-            'command',
-            'Find Previous /p..p/ Block',
-            -command => [ \&::nextblock, 'poetry', 'reverse' ]
-        ],
-        [
-            'command',
-            'Find Next Indented Block',
-            -command => [ \&::nextblock, 'indent', 'forward' ]
-        ],
-        [
-            'command',
-            'Find Previous Indented Block',
-            -command => [ \&::nextblock, 'indent', 'reverse' ]
-        ],
-        [ 'separator', '' ],
         [ 'command',   'Find ~Orphaned DP Markup...', -command => \&::orphanedmarkup ],
         [ 'command',   'Find ~Asterisks w/o Slash',   -command => \&::find_asterisks ],
         [ 'separator', '' ],

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -9,7 +9,7 @@ BEGIN {
     @EXPORT = qw(&update_sr_histories &searchtext &reg_check &getnextscanno &updatesearchlabels
       &isvalid &swapterms &findascanno &reghint &replace &replaceall
       &searchfromstartifnew &searchoptset &searchpopup &stealthscanno &find_proofer_comment
-      &find_asterisks &find_transliterations &nextblock &orphanedbrackets &orphanedmarkup &searchsize
+      &find_asterisks &find_transliterations &orphanedbrackets &orphanedmarkup &searchsize
       &loadscannos &replace_incr_counter &countmatches &setsearchpopgeometry &quickcount);
 }
 
@@ -1669,101 +1669,6 @@ sub find_transliterations {
     #} else {
     #	::operationadd('Found no more transliterations (\\[[^FIS\\d])');
     #}
-}
-
-sub nextblock {
-    my ( $mark, $direction ) = @_;
-    my $textwindow = $::textwindow;
-    my $top        = $::top;
-    unless ($::searchstartindex) { $::searchstartindex = '1.0' }
-
-    if ( $mark eq 'default' ) {
-        if ( $direction eq 'forward' ) {
-            $::searchstartindex =
-              $textwindow->search( '-exact', '--', '/*', $::searchstartindex, 'end' )
-              if $::searchstartindex;
-            ::operationadd('Found no more /*..*/ blocks')
-              unless $::searchstartindex;
-        } elsif ( $direction eq 'reverse' ) {
-            $::searchstartindex =
-              $textwindow->search( '-backwards', '-exact', '--', '/*', $::searchstartindex, '1.0' )
-              if $::searchstartindex;
-        }
-    } elsif ( $mark eq 'indent' ) {
-        if ( $direction eq 'forward' ) {
-            $::searchstartindex =
-              $textwindow->search( '-regexp', '--', '^\S', $::searchstartindex, 'end' )
-              if $::searchstartindex;
-            $::searchstartindex =
-              $textwindow->search( '-regexp', '--', '^\s', $::searchstartindex, 'end' )
-              if $::searchstartindex;
-            ::operationadd('Found no more indented blocks')
-              unless $::searchstartindex;
-        } elsif ( $direction eq 'reverse' ) {
-            $::searchstartindex =
-              $textwindow->search( '-backwards', '-regexp', '--', '^\S',
-                $::searchstartindex, '1.0' )
-              if $::searchstartindex;
-            $::searchstartindex =
-              $textwindow->search( '-backwards', '-regexp', '--', '^\s',
-                $::searchstartindex, '1.0' )
-              if $::searchstartindex;
-        }
-    } elsif ( $mark eq 'stet' ) {
-        if ( $direction eq 'forward' ) {
-            $::searchstartindex =
-              $textwindow->search( '-exact', '--', '/$', $::searchstartindex, 'end' )
-              if $::searchstartindex;
-            ::operationadd('Found no more /$..$/ blocks')
-              unless $::searchstartindex;
-        } elsif ( $direction eq 'reverse' ) {
-            $::searchstartindex =
-              $textwindow->search( '-backwards', '-exact', '--', '/$', $::searchstartindex, '1.0' )
-              if $::searchstartindex;
-        }
-    } elsif ( $mark eq 'block' ) {
-        if ( $direction eq 'forward' ) {
-            $::searchstartindex =
-              $textwindow->search( '-exact', '--', '/#', $::searchstartindex, 'end' )
-              if $::searchstartindex;
-            ::operationadd('Found no more /#..#/ blocks')
-              unless $::searchstartindex;
-        } elsif ( $direction eq 'reverse' ) {
-            $::searchstartindex =
-              $textwindow->search( '-backwards', '-exact', '--', '/#', $::searchstartindex, '1.0' )
-              if $::searchstartindex;
-        }
-    } elsif ( $mark eq 'poetry' ) {
-        if ( $direction eq 'forward' ) {
-            $::searchstartindex =
-              $textwindow->search( '-regexp', '--', '\/[pP]', $::searchstartindex, 'end' )
-              if $::searchstartindex;
-            ::operationadd('Found no more /p..p/ blocks')
-              unless $::searchstartindex;
-        } elsif ( $direction eq 'reverse' ) {
-            $::searchstartindex =
-              $textwindow->search( '-backwards', '-regexp', '--', '\/[pP]',
-                $::searchstartindex, '1.0' )
-              if $::searchstartindex;
-        }
-    }
-    $textwindow->markSet( 'insert', $::searchstartindex )
-      if $::searchstartindex;
-    if ($::searchstartindex) {
-        $textwindow->see('end');
-        $textwindow->see($::searchstartindex);
-    }
-    $textwindow->update;
-    $textwindow->focus;
-    if ( $direction eq 'forward' ) {
-        $::searchstartindex += 1;
-    } elsif ( $direction eq 'reverse' ) {
-        $::searchstartindex -= 1;
-    }
-    if ( $::searchstartindex = int($::searchstartindex) ) {
-        $::searchstartindex .= '.0';
-    }
-    ::update_indicators();
 }
 
 sub orphanedbrackets {


### PR DESCRIPTION
There are too many block types to justify having them all in the menu.
There were 6 types missing from the menu anyway.
In addition, it is trivial to do the same search manually, e.g. Search for "/#"