### PR TITLE
Convert line endings to native form in WF comma check

### DIFF
--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -1392,11 +1392,12 @@ sub slurpfile {
     my $wholefile;
     ::savefile() unless ( $textwindow->numberChanges == 0 );
     {
-        local $/;    # slurp in the file
+        local $/;                               # slurp in the file
         open my $fh, '<', $filename;
         $wholefile = <$fh>;
         close $fh;
         utf8::decode($wholefile);
+        $wholefile =~ s/\cM\cJ|\cM|\cJ/\n/g;    # Need to convert line endings to suitable one for this platform
     }
     $wholefile =~ s/-----*\s?File:\s?\S+\.(png|jpg)---.*\r?\n?//g;
     return $wholefile;


### PR DESCRIPTION
Word Frequency has its own mini load file routine, which doesn't convert
line endings, unlike the main load file in `TextUnicode.pm`.
Since #895 changed the saved line endings under Linux/Mac, it broke this
file load, stopping WF from locating in the text file the "comma, Uppercase"
errors it detected.

Fixes #935