### PR TITLE
Fix opening of scratchpad.txt

### DIFF
--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -229,20 +229,6 @@ sub keybindings {
     keybind( '<Alt-Left>',  sub { ::indent( $textwindow, 'out' ); } );
     keybind( '<Alt-Right>', sub { ::indent( $textwindow, 'in' ); } );
 
-    # Scratchpad
-    keybind(
-        '<Control-Alt-s>',
-        sub {
-            my $rcmd = $::OS_WIN ? 'start' : $::OS_MAC ? 'open' : '';
-            return unless $rcmd;
-            unless ( -e 'scratchpad.txt' ) {
-                open my $fh, '>', 'scratchpad.txt'
-                  or warn "Could not create file $!";
-            }
-            ::runner( ::cmdinterp("$rcmd scratchpad.txt") );
-        }
-    );
-
     # Help
     keybind( '<Control-Alt-r>', sub { ::display_manual("regexref"); } );
 

--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -233,12 +233,13 @@ sub keybindings {
     keybind(
         '<Control-Alt-s>',
         sub {
+            my $rcmd = $::OS_WIN ? 'start' : $::OS_MAC ? 'open' : '';
+            return unless $rcmd;
             unless ( -e 'scratchpad.txt' ) {
                 open my $fh, '>', 'scratchpad.txt'
                   or warn "Could not create file $!";
             }
-            ::runner('start scratchpad.txt') if $::OS_WIN;
-            ::runner('open scratchpad.txt')  if $::OS_MAC;
+            ::runner( ::cmdinterp("$rcmd scratchpad.txt") );
         }
     );
 


### PR DESCRIPTION
Ctrl-Alt-s should open a scratchpad.txt file on Windows/Mac systems.
It hasn't worked since at least GG 1.0.25. No idea if anyone used to use
it, or would use it now, but anyhow...

Fix it by calling the cmdinterp routine that escapes commands, etc. before
they are sent to the OS.

Fixes #938