### PR TITLE
Add Combining Characters to Compose Key Sequences

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -121,6 +121,7 @@ our $charsuitewfhighlight = 0;                  # Don't do charsuite availabilit
 our $composepopbinding    = 'Alt_R';            # Default key to pop the Compose dialog (Right hand Alt key, also labelled AltGr)
 $composepopbinding = 'Control-m' if $OS_MAC;    # Default to Ctrl+m on a Mac - Alt+RightArrow does the same indent operation
 our %composehash;                               # Keystrokes to insert character
+our %composehelp;                               # Optional help text to identify character
 our $cssvalidationlevel  = 'css3';              # CSS level checked by validator (css3 or css21)
 our $defaultindent       = 2;
 our $epubpercentoverride = 1;                   # True = override % img widths to 100% for epubs

--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -693,7 +693,7 @@ sub composekeyaction {
     my $str    = $::lglobal{composepopstr};    # Get string typed so far in dialog
 
     if ( $::composehash{$str} ) {              # Does it match one of the defined compose sequences?
-        insertit( substr( $::composehash{$str}, 0, 1 ) );    # First character only - remainder is optional help text
+        insertit( $::composehash{$str} );
         ::killpopup('composepop');
     } elsif ( $str =~ s/^(([\\0]?x)|U\+)?([0-9a-f]{4})$/$3/i ) {    # or 4 digit hex, (optional \x, 0x, x or U+)
         insertit( chr( hex($str) ) );
@@ -706,7 +706,7 @@ sub composekeyaction {
         } else {
             my $term = "\n";
             if ( $::composehash{ $str . $term } ) {                                      # Is it a string with a forced terminator, e.g. Greek betacode
-                insertit( substr( $::composehash{ $str . $term }, 0, 1 ) );              # First character only - remainder is optional help text
+                insertit( $::composehash{ $str . $term } );
             } else {
                 insertit($str);                                                          # just insert the string as it is
             }
@@ -746,78 +746,97 @@ sub composeinitialize {
     composeinitaccent( 'Ñ',       'ñ',      'N', '~' );
     composeinitaccent( "\x{178}", 'ÿ',      'Y', '"',  ':' );
     composeinitaccent( 'Ý',       'ý',      'Y', '\'', '/' );
-    composeinitaccent( "\x{A3}",  "\x{A3}", 'L', '/',  '\\' );                # pound
-    composeinitaccent( "\x{A2}",  "\x{A2}", 'C', '/',  '|' );                 # cent
-    composeinitchars( "\x{BD}",   '1/2' );                                    # 1/2
-    composeinitchars( "\x{2153}", '1/3' );                                    # 1/3
-    composeinitchars( "\x{2154}", '2/3' );                                    # 1/3
-    composeinitchars( "\x{BC}",   '1/4' );                                    # 1/4
-    composeinitchars( "\x{BE}",   '3/4' );                                    # 3/4
-    composeinitchars( "\x{2155}", '1/5' );                                    # 1/5
-    composeinitchars( "\x{2156}", '2/5' );                                    # 2/5
-    composeinitchars( "\x{2157}", '3/5' );                                    # 3/5
-    composeinitchars( "\x{2158}", '4/5' );                                    # 4/5
-    composeinitchars( "\x{2159}", '1/6' );                                    # 1/6
-    composeinitchars( "\x{215A}", '5/6' );                                    # 5/6
-    composeinitchars( "\x{2150}", '1/7' );                                    # 1/7
-    composeinitchars( "\x{215B}", '1/8' );                                    # 1/8
-    composeinitchars( "\x{215C}", '3/8' );                                    # 3/8
-    composeinitchars( "\x{215D}", '5/8' );                                    # 5/8
-    composeinitchars( "\x{215E}", '7/8' );                                    # 7/8
-    composeinitchars( "\x{2151}", '1/9' );                                    # 1/9
-    composeinitsyms( "\x{A1}",                    '!',  '!' );                # inverted !
-    composeinitsyms( "\x{BF}",                    '?',  '?' );                # inverted ?
-    composeinitsyms( "\x{AB}",                    '<',  '<' );                # left angle quotes
-    composeinitsyms( "\x{BB}",                    '>',  '>' );                # right angle quotes
-    composeinitsyms( "\x{2018}",                  '\'', '<', '\'', '6' );     # left single quote
-    composeinitsyms( "\x{2019}",                  '\'', '>', '\'', '9' );     # right single quote
-    composeinitsyms( "\x{201C}",                  '"',  '<', '"',  '6' );     # left double quote
-    composeinitsyms( "\x{201D}",                  '"',  '>', '"',  '9' );     # right double quote
-    composeinitsyms( "\x{201A}",                  '\'', ',' );                # low single quote
-    composeinitsyms( "\x{201B}",                  '\'', '^' );                # high reversed single quote
-    composeinitsyms( "\x{201E}",                  '"',  ',' );                # low double quote
-    composeinitsyms( "\x{201F}",                  '"',  '^' );                # high reversed double quote
-    composeinitsyms( "\x{B1}",                    '*',  '+' );                # plus/minus
-    composeinitsyms( "\x{B7} Middle dot",         '.',  '^', '*', '.' );      # middle dot
-    composeinitsyms( "\x{D7}",                    'x',  'x', '*', 'x' );      # multiplication
-    composeinitsyms( "\x{F7}",                    ':',  '-' );                # division
-    composeinitsyms( "\x{B0} Degree",             'o',  'o',  '*', 'o' );     # degree
-    composeinitsyms( "\x{2032}",                  '*',  '\'', '1', '\'' );    # single prime
-    composeinitsyms( "\x{2033}",                  '*',  '"',  '2', '\'' );    # double prime
-    composeinitsyms( "\x{2034}",                  '3',  '\'' );               # triple prime
-    composeinitsyms( "\x{2030}",                  '%',  '0', '%', 'o' );      # per mille
-    composeinitsyms( "\x{B9}",                    '^',  '1' );                # superscript 1
-    composeinitsyms( "\x{B2}",                    '^',  '2' );                # superscript 2
-    composeinitsyms( "\x{B3}",                    '^',  '3' );                # superscript 3
-    composeinitsyms( "\x{A0} Non-breaking space", ' ',  ' ', '*', ' ' );      # non-breaking space
-    composeinitsyms( "\x{2014} Emdash",           '-',  '-' );                # emdash
-    composeinitsyms( "\x{2013} Endash",           '-',  ' ' );                # endash
-    composeinitsyms( "\x{2042}",                  '*',  '*' );                # asterism
-    composeinitsyms( "\x{BA} Masculine ordinal",  'o',  '_' );                # masculine ordinal
-    composeinitsyms( "\x{AA} Feminine ordinal",   'a',  '_' );                # feminine ordinal
-    composeinitsyms( "\x{2016}",                  '|',  '|' );                # double vertical line
-    composeinitcombining( "\x{0300} Combining grave",      '\\', '`' );       # combining grave
-    composeinitcombining( "\x{0301} Combining acute",      '/',  '\'' );      # combining acute
-    composeinitcombining( "\x{0302} Combining circumflex", '^' );             # combining circumflex
-    composeinitcombining( "\x{0303} Combining tilde",      '~' );             # combining tilde
-    composeinitcombining( "\x{0304} Combining macron",     '-' );             # combining macron
-    composeinitcombining( "\x{0306} Combining breve",      'b' );             # combining breve
-    composeinitcombining( "\x{0307} Combining dot above",  '.' );             # combining dot above
-    composeinitcombining( "\x{0308} Combining diaresis",   ':', '"' );        # combining diaresis
-    composeinitcombining( "\x{0309} Combining hook above", '?' );             # combining hook above
-    composeinitcombining( "\x{030a} Combining ring above", 'o' );             # combining ring above
-    composeinitcombining( "\x{030c} Combining caron",      'c' );             # combining caron
-    composeinitcombining( "\x{0328} Combining ogonek",     ',' );             # combining ogonek
-    composeinitcase( 'Æ',        'æ',        'AE' );                          # ae ligature
-    composeinitcase( "\x{152}",  "\x{153}",  'OE' );                          # oe ligature
-    composeinitcase( "\x{1E9E}", 'ß',        'SS' );                          # eszett
-    composeinitcase( 'Ð',        'ð',        'DH', 'ETH' );                   # eth
-    composeinitcase( 'þ',        'Þ',        'TH' );                          # thorn
-    composeinitcase( "\x{A9}",   "\x{A9}",   'CO', '(C)' );                   # copyright
-    composeinitcase( "\x{2020}", "\x{2020}", 'DAG' );                         # dagger
-    composeinitcase( "\x{2021}", "\x{2021}", 'DDAG' );                        # double dagger
-    composeinitcase( "\x{A7}",   "\x{A7}",   'SEC', 'S*', '*S' );             # section
-    composeinitcase( "\x{B6}",   "\x{B6}",   'PIL', 'P*', '*P' );             # pilcrow
+    composeinitaccent( "\x{A3}",  "\x{A3}", 'L', '/',  '\\' );          # pound
+    composeinitaccent( "\x{A2}",  "\x{A2}", 'C', '/',  '|' );           # cent
+    composeinitchars( "\x{BD}",   '1/2' );                              # 1/2
+    composeinitchars( "\x{2153}", '1/3' );                              # 1/3
+    composeinitchars( "\x{2154}", '2/3' );                              # 1/3
+    composeinitchars( "\x{BC}",   '1/4' );                              # 1/4
+    composeinitchars( "\x{BE}",   '3/4' );                              # 3/4
+    composeinitchars( "\x{2155}", '1/5' );                              # 1/5
+    composeinitchars( "\x{2156}", '2/5' );                              # 2/5
+    composeinitchars( "\x{2157}", '3/5' );                              # 3/5
+    composeinitchars( "\x{2158}", '4/5' );                              # 4/5
+    composeinitchars( "\x{2159}", '1/6' );                              # 1/6
+    composeinitchars( "\x{215A}", '5/6' );                              # 5/6
+    composeinitchars( "\x{2150}", '1/7' );                              # 1/7
+    composeinitchars( "\x{215B}", '1/8' );                              # 1/8
+    composeinitchars( "\x{215C}", '3/8' );                              # 3/8
+    composeinitchars( "\x{215D}", '5/8' );                              # 5/8
+    composeinitchars( "\x{215E}", '7/8' );                              # 7/8
+    composeinitchars( "\x{2151}", '1/9' );                              # 1/9
+    composeinitsyms( "\x{A1}",   '!',  '!' );                           # inverted !
+    composeinitsyms( "\x{BF}",   '?',  '?' );                           # inverted ?
+    composeinitsyms( "\x{AB}",   '<',  '<' );                           # left angle quotes
+    composeinitsyms( "\x{BB}",   '>',  '>' );                           # right angle quotes
+    composeinitsyms( "\x{2018}", '\'', '<', '\'', '6' );                # left single quote
+    composeinitsyms( "\x{2019}", '\'', '>', '\'', '9' );                # right single quote
+    composeinitsyms( "\x{201C}", '"',  '<', '"',  '6' );                # left double quote
+    composeinitsyms( "\x{201D}", '"',  '>', '"',  '9' );                # right double quote
+    composeinitsyms( "\x{201A}", '\'', ',' );                           # low single quote
+    composeinitsyms( "\x{201B}", '\'', '^' );                           # high reversed single quote
+    composeinitsyms( "\x{201E}", '"',  ',' );                           # low double quote
+    composeinitsyms( "\x{201F}", '"',  '^' );                           # high reversed double quote
+    composeinitsyms( "\x{B1}",   '*',  '+' );                           # plus/minus
+    composeinitsyms( "\x{B7}",   '.',  '^', '*', '.' );                 # middle dot
+    composeinithelp( "\x{B7}", "Middle dot" );
+    composeinitsyms( "\x{D7}", 'x', 'x', '*', 'x' );                    # multiplication
+    composeinitsyms( "\x{F7}", ':', '-' );                              # division
+    composeinitsyms( "\x{B0}", 'o', 'o', '*', 'o' );                    # degree
+    composeinithelp( "\x{B0}", "Degree" );
+    composeinitsyms( "\x{2032}", '*', '\'', '1', '\'' );                # single prime
+    composeinitsyms( "\x{2033}", '*', '"',  '2', '\'' );                # double prime
+    composeinitsyms( "\x{2034}", '3', '\'' );                           # triple prime
+    composeinitsyms( "\x{2030}", '%', '0', '%', 'o' );                  # per mille
+    composeinitsyms( "\x{B9}",   '^', '1' );                            # superscript 1
+    composeinitsyms( "\x{B2}",   '^', '2' );                            # superscript 2
+    composeinitsyms( "\x{B3}",   '^', '3' );                            # superscript 3
+    composeinitsyms( "\x{A0}",   ' ', ' ', '*', ' ' );                  # non-breaking space
+    composeinithelp( "\x{A0}", "Non-breaking space" );
+    composeinitsyms( "\x{2014}", '-', '-' );                            # emdash
+    composeinithelp( "\x{2014}", "Emdash" );
+    composeinitsyms( "\x{2013}", '-', ' ' );                            # endash
+    composeinithelp( "\x{2013}", "Endash" );
+    composeinitsyms( "\x{2042}", '*', '*' );                            # asterism
+    composeinitsyms( "\x{BA}",   'o', '_' );                            # masculine ordinal
+    composeinithelp( "\x{BA}", "Masculine ordinal" );
+    composeinitsyms( "\x{AA}", 'a', '_' );                              # feminine ordinal
+    composeinithelp( "\x{AA}", "Feminine ordinal" );
+    composeinitsyms( "\x{2016}", '|', '|' );                            # double vertical line
+    composeinitcombining( "\x{0300}", '\\', '`' );                      # combining grave
+    composeinithelp( "\x{0300}", "Combining grave" );
+    composeinitcombining( "\x{0301}", '/', '\'' );                      # combining acute
+    composeinithelp( "\x{0301}", "Combining acute" );
+    composeinitcombining( "\x{0302}", '^' );                            # combining circumflex
+    composeinithelp( "\x{0302}", "Combining circumflex" );
+    composeinitcombining( "\x{0303}", '~' );                            # combining tilde
+    composeinithelp( "\x{0303}", "Combining tilde" );
+    composeinitcombining( "\x{0304}", '-' );                            # combining macron
+    composeinithelp( "\x{0304}", "Combining macron" );
+    composeinitcombining( "\x{0306}", 'b' );                            # combining breve
+    composeinithelp( "\x{0306}", "Combining breve" );
+    composeinitcombining( "\x{0307}", '.' );                            # combining dot above
+    composeinithelp( "\x{0307}", "Combining dot above" );
+    composeinitcombining( "\x{0308}", ':', '"' );                       # combining diaresis
+    composeinithelp( "\x{0308}", "Combining diaresis" );
+    composeinitcombining( "\x{0309}", '?' );                            # combining hook above
+    composeinithelp( "\x{0309}", "Combining hook above" );
+    composeinitcombining( "\x{030a}", 'o' );                            # combining ring above
+    composeinithelp( "\x{030a}", "Combining ring above" );
+    composeinitcombining( "\x{030c}", 'c' );                            # combining caron
+    composeinithelp( "\x{030c}", "Combining caron" );
+    composeinitcombining( "\x{0328}", ',' );                            # combining ogonek
+    composeinithelp( "\x{0328}", "Combining ogonek" );
+    composeinitcase( 'Æ',        'æ',        'AE' );                    # ae ligature
+    composeinitcase( "\x{152}",  "\x{153}",  'OE' );                    # oe ligature
+    composeinitcase( "\x{1E9E}", 'ß',        'SS' );                    # eszett
+    composeinitcase( 'Ð',        'ð',        'DH', 'ETH' );             # eth
+    composeinitcase( 'þ',        'Þ',        'TH' );                    # thorn
+    composeinitcase( "\x{A9}",   "\x{A9}",   'CO', '(C)' );             # copyright
+    composeinitcase( "\x{2020}", "\x{2020}", 'DAG' );                   # dagger
+    composeinitcase( "\x{2021}", "\x{2021}", 'DDAG' );                  # double dagger
+    composeinitcase( "\x{A7}",   "\x{A7}",   'SEC', 'S*', '*S' );       # section
+    composeinitcase( "\x{B6}",   "\x{B6}",   'PIL', 'P*', '*P' );       # pilcrow
     composegreekalphabet( "\x{391}", "\x{3b1}", 'ABGDEZHQIKLMNXOPRJSTUFCYW' );
     composegreekaccent( "\x{1FBA}", "\x{1F70}", 'A' );
     composegreekaccent( "\x{1FC8}", "\x{1F72}", 'E' );
@@ -839,10 +858,10 @@ sub composeinitialize {
     composegreekbreathing( "\x{1F80}", 'A', 'iota' );
     composegreekbreathing( "\x{1F90}", 'H', 'iota' );
     composegreekbreathing( "\x{1FA0}", 'W', 'iota' );
-    my $term = "\n";                                                          # Sequences require terminating with Enter/OK if betacode ordering is used
+    my $term = "\n";                                                    # Sequences require terminating with Enter/OK if betacode ordering is used
     $::composehash{"=)r"} = $::composehash{"-r)$term"} = "\x{1FE4}";
     $::composehash{"=(r"} = $::composehash{"-r($term"} = "\x{1FE5}";
-    $::composehash{"=(R"} = $::composehash{"-R($term"} = "\x{1FEC}";          # No smooth breathing upper case rho
+    $::composehash{"=(R"} = $::composehash{"-R($term"} = "\x{1FEC}";    # No smooth breathing upper case rho
 }
 
 #
@@ -900,7 +919,7 @@ sub composeinitchars {
 }
 
 #
-# Add compose sequences for characters made of 2 or more symbols
+# Add compose sequences for characters made of 2
 # First argument is character to create
 # Second and subsequent pairs of arguments are keystrokes in either order
 # E.g. given left double quotes, '"', '<', '"', '6', it will create
@@ -1018,6 +1037,14 @@ sub composegreekbreathing {
 }
 
 #
+# Store optional help text to identify the character
+sub composeinithelp {
+    my $char = shift;
+    my $help = shift;
+    $::composehelp{$char} = $help;
+}
+
+#
 # Display list of compose sequences
 sub composeref {
     my $top = $::top;
@@ -1043,11 +1070,11 @@ sub composeref {
         ::drag($comtext);
         for my $key ( sort composesort keys %::composehash ) {
             my $display = $key;
-            $display =~ s/\n/ OK\/Enter/;                                      # Some sequences require OK/Enter
-            my $chr = substr( $::composehash{$key}, 0, 1 );                    # First char is inserted character
-            $chr = ' ' . $chr if $chr ge "\x{0300}" and $chr le "\x{036f}";    # Output space before combining characters
-            $comtext->insert( 'end',
-                "$chr <= $display" . substr( $::composehash{$key}, 1 ) . "\n" );    # Add optional help text at the end
+            $display =~ s/\n/ OK\/Enter/;                                             # Some sequences require OK/Enter
+            my $chr  = $::composehash{$key};
+            my $help = $::composehelp{$chr} ? "  " . $::composehelp{$chr} : "";
+            $chr = "\x{25cc}" . $chr if $chr ge "\x{0300}" and $chr le "\x{036f}";    # Output dotted circle before combining characters
+            $comtext->insert( 'end', "$chr <= $display" . $help . "\n" );             # Add optional help text at the end
         }
     }
 }

--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -693,7 +693,7 @@ sub composekeyaction {
     my $str    = $::lglobal{composepopstr};    # Get string typed so far in dialog
 
     if ( $::composehash{$str} ) {              # Does it match one of the defined compose sequences?
-        insertit( $::composehash{$str} );
+        insertit( substr( $::composehash{$str}, 0, 1 ) );    # First character only - remainder is optional help text
         ::killpopup('composepop');
     } elsif ( $str =~ s/^(([\\0]?x)|U\+)?([0-9a-f]{4})$/$3/i ) {    # or 4 digit hex, (optional \x, 0x, x or U+)
         insertit( chr( hex($str) ) );
@@ -706,7 +706,7 @@ sub composekeyaction {
         } else {
             my $term = "\n";
             if ( $::composehash{ $str . $term } ) {                                      # Is it a string with a forced terminator, e.g. Greek betacode
-                insertit( $::composehash{ $str . $term } );
+                insertit( substr( $::composehash{ $str . $term }, 0, 1 ) );              # First character only - remainder is optional help text
             } else {
                 insertit($str);                                                          # just insert the string as it is
             }
@@ -746,66 +746,78 @@ sub composeinitialize {
     composeinitaccent( 'Ñ',       'ñ',      'N', '~' );
     composeinitaccent( "\x{178}", 'ÿ',      'Y', '"',  ':' );
     composeinitaccent( 'Ý',       'ý',      'Y', '\'', '/' );
-    composeinitaccent( "\x{A3}",  "\x{A3}", 'L', '/',  '\\' );          # pound
-    composeinitaccent( "\x{A2}",  "\x{A2}", 'C', '/',  '|' );           # cent
-    composeinitchars( "\x{BD}",   '1/2' );                              # 1/2
-    composeinitchars( "\x{2153}", '1/3' );                              # 1/3
-    composeinitchars( "\x{2154}", '2/3' );                              # 1/3
-    composeinitchars( "\x{BC}",   '1/4' );                              # 1/4
-    composeinitchars( "\x{BE}",   '3/4' );                              # 3/4
-    composeinitchars( "\x{2155}", '1/5' );                              # 1/5
-    composeinitchars( "\x{2156}", '2/5' );                              # 2/5
-    composeinitchars( "\x{2157}", '3/5' );                              # 3/5
-    composeinitchars( "\x{2158}", '4/5' );                              # 4/5
-    composeinitchars( "\x{2159}", '1/6' );                              # 1/6
-    composeinitchars( "\x{215A}", '5/6' );                              # 5/6
-    composeinitchars( "\x{2150}", '1/7' );                              # 1/7
-    composeinitchars( "\x{215B}", '1/8' );                              # 1/8
-    composeinitchars( "\x{215C}", '3/8' );                              # 3/8
-    composeinitchars( "\x{215D}", '5/8' );                              # 5/8
-    composeinitchars( "\x{215E}", '7/8' );                              # 7/8
-    composeinitchars( "\x{2151}", '1/9' );                              # 1/9
-    composeinitsyms( "\x{A1}",   '!',  '!' );                           # inverted !
-    composeinitsyms( "\x{BF}",   '?',  '?' );                           # inverted ?
-    composeinitsyms( "\x{AB}",   '<',  '<' );                           # left angle quotes
-    composeinitsyms( "\x{BB}",   '>',  '>' );                           # right angle quotes
-    composeinitsyms( "\x{2018}", '\'', '<', '\'', '6' );                # left single quote
-    composeinitsyms( "\x{2019}", '\'', '>', '\'', '9' );                # right single quote
-    composeinitsyms( "\x{201C}", '"',  '<', '"',  '6' );                # left double quote
-    composeinitsyms( "\x{201D}", '"',  '>', '"',  '9' );                # right double quote
-    composeinitsyms( "\x{201A}", '\'', ',' );                           # low single quote
-    composeinitsyms( "\x{201B}", '\'', '^' );                           # high reversed single quote
-    composeinitsyms( "\x{201E}", '"',  ',' );                           # low double quote
-    composeinitsyms( "\x{201F}", '"',  '^' );                           # high reversed double quote
-    composeinitsyms( "\x{B1}",   '+',  '-' );                           # plus/minus
-    composeinitsyms( "\x{B7}",   '.',  '^', '*', '.' );                 # middle dot
-    composeinitsyms( "\x{D7}",   'x',  'x', '*', 'x' );                 # multiplication
-    composeinitsyms( "\x{F7}",   ':',  '-' );                           # division
-    composeinitsyms( "\x{B0}",   'o',  'o',  '*', 'o' );                # degree
-    composeinitsyms( "\x{2032}", '*',  '\'', '1', '\'' );               # single prime
-    composeinitsyms( "\x{2033}", '*',  '"',  '2', '\'' );               # double prime
-    composeinitsyms( "\x{2034}", '3',  '\'' );                          # triple prime
-    composeinitsyms( "\x{2030}", '%',  '0', '%', 'o' );                 # per mille
-    composeinitsyms( "\x{B9}",   '^',  '1' );                           # superscript 1
-    composeinitsyms( "\x{B2}",   '^',  '2' );                           # superscript 2
-    composeinitsyms( "\x{B3}",   '^',  '3' );                           # superscript 3
-    composeinitsyms( "\x{A0}",   ' ',  ' ', '*', ' ' );                 # non-breaking space
-    composeinitsyms( "\x{2014}", '-',  '-' );                           # emdash
-    composeinitsyms( "\x{2013}", '-',  ' ' );                           # endash
-    composeinitsyms( "\x{2042}", '*',  '*' );                           # asterism
-    composeinitsyms( "\x{BA}",   'o',  '_' );                           # masculine ordinal
-    composeinitsyms( "\x{AA}",   'a',  '_' );                           # feminine ordinal
-    composeinitsyms( "\x{2016}", '|',  '|' );                           # double vertical line
-    composeinitcase( 'Æ',        'æ',        'AE' );                    # ae ligature
-    composeinitcase( "\x{152}",  "\x{153}",  'OE' );                    # oe ligature
-    composeinitcase( "\x{1E9E}", 'ß',        'SS' );                    # eszett
-    composeinitcase( 'Ð',        'ð',        'DH', 'ETH' );             # eth
-    composeinitcase( 'þ',        'Þ',        'TH' );                    # thorn
-    composeinitcase( "\x{A9}",   "\x{A9}",   'CO', '(C)' );             # copyright
-    composeinitcase( "\x{2020}", "\x{2020}", 'DAG' );                   # dagger
-    composeinitcase( "\x{2021}", "\x{2021}", 'DDAG' );                  # double dagger
-    composeinitcase( "\x{A7}",   "\x{A7}",   'SEC', 'S*', '*S' );       # section
-    composeinitcase( "\x{B6}",   "\x{B6}",   'PIL', 'P*', '*P' );       # pilcrow
+    composeinitaccent( "\x{A3}",  "\x{A3}", 'L', '/',  '\\' );                # pound
+    composeinitaccent( "\x{A2}",  "\x{A2}", 'C', '/',  '|' );                 # cent
+    composeinitchars( "\x{BD}",   '1/2' );                                    # 1/2
+    composeinitchars( "\x{2153}", '1/3' );                                    # 1/3
+    composeinitchars( "\x{2154}", '2/3' );                                    # 1/3
+    composeinitchars( "\x{BC}",   '1/4' );                                    # 1/4
+    composeinitchars( "\x{BE}",   '3/4' );                                    # 3/4
+    composeinitchars( "\x{2155}", '1/5' );                                    # 1/5
+    composeinitchars( "\x{2156}", '2/5' );                                    # 2/5
+    composeinitchars( "\x{2157}", '3/5' );                                    # 3/5
+    composeinitchars( "\x{2158}", '4/5' );                                    # 4/5
+    composeinitchars( "\x{2159}", '1/6' );                                    # 1/6
+    composeinitchars( "\x{215A}", '5/6' );                                    # 5/6
+    composeinitchars( "\x{2150}", '1/7' );                                    # 1/7
+    composeinitchars( "\x{215B}", '1/8' );                                    # 1/8
+    composeinitchars( "\x{215C}", '3/8' );                                    # 3/8
+    composeinitchars( "\x{215D}", '5/8' );                                    # 5/8
+    composeinitchars( "\x{215E}", '7/8' );                                    # 7/8
+    composeinitchars( "\x{2151}", '1/9' );                                    # 1/9
+    composeinitsyms( "\x{A1}",                    '!',  '!' );                # inverted !
+    composeinitsyms( "\x{BF}",                    '?',  '?' );                # inverted ?
+    composeinitsyms( "\x{AB}",                    '<',  '<' );                # left angle quotes
+    composeinitsyms( "\x{BB}",                    '>',  '>' );                # right angle quotes
+    composeinitsyms( "\x{2018}",                  '\'', '<', '\'', '6' );     # left single quote
+    composeinitsyms( "\x{2019}",                  '\'', '>', '\'', '9' );     # right single quote
+    composeinitsyms( "\x{201C}",                  '"',  '<', '"',  '6' );     # left double quote
+    composeinitsyms( "\x{201D}",                  '"',  '>', '"',  '9' );     # right double quote
+    composeinitsyms( "\x{201A}",                  '\'', ',' );                # low single quote
+    composeinitsyms( "\x{201B}",                  '\'', '^' );                # high reversed single quote
+    composeinitsyms( "\x{201E}",                  '"',  ',' );                # low double quote
+    composeinitsyms( "\x{201F}",                  '"',  '^' );                # high reversed double quote
+    composeinitsyms( "\x{B1}",                    '*',  '+' );                # plus/minus
+    composeinitsyms( "\x{B7} Middle dot",         '.',  '^', '*', '.' );      # middle dot
+    composeinitsyms( "\x{D7}",                    'x',  'x', '*', 'x' );      # multiplication
+    composeinitsyms( "\x{F7}",                    ':',  '-' );                # division
+    composeinitsyms( "\x{B0} Degree",             'o',  'o',  '*', 'o' );     # degree
+    composeinitsyms( "\x{2032}",                  '*',  '\'', '1', '\'' );    # single prime
+    composeinitsyms( "\x{2033}",                  '*',  '"',  '2', '\'' );    # double prime
+    composeinitsyms( "\x{2034}",                  '3',  '\'' );               # triple prime
+    composeinitsyms( "\x{2030}",                  '%',  '0', '%', 'o' );      # per mille
+    composeinitsyms( "\x{B9}",                    '^',  '1' );                # superscript 1
+    composeinitsyms( "\x{B2}",                    '^',  '2' );                # superscript 2
+    composeinitsyms( "\x{B3}",                    '^',  '3' );                # superscript 3
+    composeinitsyms( "\x{A0} Non-breaking space", ' ',  ' ', '*', ' ' );      # non-breaking space
+    composeinitsyms( "\x{2014} Emdash",           '-',  '-' );                # emdash
+    composeinitsyms( "\x{2013} Endash",           '-',  ' ' );                # endash
+    composeinitsyms( "\x{2042}",                  '*',  '*' );                # asterism
+    composeinitsyms( "\x{BA} Masculine ordinal",  'o',  '_' );                # masculine ordinal
+    composeinitsyms( "\x{AA} Feminine ordinal",   'a',  '_' );                # feminine ordinal
+    composeinitsyms( "\x{2016}",                  '|',  '|' );                # double vertical line
+    composeinitcombining( "\x{0300} Combining grave",      '\\', '`' );       # combining grave
+    composeinitcombining( "\x{0301} Combining acute",      '/',  '\'' );      # combining acute
+    composeinitcombining( "\x{0302} Combining circumflex", '^' );             # combining circumflex
+    composeinitcombining( "\x{0303} Combining tilde",      '~' );             # combining tilde
+    composeinitcombining( "\x{0304} Combining macron",     '-' );             # combining macron
+    composeinitcombining( "\x{0306} Combining breve",      'b' );             # combining breve
+    composeinitcombining( "\x{0307} Combining dot above",  '.' );             # combining dot above
+    composeinitcombining( "\x{0308} Combining diaresis",   ':', '"' );        # combining diaresis
+    composeinitcombining( "\x{0309} Combining hook above", '?' );             # combining hook above
+    composeinitcombining( "\x{030a} Combining ring above", 'o' );             # combining ring above
+    composeinitcombining( "\x{030c} Combining caron",      'c' );             # combining caron
+    composeinitcombining( "\x{0328} Combining ogonek",     ',' );             # combining ogonek
+    composeinitcase( 'Æ',        'æ',        'AE' );                          # ae ligature
+    composeinitcase( "\x{152}",  "\x{153}",  'OE' );                          # oe ligature
+    composeinitcase( "\x{1E9E}", 'ß',        'SS' );                          # eszett
+    composeinitcase( 'Ð',        'ð',        'DH', 'ETH' );                   # eth
+    composeinitcase( 'þ',        'Þ',        'TH' );                          # thorn
+    composeinitcase( "\x{A9}",   "\x{A9}",   'CO', '(C)' );                   # copyright
+    composeinitcase( "\x{2020}", "\x{2020}", 'DAG' );                         # dagger
+    composeinitcase( "\x{2021}", "\x{2021}", 'DDAG' );                        # double dagger
+    composeinitcase( "\x{A7}",   "\x{A7}",   'SEC', 'S*', '*S' );             # section
+    composeinitcase( "\x{B6}",   "\x{B6}",   'PIL', 'P*', '*P' );             # pilcrow
     composegreekalphabet( "\x{391}", "\x{3b1}", 'ABGDEZHQIKLMNXOPRJSTUFCYW' );
     composegreekaccent( "\x{1FBA}", "\x{1F70}", 'A' );
     composegreekaccent( "\x{1FC8}", "\x{1F72}", 'E' );
@@ -827,10 +839,10 @@ sub composeinitialize {
     composegreekbreathing( "\x{1F80}", 'A', 'iota' );
     composegreekbreathing( "\x{1F90}", 'H', 'iota' );
     composegreekbreathing( "\x{1FA0}", 'W', 'iota' );
-    my $term = "\n";                                                    # Sequences require terminating with Enter/OK if betacode ordering is used
+    my $term = "\n";                                                          # Sequences require terminating with Enter/OK if betacode ordering is used
     $::composehash{"=)r"} = $::composehash{"-r)$term"} = "\x{1FE4}";
     $::composehash{"=(r"} = $::composehash{"-r($term"} = "\x{1FE5}";
-    $::composehash{"=(R"} = $::composehash{"-R($term"} = "\x{1FEC}";    # No smooth breathing upper case rho
+    $::composehash{"=(R"} = $::composehash{"-R($term"} = "\x{1FEC}";          # No smooth breathing upper case rho
 }
 
 #
@@ -875,7 +887,7 @@ sub composeinitcase {
 
 #
 # Add compose sequences for characters made of 2 or more characters
-# First argument is uppercase character to create
+# First argument is character to create
 # Second and subsequent are compose character strings
 # E.g. given one-half and '1/2', it will create
 # '1/2' to generate the half character
@@ -904,7 +916,21 @@ sub composeinitsyms {
 }
 
 #
-# Add compose sequences for plain Greek characters
+# Add compose sequences for combining characters - introduced with plus sign
+# First argument is character to create
+# Second and subsequent are compose characters to follow plus sign
+# E.g. given combining diaresis, ':' and '"', it will create
+# '+:' and '+"' to generate the combining diaresis character
+sub composeinitcombining {
+    my $comb = shift;
+
+    while ( my $chr = shift ) {
+        $::composehash{"+$chr"} = $comb;
+    }
+}
+
+#
+# Add compose sequences for plain Greek characters - introduced with equals sign
 # First argument is start of uppercase alphabet
 # Second argument is start of lowercase alphabet
 # Third argument is string of English letters to be used
@@ -1017,8 +1043,11 @@ sub composeref {
         ::drag($comtext);
         for my $key ( sort composesort keys %::composehash ) {
             my $display = $key;
-            $display =~ s/\n/ OK\/Enter/;    # Some sequences require OK/Enter
-            $comtext->insert( 'end', $::composehash{$key} . " <= " . $display . "\n" );
+            $display =~ s/\n/ OK\/Enter/;                                      # Some sequences require OK/Enter
+            my $chr = substr( $::composehash{$key}, 0, 1 );                    # First char is inserted character
+            $chr = ' ' . $chr if $chr ge "\x{0300}" and $chr le "\x{036f}";    # Output space before combining characters
+            $comtext->insert( 'end',
+                "$chr <= $display" . substr( $::composehash{$key}, 1 ) . "\n" );    # Add optional help text at the end
         }
     }
 }

--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -718,36 +718,41 @@ sub composekeyaction {
 #
 # Initialise hash of compose keystrokes to characters
 sub composeinitialize {
-    composeinitaccent( 'À',       'à',      'A', '`',  '\\' );
-    composeinitaccent( 'Á',       'á',      'A', '\'', '/' );
-    composeinitaccent( 'Â',       'â',      'A', '^' );
-    composeinitaccent( 'Ã',       'ã',      'A', '~' );
-    composeinitaccent( 'Ä',       'ä',      'A', '"',  ':' );
-    composeinitaccent( 'Å',       'å',      'A', 'o',  '*' );
-    composeinitaccent( 'È',       'è',      'E', '`',  '\\' );
-    composeinitaccent( 'É',       'é',      'E', '\'', '/' );
-    composeinitaccent( 'Ê',       'ê',      'E', '^' );
-    composeinitaccent( 'Ë',       'ë',      'E', '"',  ':' );
-    composeinitaccent( 'Ì',       'ì',      'I', '`',  '\\' );
-    composeinitaccent( 'Í',       'í',      'I', '\'', '/' );
-    composeinitaccent( 'Î',       'î',      'I', '^' );
-    composeinitaccent( 'Ï',       'ï',      'I', '"', ':' );
-    composeinitaccent( 'Ò',       'ò',      'O', '`', '\\' );
-    composeinitaccent( 'Ó',       'ó',      'O', '\'' );
-    composeinitaccent( 'Ô',       'ô',      'O', '^' );
-    composeinitaccent( 'Õ',       'õ',      'O', '~' );
-    composeinitaccent( 'Ö',       'ö',      'O', '"', ':' );
-    composeinitaccent( 'Ø',       'ø',      'O', '/' );
-    composeinitaccent( 'Ù',       'ù',      'U', '`',  '\\' );
-    composeinitaccent( 'Ú',       'ú',      'U', '\'', '/' );
-    composeinitaccent( 'Û',       'û',      'U', '^' );
-    composeinitaccent( 'Ü',       'ü',      'U', '"', ':' );
-    composeinitaccent( 'Ç',       'ç',      'C', ',' );
-    composeinitaccent( 'Ñ',       'ñ',      'N', '~' );
-    composeinitaccent( "\x{178}", 'ÿ',      'Y', '"',  ':' );
-    composeinitaccent( 'Ý',       'ý',      'Y', '\'', '/' );
-    composeinitaccent( "\x{A3}",  "\x{A3}", 'L', '/',  '\\' );          # pound
-    composeinitaccent( "\x{A2}",  "\x{A2}", 'C', '/',  '|' );           # cent
+    composeinitaccent( 'À',       'à',       'A', '`',  '\\' );
+    composeinitaccent( 'Á',       'á',       'A', '\'', '/' );
+    composeinitaccent( 'Â',       'â',       'A', '^' );
+    composeinitaccent( 'Ã',       'ã',       'A', '~' );
+    composeinitaccent( 'Ä',       'ä',       'A', '"',  ':' );
+    composeinitaccent( 'Å',       'å',       'A', 'o',  '*' );
+    composeinitaccent( "\x{100}", "\x{101}", 'A', '-',  '=' );
+    composeinitaccent( 'È',       'è',       'E', '`',  '\\' );
+    composeinitaccent( 'É',       'é',       'E', '\'', '/' );
+    composeinitaccent( 'Ê',       'ê',       'E', '^' );
+    composeinitaccent( 'Ë',       'ë',       'E', '"',  ':' );
+    composeinitaccent( "\x{112}", "\x{113}", 'E', '-',  '=' );
+    composeinitaccent( 'Ì',       'ì',       'I', '`',  '\\' );
+    composeinitaccent( 'Í',       'í',       'I', '\'', '/' );
+    composeinitaccent( 'Î',       'î',       'I', '^' );
+    composeinitaccent( 'Ï',       'ï',       'I', '"', ':' );
+    composeinitaccent( "\x{12a}", "\x{12b}", 'I', '-', '=' );
+    composeinitaccent( 'Ò',       'ò',       'O', '`', '\\' );
+    composeinitaccent( 'Ó',       'ó',       'O', '\'' );
+    composeinitaccent( 'Ô',       'ô',       'O', '^' );
+    composeinitaccent( 'Õ',       'õ',       'O', '~' );
+    composeinitaccent( 'Ö',       'ö',       'O', '"', ':' );
+    composeinitaccent( 'Ø',       'ø',       'O', '/' );
+    composeinitaccent( "\x{14c}", "\x{14d}", 'O', '-',  '=' );
+    composeinitaccent( 'Ù',       'ù',       'U', '`',  '\\' );
+    composeinitaccent( 'Ú',       'ú',       'U', '\'', '/' );
+    composeinitaccent( 'Û',       'û',       'U', '^' );
+    composeinitaccent( 'Ü',       'ü',       'U', '"', ':' );
+    composeinitaccent( "\x{16a}", "\x{16b}", 'U', '-', '=' );
+    composeinitaccent( 'Ç',       'ç',       'C', ',' );
+    composeinitaccent( 'Ñ',       'ñ',       'N', '~' );
+    composeinitaccent( "\x{178}", 'ÿ',       'Y', '"',  ':' );
+    composeinitaccent( 'Ý',       'ý',       'Y', '\'', '/' );
+    composeinitaccent( "\x{A3}",  "\x{A3}",  'L', '/',  '\\' );         # pound
+    composeinitaccent( "\x{A2}",  "\x{A2}",  'C', '/',  '|' );          # cent
     composeinitchars( "\x{BD}",   '1/2' );                              # 1/2
     composeinitchars( "\x{2153}", '1/3' );                              # 1/3
     composeinitchars( "\x{2154}", '2/3' );                              # 1/3
@@ -811,9 +816,9 @@ sub composeinitialize {
     composeinithelp( "\x{0302}", "Combining circumflex" );
     composeinitcombining( "\x{0303}", '~' );                            # combining tilde
     composeinithelp( "\x{0303}", "Combining tilde" );
-    composeinitcombining( "\x{0304}", '-' );                            # combining macron
+    composeinitcombining( "\x{0304}", '-', '=' );                       # combining macron
     composeinithelp( "\x{0304}", "Combining macron" );
-    composeinitcombining( "\x{0306}", 'b' );                            # combining breve
+    composeinitcombining( "\x{0306}", ')' );                            # combining breve
     composeinithelp( "\x{0306}", "Combining breve" );
     composeinitcombining( "\x{0307}", '.' );                            # combining dot above
     composeinithelp( "\x{0307}", "Combining dot above" );
@@ -821,9 +826,9 @@ sub composeinitialize {
     composeinithelp( "\x{0308}", "Combining diaresis" );
     composeinitcombining( "\x{0309}", '?' );                            # combining hook above
     composeinithelp( "\x{0309}", "Combining hook above" );
-    composeinitcombining( "\x{030a}", 'o' );                            # combining ring above
+    composeinitcombining( "\x{030a}", 'o', 'O', '*' );                  # combining ring above
     composeinithelp( "\x{030a}", "Combining ring above" );
-    composeinitcombining( "\x{030c}", 'c' );                            # combining caron
+    composeinitcombining( "\x{030c}", 'v', 'V' );                       # combining caron
     composeinithelp( "\x{030c}", "Combining caron" );
     composeinitcombining( "\x{0328}", ',' );                            # combining ogonek
     composeinithelp( "\x{0328}", "Combining ogonek" );
@@ -837,6 +842,7 @@ sub composeinitialize {
     composeinitcase( "\x{2021}", "\x{2021}", 'DDAG' );                  # double dagger
     composeinitcase( "\x{A7}",   "\x{A7}",   'SEC', 'S*', '*S' );       # section
     composeinitcase( "\x{B6}",   "\x{B6}",   'PIL', 'P*', '*P' );       # pilcrow
+    composeinitcase( "\x{17F}",  "\x{17F}",  'SF',  'sf' );             # long s
     composegreekalphabet( "\x{391}", "\x{3b1}", 'ABGDEZHQIKLMNXOPRJSTUFCYW' );
     composegreekaccent( "\x{1FBA}", "\x{1F70}", 'A' );
     composegreekaccent( "\x{1FC8}", "\x{1F72}", 'E' );
@@ -960,10 +966,10 @@ sub composegreekalphabet {
     my $term     = "\n";         # Sequences require terminating with Enter/OK if betacode ordering is used
 
     for my $ch ( split( //, $alphabet ) ) {
-        $::composehash{"=$ch"} = $::composehash{"-$ch$term"} = chr( $ustart++ );
+        $::composehash{"=$ch"} = $::composehash{"#$ch$term"} = chr( $ustart++ );
     }
     for my $ch ( split( //, lc $alphabet ) ) {
-        $::composehash{"=$ch"} = $::composehash{"-$ch$term"} = chr( $lstart++ );
+        $::composehash{"=$ch"} = $::composehash{"#$ch$term"} = chr( $lstart++ );
     }
 }
 
@@ -982,21 +988,21 @@ sub composegreekaccent {
 
     # Uppercase
     if ($iota) {                         # Either accents or iota, not both for uppercase
-        $::composehash{"=$iota$base"} = $::composehash{"=$base$iota$term"} = chr( $ustart++ );
+        $::composehash{"=$iota$base"} = $::composehash{"#$base$iota$term"} = chr( $ustart++ );
     } else {
-        $::composehash{"=`$base"} = $::composehash{"=\\$base"} = $::composehash{"-$base`$term"} =
-          $::composehash{"-$base\\$term"} = chr( $ustart++ );
-        $::composehash{"='$base"} = $::composehash{"=/$base"} = $::composehash{"-$base'$term"} =
-          $::composehash{"-$base/$term"} = chr( $ustart++ );
+        $::composehash{"=`$base"} = $::composehash{"=\\$base"} = $::composehash{"#$base`$term"} =
+          $::composehash{"#$base\\$term"} = chr( $ustart++ );
+        $::composehash{"='$base"} = $::composehash{"=/$base"} = $::composehash{"#$base'$term"} =
+          $::composehash{"#$base/$term"} = chr( $ustart++ );
     }
 
     # Lowercase
     $base = lc $base;
     $::composehash{"=`$iota$base"} = $::composehash{"=\\$iota$base"} =
-      $::composehash{"-$base`$iota$term"} = $::composehash{"-$base\\$iota$term"} = chr( $lstart++ );
-    $::composehash{"=$iota$base"}  = $::composehash{"-$base$iota$term"} = chr( $lstart++ ) if $iota;
+      $::composehash{"#$base`$iota$term"} = $::composehash{"#$base\\$iota$term"} = chr( $lstart++ );
+    $::composehash{"=$iota$base"}  = $::composehash{"#$base$iota$term"} = chr( $lstart++ ) if $iota;
     $::composehash{"='$iota$base"} = $::composehash{"=/$iota$base"} =
-      $::composehash{"-$base'$iota$term"} = $::composehash{"-$base/$iota$term"} = chr( $lstart++ );
+      $::composehash{"#$base'$iota$term"} = $::composehash{"#$base/$iota$term"} = chr( $lstart++ );
 }
 
 #
@@ -1013,25 +1019,25 @@ sub composegreekbreathing {
     my $lbase = lc $ubase;
 
     for my $base ( $lbase, $ubase ) {
-        $::composehash{"=)$iota$base"}  = $::composehash{"-$base)$iota$term"} = chr( $start++ );
-        $::composehash{"=($iota$base"}  = $::composehash{"-$base($iota$term"} = chr( $start++ );
+        $::composehash{"=)$iota$base"}  = $::composehash{"#$base)$iota$term"} = chr( $start++ );
+        $::composehash{"=($iota$base"}  = $::composehash{"#$base($iota$term"} = chr( $start++ );
         $::composehash{"=)`$iota$base"} = $::composehash{"=)\\$iota$base"} =
-          $::composehash{"-$base)`$iota$term"} = $::composehash{"-$base)\\$iota$term"} =
+          $::composehash{"#$base)`$iota$term"} = $::composehash{"#$base)\\$iota$term"} =
           chr( $start++ );
         $::composehash{"=(`$iota$base"} = $::composehash{"=(\\$iota$base"} =
-          $::composehash{"-$base(`$iota$term"} = $::composehash{"-$base(\\$iota$term"} =
+          $::composehash{"#$base(`$iota$term"} = $::composehash{"#$base(\\$iota$term"} =
           chr( $start++ );
         $::composehash{"=)'$iota$base"} = $::composehash{"=)/$iota$base"} =
-          $::composehash{"-$base)'$iota$term"} = $::composehash{"-$base)/$iota$term"} =
+          $::composehash{"#$base)'$iota$term"} = $::composehash{"#$base)/$iota$term"} =
           chr( $start++ );
         $::composehash{"=('$iota$base"} = $::composehash{"=(/$iota$base"} =
-          $::composehash{"-$base('$iota$term"} = $::composehash{"-$base(/$iota$term"} =
+          $::composehash{"#$base('$iota$term"} = $::composehash{"#$base(/$iota$term"} =
           chr( $start++ );
         $::composehash{"=)^$iota$base"} = $::composehash{"=)~$iota$base"} =
-          $::composehash{"-$base)^$iota$term"} = $::composehash{"-$base)~$iota$term"} =
+          $::composehash{"#$base)^$iota$term"} = $::composehash{"#$base)~$iota$term"} =
           chr( $start++ );
         $::composehash{"=(^$iota$base"} = $::composehash{"=(~$iota$base"} =
-          $::composehash{"-$base(^$iota$term"} = $::composehash{"-$base(~$iota$term"} =
+          $::composehash{"#$base(^$iota$term"} = $::composehash{"#$base(~$iota$term"} =
           chr( $start++ );
     }
 }


### PR DESCRIPTION
PPers are being encouraged to use combining characters when a precomposed
Unicode character does not exist.
Add the more common characters to the available Compose Sequences.
Each is introduced with a plus sign, e.g. `+~` for combining tilde, `+-` for
combining macron, etc.

Also, add ability to provide a description in the Help dialog, to make it
clearer which character can be created with the Compose Sequence.