### PR TITLE
Add Cmd-Up/Down key bindings for Mac

### DIFF
--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -242,15 +242,19 @@ sub keybindings {
 
     # Extra bindings for Mac
     if ($::OS_MAC) {
-        keybind( '<Meta-q>', sub { ::_exit(); } );
-        keybind( '<Meta-s>', sub { ::savefile(); } );
-        keybind( '<Meta-a>', sub { $textwindow->selectAll; } );
-        keybind( '<Meta-c>', sub { ::textcopy(); } );
-        keybind( '<Meta-x>', sub { ::cut(); } );
-        keybind( '<Meta-v>', sub { ::paste(); } );
-        keybind( '<Meta-f>', sub { ::searchpopup(); } );
-        keybind( '<Meta-z>', undef, '<<Undo>>' );
-        keybind( '<Meta-y>', undef, '<<Redo>>' );
+        keybind( '<Meta-q>',          sub { ::_exit(); } );
+        keybind( '<Meta-s>',          sub { ::savefile(); } );
+        keybind( '<Meta-a>',          sub { $textwindow->selectAll; } );
+        keybind( '<Meta-c>',          sub { ::textcopy(); } );
+        keybind( '<Meta-x>',          sub { ::cut(); } );
+        keybind( '<Meta-v>',          sub { ::paste(); } );
+        keybind( '<Meta-f>',          sub { ::searchpopup(); } );
+        keybind( '<Meta-z>',          undef, '<<Undo>>' );
+        keybind( '<Meta-y>',          undef, '<<Redo>>' );
+        keybind( '<Meta-Up>',         [ 'SetCursor', '1.0' ] );
+        keybind( '<Meta-Shift-Up>',   [ 'KeySelect', '1.0' ] );
+        keybind( '<Meta-Down>',       [ 'SetCursor', 'end-1c' ] );
+        keybind( '<Meta-Shift-Down>', [ 'KeySelect', '1.0' ] );
     }
 
     # Bookmarks - multiple key-combinations to allow for keyboard differences


### PR DESCRIPTION
Cmd-Up should move to top of file
Cmd-Down should move to bottom
Holding the Shift key should select instead of just moving