### PR TITLE
Add option to normalize selected text

### DIFF
--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -3,13 +3,14 @@ use strict;
 use warnings;
 
 use Unicode::UCD 'prop_invmap';
+use Unicode::Normalize;
 
 BEGIN {
     use Exporter();
     our ( @ISA, @EXPORT );
     @ISA    = qw(Exporter);
     @EXPORT = qw(&commoncharspopup &utfpopup &utfcharentrypopup &utfcharsearchpopup &cp1252toUni
-      &composepopup  &composeinitialize &composeref &fractionconvert);
+      &composepopup  &composeinitialize &composeref &fractionconvert &utfcharnormalize);
 }
 
 #
@@ -1182,6 +1183,27 @@ sub fractionconvert {
         } else {
             $start .= "+${length}c";                        # Step over skipped fraction
         }
+    }
+    $textwindow->addGlobEnd;
+}
+
+#
+# Normalize selected characters into Unicode Normalization Form C
+sub utfcharnormalize {
+    my $textwindow  = $::textwindow;
+    my @ranges      = $textwindow->tagRanges('sel');
+    my $range_total = @ranges;
+
+    return if $range_total == 0;
+
+    $textwindow->addGlobStart;
+    while (@ranges) {
+        my $end            = pop(@ranges);
+        my $start          = pop(@ranges);
+        my $thisblockstart = $start;
+        my $thisblockend   = $end;
+        my $nfc_text       = NFC( $textwindow->get( $thisblockstart, $thisblockend ) );
+        $textwindow->replacewith( $start, $end, $nfc_text );
     }
     $textwindow->addGlobEnd;
 }

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -475,6 +475,7 @@ sub menu_tools_charactertools {
             -accelerator => 'AltGr / Ctrl+m',
             -command     => \&::composepopup
         ],
+        [ 'command',   '~Normalize Selected Characters', -command => \&::utfcharnormalize ],
         [ 'separator', '' ],
         [ 'command',   '~Greek Transliteration',     -command => \&::greekpopup ],
         [ 'command',   'Find and ~Convert Greek...', -command => \&::findandextractgreek ],


### PR DESCRIPTION
For HTML to validate, text needs to be in Unicode Normalization Form C.
PPer might have composed a character by using a combining character when
in fact there was a precomposed character they should have used.
When they get the error from the validator, they can run the new command
on selected text. The reason for doing selected text, rather than the whole
file, is there are rare circumstances, e.g. Greek oxia, where normalizing it
may not be what an expert Greek PPer wants.