### PR TITLE
Fix footnote infinite loop

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1088,8 +1088,8 @@ sub html_convert_footnoteblocks {
         while (1) {
 
             # Find the next </div>
-            my $endoflastfootnoteinblock =
-              $textwindow->search( '-exact', '--', '</div>', $endoflastfootnoteinblock );
+            $endoflastfootnoteinblock =
+              $textwindow->search( '-exact', '--', '</div>', "$endoflastfootnoteinblock+1c" );
             if ($endoflastfootnoteinblock) {
 
                 # Get 8 characters before </div> in case of blank lines between </p> and </div>


### PR DESCRIPTION
Redeclaration of variable with `my` inside a loop created a new variable with
the same name hiding the previous declaration outside the loop.
Therefore, instead of the next search continuing from after the last position
found, it searched again from the end of the previous block.
Also, step forward 1 character from previous location to avoid finding the
same place twice.

Fixes #943