### PR TITLE
Use homebrew perl to run cpanm

### DIFF
--- a/src/install_cpan_modules.pl
+++ b/src/install_cpan_modules.pl
@@ -27,7 +27,28 @@ if ( $^O eq 'MSWin32' ) {
     push @modules, "Win32::Unicode::Process";
 }
 
+# Command to use to run cpanm, default to the command directly
+$cpanm = "cpanm";
+
+# On Mac, we want to run cpanm with the version of perl on the path -- which
+# should be the homebrew-installed version -- not whatever version cpanm is
+# pointing to which might be the one that came with macOS.
+if ( $^O eq 'darwin' ) {
+
+    # Intel
+    if ( -e "/usr/local/bin/cpanm" ) {
+        $cpanm = "perl /usr/local/bin/cpanm";
+    }
+
+    # Apple Silicon
+    elsif ( -e "/opt/homebrew/bin/cpanm" ) {
+        $cpanm = "perl /opt/homebrew/bin/cpanm";
+    }
+
+    # fall-through to using cpanm directly
+}
+
 foreach my $module (@modules) {
-    system("cpanm --notest $module") == 0
+    system("$cpanm --notest $module") == 0
       or die("Failed trying to install $module\n");
 }


### PR DESCRIPTION
`cpanm` needs to be run with the version of perl we want to install the modules into. For macOS, attempt to detect where `cpanm` is located and ensure it is run with the version of perl on the path. This should not change how the script works on non-Mac platforms.

This can be tested by simply running `perl install_cpan_modules.pl` on systems where it failed before (after restoring the first line of `cpanm` to its original condition). No need to uninstall packages before re-running it.