### PR TITLE
Set kindlegen path to an absolute path (macOS)

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1128,8 +1128,8 @@ sub initialize {
         $::kindlegencommand = ::setdefaultpath(
             $::kindlegencommand,
             ::catfile(
-                'Applications', 'Kindle Previewer 3.app',
-                'Contents',     'lib', 'fc', 'bin', 'kindlegen'
+                '/Applications', 'Kindle Previewer 3.app',
+                'Contents', 'lib', 'fc', 'bin', 'kindlegen'
             )
         );
     } else {


### PR DESCRIPTION
The default path to kindlegen on startup (without a setting.rc) is
`Applications/Kindle Previewer 3.app/Contents/lib/fc/bin/kindlegen`
when run on macOS.

Without a leading `/` or `./` or `../` Guiguts will consider this
a relative path. Unless the user happens to start guiguts while
in the root directory, this will never work.

This patch adjusts the default value for `$kindlegencommand`
to include the leading `/`
