### PR TITLE
Add `\IP` extension to regex syntax to insert page label

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -707,6 +707,14 @@ sub replaceeval {
     my ( $m1,         $m2,     $m3,     $m4,     $m5,     $m6,     $m7,     $m8 );
     my ( $cfound,     $lfound, $ufound, $tfound, $xfound, $bfound, $gfound, $afound, $rfound );
 
+    # convert \Ix (insert something) codes early, since they don't rely on the match string
+    if ( $replaceterm =~ /\\IP/ ) {    # Replace \IP with the page label of the start of the matched text
+        my $label = $::pagenumbers{ "Pg" . ::get_page_number($::searchstartindex) }{label};
+        $label =~ s/Pg //;
+        $label = "999999" if $label eq "";    # Alert PPer if no label
+        $replaceterm =~ s/\\IP/$label/g;
+    }
+
     #check for control codes before the $1 codes for text found are inserted
     $replaceterm =~ s/\\GA/\\GX/g;
     $replaceterm =~ s/\\GX/\\X/g;

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2442,10 +2442,13 @@ sub poetrynumbers {
     }
 }
 
+#
+# Accepts an optional index to find the page number at that index
+# Otherwise returns page number at index of the current insert position
 sub get_page_number {
     my $textwindow = $::textwindow;
     my $pnum;
-    my $markindex = $textwindow->index('insert');
+    my $markindex = shift // $textwindow->index('insert');
     my $mark      = $textwindow->markPrevious($markindex);
     while ($mark) {
         if ( $mark =~ /Pg(\S+)/ ) {


### PR DESCRIPTION
`\IP` gets replaced with the page number from the book by using the labels
from the pagenumbers hash.

The primary identified use of this is to better automate the naming of links
and their associated ids, e.g. for chapter headings or illos.