### PR TITLE
Implement --home flag

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -326,14 +326,14 @@ $lglobal{runtests} = ( @ARGV == 1 and $ARGV[0] eq 'runtests' );
 
 # We need to check @ARGV for --home now, before initialize() and readlabels()
 # are run, otherwise we'll write files in the wrong location
-if (@ARGV and $ARGV[0] eq '--home') {
+if ( @ARGV and $ARGV[0] eq '--home' ) {
     shift @ARGV;
     die "ERROR: malformed command (--home must specify a path)\n" unless @ARGV;
 
-    $lglobal{homedirectory} = ::rel2abs(shift @ARGV);
-    ::infoerror("Resolved --home to " . $lglobal{homedirectory});
+    $lglobal{homedirectory} = ::rel2abs( shift @ARGV );
+    ::infoerror( "Resolved --home to " . $lglobal{homedirectory} );
 
-    if (-e $lglobal{homedirectory}) {
+    if ( -e $lglobal{homedirectory} ) {
         die "ERROR: --home directory must be a directory\n" unless -d $lglobal{homedirectory};
     } else {
         die "ERROR: --home directory could not be created\n" unless mkdir $lglobal{homedirectory};

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -899,7 +899,7 @@ EOM
 
     #my $thispath = $0;
     #$thispath =~ s/[^\\]*$//;
-    my $savefile = ::catfile( $::lglobal{guigutsdirectory}, 'setting.rc' );
+    my $savefile = ::catfile( $::lglobal{homedirectory}, 'setting.rc' );
     $::geometry = $top->geometry unless $::geometry;
     if ( open my $save_handle, '>', $savefile ) {
         print $save_handle $message;

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1319,10 +1319,10 @@ sub html_parse_header {
         }
         $textwindow->ntdelete( '1.0', "$step.0 +1c" );
     } else {
-        unless ( -e 'header.txt' ) {
-            ::copy( 'headerdefault.txt', 'header.txt' );
+        unless ( -e ::catfile( $::lglobal{homedirectory}, 'header.txt' ) ) {
+            ::copy( 'headerdefault.txt', ::catfile( $::lglobal{homedirectory}, 'header.txt' ) );
         }
-        open my $infile, '<:encoding(utf8)', 'header.txt'
+        open my $infile, '<:encoding(utf8)', ::catfile( $::lglobal{homedirectory}, 'header.txt' )
           or warn "Could not open header file. $!\n";
         while ( my $line = <$infile> ) {
             $line =~ s/\cM\cJ|\cM|\cJ/\n/g;

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -523,7 +523,7 @@ sub deaccentdisplay {
 }
 
 sub readlabels {
-    my $labelfile        = ::catfile( 'data', "labels_$::booklang.rc" );
+    my $labelfile        = ::catfile( $::lglobal{homedirectory}, "labels_$::booklang.rc" );
     my $defaultlabelfile = ::catfile( 'data', "labels_$::booklang" . "_default.rc" );
     $defaultlabelfile = ::catfile( 'data', 'labels_en_default.rc' ) unless ( -e $defaultlabelfile );
     @::gcviewlang     = ();


### PR DESCRIPTION
Adds a -`-home` flag, which takes an argument (a path). When invoked with `--home <path>`, Guiguts will store its data & settings files in the specified directory rather than in the Guiguts code directory.

This may be desired because:

1. It may make it easier to maintain settings between upgrades
2. I am working on a macOS app bundle for Guiguts; these bundles are signed, and the contents can't change or the signature is invalidated. This flag permits us to write our metadata outside of the app bundle directory into another location,       e.g. `$HOME/.guiguts/`