### PR TITLE
Add --home to specify location for persistent data

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -809,12 +809,12 @@ sub readsettings {
     return if $::lglobal{runtests};    # don't want tests to be affected by a saved setting.rc file
 
     # Should be able to "do" the file if it exists
-    if ( -e 'setting.rc' ) {
-        my $result = ::dofile('setting.rc');
+    if ( -e ::path_settings() ) {
+        my $result = ::dofile( ::path_settings() );
 
         # If that fails, try to read the file and "eval" the contents
         unless ( $result and $result == 1 ) {
-            open my $file, "<", "setting.rc" or die "Could not open setting file\n";
+            open my $file, "<", ::path_settings() or die "Could not open setting file\n";
             my @file = <$file>;
             close $file;
             my $settings = '';
@@ -824,7 +824,7 @@ sub readsettings {
             # If that fails, copy so user can inspect it since setting.rc will be overwritten
             unless ( $result and $result == 1 ) {
                 warn "Copying corrupt setting.rc to setting.err\n";
-                open $file, ">", "setting.err";
+                open $file, ">", ::catfile( $::lglobal{homedirectory}, 'setting.err' );
                 print $file @file;
                 close $file;
             }
@@ -899,7 +899,7 @@ EOM
 
     #my $thispath = $0;
     #$thispath =~ s/[^\\]*$//;
-    my $savefile = ::catfile( $::lglobal{guigutsdirectory}, 'setting.rc' );
+    my $savefile = ::path_settings();
     $::geometry = $top->geometry unless $::geometry;
     if ( open my $save_handle, '>', $savefile ) {
         print $save_handle $message;

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1319,10 +1319,10 @@ sub html_parse_header {
         }
         $textwindow->ntdelete( '1.0', "$step.0 +1c" );
     } else {
-        unless ( -e 'header.txt' ) {
-            ::copy( 'headerdefault.txt', 'header.txt' );
+        unless ( -e ::path_htmlheader() ) {
+            ::copy( ::path_defaulthtmlheader(), ::path_htmlheader() );
         }
-        open my $infile, '<:encoding(utf8)', 'header.txt'
+        open my $infile, '<:encoding(utf8)', ::path_htmlheader()
           or warn "Could not open header file. $!\n";
         while ( my $line = <$infile> ) {
             $line =~ s/\cM\cJ|\cM|\cJ/\n/g;

--- a/src/lib/Guiguts/Tests.pm
+++ b/src/lib/Guiguts/Tests.pm
@@ -11,7 +11,7 @@ BEGIN {
     @EXPORT = qw(&runtests);
 }
 
-# From the command line run "guiguts.pl runtests"
+# From the command line run "guiguts.pl --runtests"
 # Results will be reported to the command window
 sub runtests {
 

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -20,7 +20,8 @@ BEGIN {
       &getprojectid &setprojectid &viewprojectcomments &viewprojectdiscussion &viewprojectpage
       &scrolldismiss &updatedrecently &hidelinenumbers &restorelinenumbers &displaylinenumbers
       &enable_interrupt &disable_interrupt &set_interrupt &query_interrupt &soundbell &busy &unbusy
-      &dieerror &warnerror &infoerror &poperror &BindMouseWheel &display_manual);
+      &dieerror &warnerror &infoerror &poperror &BindMouseWheel &display_manual
+      &path_settings &path_htmlheader &path_defaulthtmlheader &path_labels &path_defaultlabels);
 
 }
 
@@ -337,6 +338,39 @@ sub dos_path {
     return Win32::GetShortPathName( $_[0] );
 }
 
+# Return paths to common files used by the application.
+sub path_settings {
+    return ::catfile( $::lglobal{homedirectory}, 'setting.rc' );
+}
+
+sub path_htmlheader {
+    return ::catfile( $::lglobal{homedirectory}, 'header.txt' );
+}
+
+sub path_defaulthtmlheader {
+    return 'headerdefault.txt';
+}
+
+sub path_labels {
+
+    # If we're using --home (a separate data directory), then we store the
+    # labels file directly there
+    if ( $::lglobal{homedirectory} ne $::lglobal{guigutsdirectory} ) {
+        return ::catfile( $::lglobal{homedirectory}, "labels_$::booklang.rc" );
+    }
+
+    # Otherwise it's stored in a subdirectory data/ from Guiguts' directory
+    return ::catfile( $::lglobal{guigutsdirectory}, 'data', "labels_$::booklang.rc" );
+}
+
+sub path_defaultlabels {
+    my $f = ::catfile( 'data', "labels_$::booklang" . "_default.rc" );
+    return $f if -e $f;
+
+    # Default to English if $::booklang has no defaults file
+    return ::catfile( 'data', 'labels_en_default.rc' );
+}
+
 # system(LIST)
 # (but slightly more robust, particularly on Windows).
 sub run {
@@ -523,10 +557,9 @@ sub deaccentdisplay {
 }
 
 sub readlabels {
-    my $labelfile        = ::catfile( 'data', "labels_$::booklang.rc" );
-    my $defaultlabelfile = ::catfile( 'data', "labels_$::booklang" . "_default.rc" );
-    $defaultlabelfile = ::catfile( 'data', 'labels_en_default.rc' ) unless ( -e $defaultlabelfile );
-    @::gcviewlang     = ();
+    my $labelfile        = path_labels();
+    my $defaultlabelfile = path_defaultlabels();
+    @::gcviewlang = ();
 
     # read the default values first, in case some are missing from the user file
     ::dofile($defaultlabelfile);
@@ -870,6 +903,11 @@ sub initialize {
     $::manualhash{'wfpop'}             = '/Tools_Menu#Word_Frequency';
     $::manualhash{'workpop'}           = '#Overview';
 
+    $::lglobal{guigutsdirectory} = ::dirname( ::rel2abs($0) )
+      unless defined $::lglobal{guigutsdirectory};
+    $::lglobal{homedirectory} = $::lglobal{guigutsdirectory}
+      unless $::lglobal{homedirectory};
+
     ::composeinitialize();
 
     ::readsettings();
@@ -1085,9 +1123,6 @@ sub initialize {
         'Wrongspaced singlequotes',
     );
     $::gsopt[$_] = $::mygcview[$_] for 0 .. $#::mygcview;    # Use default gc/bl view settings
-
-    $::lglobal{guigutsdirectory} = ::dirname( ::rel2abs($0) )
-      unless defined $::lglobal{guigutsdirectory};
 
     # Find tool locations. setdefaultpath handles differences in *nix/Windows
     # executable names and looks on the search path.

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -353,9 +353,19 @@ sub path_defaulthtmlheader {
 
 sub path_labels {
 
+    my $homedirectory    = $::lglobal{homedirectory};
+    my $guigutsdirectory = $::lglobal{guigutsdirectory};
+
+    # Windows and macOS have case-insensitive filesystems. Lowercase
+    # the paths before comparing them
+    if ( $::OS_WIN or $::OS_MAC ) {
+        $homedirectory    = lc $homedirectory;
+        $guigutsdirectory = lc $guigutsdirectory;
+    }
+
     # If we're using --home (a separate data directory), then we store the
-    # labels file directly there
-    if ( $::lglobal{homedirectory} ne $::lglobal{guigutsdirectory} ) {
+    # labels file directly there, not in a subdirectory
+    if ( $homedirectory ne $guigutsdirectory ) {
         return ::catfile( $::lglobal{homedirectory}, "labels_$::booklang.rc" );
     }
 


### PR DESCRIPTION
## Changes

Adds a `--home` flag, taking a directory as an argument, which specifies a directory for storing persistent user data. At this time, three things would be stored in this directory:

 - `setting.rc`
 - `header.txt`
 - `labels_{lang}.rc`

In the case of a corrupted `setting.rc`, then this location is also where `setting.err` might be written.

This flag is optional, the default behavior is preserved.

Changes argument parsing to use Getopt::Long. Options `--home` and `--runtests` are parsed with Getopt::Long. If a filename is specified, that is still handled by reading `@ARGV`.

**Note that this means a new arg `--runtests` replaces the older form `runtests`.**

Also adds helper functions to return various paths:
 - `header.txt`
 - `headerdefault.txt`
 - `labels_{lang}.default.rc`
 - `labels_{lang}.rc`
 - `setting.rc`

Some of the helpers are to simplify things with the variable location (whether `--home` is in use or not), some are just for the sake of convenience.

## Purposes

As described in #954, one purpose is to allow an easy way for users to carry their settings from one release to the next without manually copying files around.

I am working on a macOS app bundle to simplify the install and upgrade process for Mac users. Since Mac apps must be signed, their contents can't change; the `--home` flag permits user data to live outside of the application's directory, making this possible.

## Testing

I tested these changes on macOS. Since macOS uses a similar filesystem interface, Linux probably also works, but I didn't test directly.

I have no Windows machines handy to test with, so I'd appreciate if someone could give it a try on Windows.