### PR TITLE
Fix crash when `Save As` is triggered by a `Save`

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -69,7 +69,7 @@ sub file_saveas {
         -initialfile => $initialfile,
     );
 
-    if ( defined($name) and length($name) and not bad_filename_chars($name)) {
+    if ( defined($name) and length($name) and not bad_filename_chars($name) ) {
         $::top->Busy( -recurse => 1 );
         $textwindow->SaveUTF($name);
         my ( $fname, $extension, $filevar );
@@ -81,7 +81,7 @@ sub file_saveas {
         _bin_save();
         ::_recentupdate($name);
         $::top->Unbusy( -recurse => 1 );
-        $textwindow->ResetUndo;               #necessary to reset edited flag
+        $textwindow->ResetUndo;    #necessary to reset edited flag
         ::setedited(0);
         ::update_indicators();
     }

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -52,71 +52,74 @@ sub file_include {    # FIXME: Should include even if no file loaded.
 
 sub file_saveas {
 
-    # Block/local ensures global is safely saved & restored
-    {    # Don't want to autosave mid-save
-        local $::autosave = 0;
-        ::reset_autosave();
+    # Temporarily disable autosave - don't want that to happen part way through saving
+    my $saveautosave = $::autosave;
+    $::autosave = 0;
+    ::reset_autosave();
 
-        my $textwindow = shift;
-        ::hidepagenums();
-        my $initialfile = '';
-        $initialfile = $::lglobal{global_filename}
-          unless ( $::lglobal{global_filename} =~ m/No File Loaded/ );
-        $initialfile =~ s|.*/([^/]*)$|$1|;
-        my $name = $textwindow->getSaveFile(
-            -title       => 'Save As',
-            -initialdir  => $::globallastpath,
-            -initialfile => $initialfile,
-        );
+    my $textwindow = shift;
+    ::hidepagenums();
+    my $initialfile = '';
+    $initialfile = $::lglobal{global_filename}
+      unless ( $::lglobal{global_filename} =~ m/No File Loaded/ );
+    $initialfile =~ s|.*/([^/]*)$|$1|;
+    my $name = $textwindow->getSaveFile(
+        -title       => 'Save As',
+        -initialdir  => $::globallastpath,
+        -initialfile => $initialfile,
+    );
 
-        if ( defined($name) and length($name) ) {
-            last if bad_filename_chars($name);    # break out of block if bad filename
-            $::top->Busy( -recurse => 1 );
-            $textwindow->SaveUTF($name);
-            my ( $fname, $extension, $filevar );
-            ( $fname, $::globallastpath, $extension ) = ::fileparse($name);
-            $::globallastpath = ::os_normal($::globallastpath);
-            $name             = ::os_normal($name);
-            $textwindow->FileName($name);
-            $::lglobal{global_filename} = $name;
-            _bin_save();
-            ::_recentupdate($name);
-            $::top->Unbusy( -recurse => 1 );
-            $textwindow->ResetUndo;               #necessary to reset edited flag
-            ::setedited(0);
-            ::update_indicators();
-        }
-    }    # End of block restores autosave setting
+    if ( defined($name) and length($name) and not bad_filename_chars($name)) {
+        $::top->Busy( -recurse => 1 );
+        $textwindow->SaveUTF($name);
+        my ( $fname, $extension, $filevar );
+        ( $fname, $::globallastpath, $extension ) = ::fileparse($name);
+        $::globallastpath = ::os_normal($::globallastpath);
+        $name             = ::os_normal($name);
+        $textwindow->FileName($name);
+        $::lglobal{global_filename} = $name;
+        _bin_save();
+        ::_recentupdate($name);
+        $::top->Unbusy( -recurse => 1 );
+        $textwindow->ResetUndo;               #necessary to reset edited flag
+        ::setedited(0);
+        ::update_indicators();
+    }
+
+    # Restore autosave flag
+    $::autosave = $saveautosave;
     ::reset_autosave();
 }
 
 sub file_savecopyas {
 
-    # Block/local ensures global is safely saved & restored
-    {    # Don't want to autosave mid-save
-        local $::autosave = 0;
-        ::reset_autosave();
+    # Temporarily disable autosave - don't want that to happen part way through saving
+    my $saveautosave = $::autosave;
+    $::autosave = 0;
+    ::reset_autosave();
 
-        my $textwindow = shift;
-        ::hidepagenums();
-        my $name = $textwindow->getSaveFile(
-            -title       => 'Save As',
-            -initialdir  => $::globallastpath,
-            -initialfile => $::lglobal{global_filename},
-        );
-        if ( defined($name) and length($name) ) {
-            $::top->Busy( -recurse => 1 );
-            $textwindow->SaveUTF($name);
-            $name = ::os_normal($name);
-            my $oldfilename = $::lglobal{global_filename};
-            $::lglobal{global_filename} = $name;    # first do a bin_save, then restore the file name
-            _bin_save();
-            $::lglobal{global_filename} = $oldfilename;
-            $textwindow->FileName($oldfilename);
-            ::_recentupdate($name);
-            $::top->Unbusy( -recurse => 1 );
-        }
-    }    # End of block restores autosave setting
+    my $textwindow = shift;
+    ::hidepagenums();
+    my $name = $textwindow->getSaveFile(
+        -title       => 'Save As',
+        -initialdir  => $::globallastpath,
+        -initialfile => $::lglobal{global_filename},
+    );
+    if ( defined($name) and length($name) ) {
+        $::top->Busy( -recurse => 1 );
+        $textwindow->SaveUTF($name);
+        $name = ::os_normal($name);
+        my $oldfilename = $::lglobal{global_filename};
+        $::lglobal{global_filename} = $name;    # first do a bin_save, then restore the file name
+        _bin_save();
+        $::lglobal{global_filename} = $oldfilename;
+        $textwindow->FileName($oldfilename);
+        ::_recentupdate($name);
+        $::top->Unbusy( -recurse => 1 );
+    }
+
+    # Restore autosave flag
+    $::autosave = $saveautosave;
     ::reset_autosave();
 }
 
@@ -389,55 +392,56 @@ sub clearpopups {
 # Save the currently loaded file
 sub savefile {
 
-    # Block/local ensures global is safely saved & restored
-    {    # Don't want to autosave mid-save
-        local $::autosave = 0;
-        ::reset_autosave();
+    # Temporarily disable autosave - don't want that to happen part way through saving
+    my $saveautosave = $::autosave;
+    $::autosave = 0;
+    ::reset_autosave();
 
-        my ( $textwindow, $top ) = ( $::textwindow, $::top );
-        my $filename = $::lglobal{global_filename};
-        last if bad_filename_chars($filename);    # break out of block if bad filename
+    my ( $textwindow, $top ) = ( $::textwindow, $::top );
+    my $filename = $::lglobal{global_filename};
 
-        # If no filename, do "Save As".
-        if ( $filename =~ /No File Loaded/ ) {
-            file_saveas($textwindow);
-        } else {
-            ::hidepagenums();
-            if (
-                !fileisreadonly($filename)
-                or 'Yes' eq $top->messageBox(
-                    -icon    => 'warning',
-                    -title   => 'Confirm save?',
-                    -type    => 'YesNo',
-                    -default => 'no',
-                    -message =>
-                      "File $filename is write-protected. Remove write-protection and save anyway?",
-                )
-            ) {
-                $::top->Busy( -recurse => 1 );
-                if ($::autobackup) {
-                    if ( -e $filename ) {
-                        print "$filename\n";
-                        if ( -e "$filename.bk2" ) {
-                            unlink "$filename.bk2";
-                        }
-                        if ( -e "$filename.bk1" ) {
-                            rename( "$filename.bk1", "$filename.bk2" );
-                        }
-                        rename( $filename, "$filename.bk1" );
+    if ( bad_filename_chars($filename) ) {    # Do not save if filename contains illegal characters
+        ;
+    } elsif ( $filename =~ /No File Loaded/ ) {    # If no filename, do "Save As".
+        file_saveas($textwindow);
+    } else {
+        ::hidepagenums();
+        if (
+            !fileisreadonly($filename)
+            or 'Yes' eq $top->messageBox(
+                -icon    => 'warning',
+                -title   => 'Confirm save?',
+                -type    => 'YesNo',
+                -default => 'no',
+                -message =>
+                  "File $filename is write-protected. Remove write-protection and save anyway?",
+            )
+        ) {
+            $::top->Busy( -recurse => 1 );
+            if ($::autobackup) {
+                if ( -e $filename ) {
+                    print "$filename\n";
+                    if ( -e "$filename.bk2" ) {
+                        unlink "$filename.bk2";
                     }
+                    if ( -e "$filename.bk1" ) {
+                        rename( "$filename.bk1", "$filename.bk2" );
+                    }
+                    rename( $filename, "$filename.bk1" );
                 }
-                $textwindow->SaveUTF;
-                $::top->Unbusy( -recurse => 1 );
-                $textwindow->ResetUndo;    #necessary to reset edited flag
-                ::_bin_save();
-                ::setedited(0);
-                ::reset_autosave();
-                ::update_indicators();
             }
+            $textwindow->SaveUTF;
+            $::top->Unbusy( -recurse => 1 );
+            $textwindow->ResetUndo;    #necessary to reset edited flag
+            ::_bin_save();
+            ::setedited(0);
+            ::reset_autosave();
+            ::update_indicators();
         }
+    }
 
-    }    # End of block restores autosave setting
+    # Restore autosave flag
+    $::autosave = $saveautosave;
     ::reset_autosave();
 }
 


### PR DESCRIPTION
If the user created a new file, then tried to `Save` the file, it detected that
it hadn't been saved before, and so called the `Save As` routine.

Both the `Save` and `Save As` (and incidentally `Save As Copy`) routines
temporarily disabled the autosave feature using the Perl `local` keyword,
which stores a backup of a global variable, restoring it when the current
block is exited.

It appears that this mechanism in Perl does not work if a global variable is
saved, then in a subroutine called from within the block (i.e. while the `local`
is still in effect) the global variable is `local`ed again. Perl crashed when
the inner block was exited.

Recoded to backup to a `my` scope variable, with a few adjustments to
ensure that the restoring lines couldn't be skipped by early exit of the
routines.

Fixes #960