### PR TITLE
Display filename correctly when `Saving a Copy As` on Mac

### DIFF
--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -56,9 +56,13 @@ sub menu_file {
             -accelerator => 'Ctrl+Shift+s',
             -command     => sub { ::file_saveas($textwindow); }
         ],
-        [ 'command',   'Sa~ve a Copy As...', -command => sub { ::file_savecopyas($textwindow); } ],
-        [ 'command',   '~Include File...',   -command => sub { ::file_include($textwindow); } ],
-        [ 'command',   '~Close',             -command => sub { ::file_close($textwindow); } ],
+        [
+            'command',
+            'Sa~ve a Copy As...',
+            -command => sub { ::file_saveas( $textwindow, "copy" ); }
+        ],
+        [ 'command',   '~Include File...', -command => sub { ::file_include($textwindow); } ],
+        [ 'command',   '~Close',           -command => sub { ::file_close($textwindow); } ],
         [ 'separator', '' ],
 
         menu_cascade( '~Project', &menu_file_project ),


### PR DESCRIPTION
Unlike `Save As`, `Save a Copy As` displayed the full path instead of just
the filename in the filename field of the Save dialog. This did not happen
on Windows (possibly a native Windows dialog is used which copes).
Also, on all OS, if the current file had not yet been saved, the filename
field was set to "No File Loaded" in the Save a Copy dialog only.

Much of the code in the two routines that did these operations was the
same, so the routines have been combined into one. Also, the title of the
dialog now says "Save As" or "Save a Copy As" accordingly.