### PR TITLE
Allow prep text files to have spaces in names

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -131,7 +131,7 @@ sub file_import_preptext {
     $::globallastpath = $directory;
 
     for my $file ( sort @files ) {
-        if ( $file =~ /^(\w+)\.txt/ ) {
+        if ( $file =~ /(\w+)\.txt$/ ) {
             $textwindow->ntinsert( 'end', ( "\n" . '-' x 5 ) );
             $textwindow->ntinsert( 'end', "File: $1.png" );
             $textwindow->ntinsert( 'end', ( '-' x 45 ) . "\n" );


### PR DESCRIPTION
File names are sometimes of the form `title - 001.txt` rather than just
`001.txt`. Allow non-word characters at start of file name as long as
there are word characters just before the file extension.

Fixes issue reported by PM using Abby files.

**Edited to clarify**, this PR is to do with importing, not exporting prep text files.