### PR TITLE
Add search capability to spell query dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   each query to be handled. Hover over buttons to see which combination of
   Shift/Ctrl with Left/Right click can be used as shortcut. If spelling
   occurs more often than the threshold (default 3), it is not reported.
+  Use Alt+Left click to pop the Search dialog to search for the queried word.
 - Combining Characters now available in Compose Sequences, e.g. `+~` for 
   combining tilde above; `_~` for combining tilde below
 - Additional compose sequences added for precomposed vowels with macron and
@@ -44,6 +45,7 @@
 - Ctrl-Alt-s scratchpad shortcut did not work - removed feature entirely
 - Using `Save` instead of `Save As` to save a new file could cause a crash
 - Filename was not displayed correctly in `Save a Copy As` dialog
+- `Import Prep Text Files` did not import files with a space in their names
 
 
 ## Version 1.4.0

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -11,6 +11,7 @@ BEGIN {
 
 my @errorchecklines;
 my %errors;
+my $APOS = "\x{2019}";
 
 # General error check window
 # Handles Bookloupe, Jeebies, HTML & CSS Validate, Tidy, Link Check
@@ -258,6 +259,29 @@ sub errorcheckpop_up {
             errorchecksetactive();
             errorcheckremovesimilar($errorchecktype);
             errorcheckview($errorchecktype);
+        }
+    );
+
+    # Alt + button 1 pops the Search dialog prepopulated with the queried word
+    $::lglobal{errorchecklistbox}->eventAdd( '<<search>>' => '<Alt-ButtonRelease-1>' );
+    $::lglobal{errorchecklistbox}->bind(
+        '<<search>>',
+        sub {
+            errorchecksetactive();
+            my $line = $::lglobal{errorchecklistbox}->get('active');
+            return
+                  unless defined $line
+              and defined $errors{$line}
+              and $line =~ s/^\d+:\d+ +- ([\w'$APOS]+) .*/$1/;
+
+            ::searchpopup();
+            ::searchoptset(qw/1 x x 0/);    # Whole-word non-regex search
+            $::lglobal{searchentry}->delete( 0, 'end' );
+            $::lglobal{searchentry}->insert( 'end', $line );
+            ::updatesearchlabels();         # Updates count in S&R dialog if word frequency has been run previously
+            $::lglobal{searchpop}->deiconify;
+            $::lglobal{searchpop}->raise;
+            $::lglobal{searchpop}->focus;
         }
     );
 
@@ -1229,7 +1253,6 @@ sub booklouperun {
     sub spellqueryrun {
         my $errname    = shift;
         my $textwindow = $::textwindow;
-        my $APOS       = "\x{2019}";
 
         return unless spellqueryinitialize();
 

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -11,7 +11,7 @@ BEGIN {
 
 my @errorchecklines;
 my %errors;
-my $APOS = "\x{2019}";
+my $APOS = "\x{2019}";    # Curly apostrophe/right single quote
 
 # General error check window
 # Handles Bookloupe, Jeebies, HTML & CSS Validate, Tidy, Link Check

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -264,6 +264,8 @@ sub errorcheckpop_up {
 
     # Alt + button 1 pops the Search dialog prepopulated with the queried word
     $::lglobal{errorchecklistbox}->eventAdd( '<<search>>' => '<Alt-ButtonRelease-1>' );
+    $::lglobal{errorchecklistbox}->eventAdd( '<<search>>' => '<Meta-ButtonRelease-1>' )
+      if $::OS_MAC;
     $::lglobal{errorchecklistbox}->bind(
         '<<search>>',
         sub {


### PR DESCRIPTION
In a similar manner to the Word Frequency dialog, allow user to pop the
S&R dialog with the queried word in it - this allows them to review all the
occurrences (of which there will be no more than the threshold number) to
decide if it's a good/bad spelling.