### PR TITLE
Use `Command` key for `Alt` key shortcuts on Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Shortcuts and regex help now links to manual pages
 - Minor wording improvements for some highlighting buttons
 - Improvements to installation procedure and instructions for Mac users
+- Use Command key in place of Alt key in keyboard shortcuts on Macs
 - Cmd-up/down key bindings added to match usual Mac behavior
 - Optional command line argument `--home` added to specify the directory
   where persistent data files, such as `setting.rc`, will be stored,

--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -104,8 +104,10 @@ our $urlprojectpage       = 'https://www.pgdp.net/c/project.php?id=';
 our $urlprojectdiscussion = 'https://www.pgdp.net/c/tools/proofers/project_topic.php?project=';
 
 ### Application Globals
-our $activecolor      = '#24baec';    #'#f2f818';
+our $activecolor      = '#24baec';                      #'#f2f818';
 our $alpha_sort       = 'f';
+our $altkey           = $OS_MAC ? "Meta"    : "Alt";    # Alt key used in binding routine calls
+our $altkeyname       = $OS_MAC ? "Command" : "Alt";    # Name of Alt key for display to user
 our $auto_page_marks  = 1;
 our $auto_show_images = 0;
 our $autobackup       = 0;

--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -103,7 +103,7 @@ our $urlprojectpage       = 'https://www.pgdp.net/c/project.php?id=';
 our $urlprojectdiscussion = 'https://www.pgdp.net/c/tools/proofers/project_topic.php?project=';
 
 ### Application Globals
-our $activecolor      = '#24baec';                      #'#f2f818';
+our $activecolor      = '#24baec';
 our $alpha_sort       = 'f';
 our $altkey           = $OS_MAC ? "Meta"    : "Alt";    # Alt key used in binding routine calls
 our $altkeyname       = $OS_MAC ? "Command" : "Alt";    # Name of Alt key for display to user

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -262,10 +262,8 @@ sub errorcheckpop_up {
         }
     );
 
-    # Alt + button 1 pops the Search dialog prepopulated with the queried word
-    $::lglobal{errorchecklistbox}->eventAdd( '<<search>>' => '<Alt-ButtonRelease-1>' );
-    $::lglobal{errorchecklistbox}->eventAdd( '<<search>>' => '<Meta-ButtonRelease-1>' )
-      if $::OS_MAC;
+    # Alt/command + button 1 pops the Search dialog prepopulated with the queried word
+    $::lglobal{errorchecklistbox}->eventAdd( '<<search>>' => "<$::altkey-ButtonRelease-1>" );
     $::lglobal{errorchecklistbox}->bind(
         '<<search>>',
         sub {

--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -14,11 +14,11 @@ sub keybindings {
     my $top        = $::top;
 
     # Highlight
-    keybind( '<Control-comma>',   sub { ::hilitesinglequotes(); } );
-    keybind( '<Control-period>',  sub { ::hilitedoublequotes(); } );
-    keybind( '<Control-Alt-h>',   sub { ::hilitepopup(); } );
-    keybind( '<Control-Shift-a>', sub { ::hilite_alignment_toggle(); } );
-    keybind( '<Control-0>',       sub { ::hiliteremove(); } );
+    keybind( '<Control-comma>',       sub { ::hilitesinglequotes(); } );
+    keybind( '<Control-period>',      sub { ::hilitedoublequotes(); } );
+    keybind( "<Control-$::altkey-h>", sub { ::hilitepopup(); } );
+    keybind( '<Control-Shift-a>',     sub { ::hilite_alignment_toggle(); } );
+    keybind( '<Control-0>',           sub { ::hiliteremove(); } );
     keybind(
         '<Control-semicolon>',
         sub {
@@ -33,14 +33,14 @@ sub keybindings {
     keybind( '<Control-Shift-s>', sub { ::file_saveas($textwindow); } );
 
     # Select, copy, paste
-    keybind( '<Control-a>',     sub { $textwindow->selectAll; } );
-    keybind( '<Control-c>',     sub { ::textcopy(); }, '<<Copy>>' );
-    keybind( '<Control-x>',     sub { ::cut(); },      '<<Cut>>' );
-    keybind( '<Control-v>',     sub { ::paste(); } );
-    keybind( '<Control-Alt-v>', sub { ::paste('alternative'); } );    # to avoid Perl/Tk paste bug
-    keybind( '<F1>',            sub { ::colcopy($textwindow); } );
-    keybind( '<F2>',            sub { ::colcut($textwindow); } );
-    keybind( '<F3>',            sub { ::colpaste($textwindow); } );
+    keybind( '<Control-a>',           sub { $textwindow->selectAll; } );
+    keybind( '<Control-c>',           sub { ::textcopy(); }, '<<Copy>>' );
+    keybind( '<Control-x>',           sub { ::cut(); },      '<<Cut>>' );
+    keybind( '<Control-v>',           sub { ::paste(); } );
+    keybind( "<Control-$::altkey-v>", sub { ::paste('alternative'); } );    # to avoid Perl/Tk paste bug
+    keybind( '<F1>',                  sub { ::colcopy($textwindow); } );
+    keybind( '<F2>',                  sub { ::colcut($textwindow); } );
+    keybind( '<F3>',                  sub { ::colpaste($textwindow); } );
 
     # Tools
     keybind( '<F5>',       sub { ::wordfrequency(); } );
@@ -203,7 +203,7 @@ sub keybindings {
     keybind( '<Control-m>',       sub { ::indent( $textwindow, 'in' ); } );
     keybind( '<Control-Shift-m>', sub { ::indent( $textwindow, 'out' ); } );
     keybind(
-        '<Control-Alt-m>',
+        "<Control-$::altkey-m>",
         sub {
             $textwindow->addGlobStart;
             ::indent( $textwindow, 'in' ) for ( 1 .. 4 );
@@ -211,18 +211,18 @@ sub keybindings {
         }
     );
     keybind(
-        '<Control-Alt-Shift-m>',
+        "<Control-$::altkey-Shift-m>",
         sub {
             $textwindow->addGlobStart;
             ::indent( $textwindow, 'out' ) for ( 1 .. 4 );
             $textwindow->addGlobEnd;
         }
     );
-    keybind( '<Alt-Left>',  sub { ::indent( $textwindow, 'out' ); } );
-    keybind( '<Alt-Right>', sub { ::indent( $textwindow, 'in' ); } );
+    keybind( "<$::altkey-Left>",  sub { ::indent( $textwindow, 'out' ); } );
+    keybind( "<$::altkey-Right>", sub { ::indent( $textwindow, 'in' ); } );
 
     # Help
-    keybind( '<Control-Alt-r>', sub { ::display_manual("regexref"); } );
+    keybind( "<Control-$::altkey-r>", sub { ::display_manual("regexref"); } );
 
     # Mouse
     keybind( '<Shift-B1-Motion>', sub { $textwindow->shiftB1_Motion(@_); } );
@@ -293,7 +293,7 @@ sub keybindings {
 
     # Alternative paste to give user a second option if Perl/Tk utf8 bug strikes
     $textwindow->MainWindow->bind( 'Tk::Entry',
-        '<Control-Alt-v>' => sub { ::entrypaste( shift, 'alternative' ); }, );
+        "<Control-$::altkey-v>" => sub { ::entrypaste( shift, 'alternative' ); }, );
 
     # Override bindings relating to word movement/selection in Entry fields
     $textwindow->MainWindow->bind( 'Tk::Entry',

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -165,7 +165,7 @@ sub menu_edit {
         menu_edit_cutcopypaste(),
         [
             'command', 'Alternative Paste',
-            -accelerator => 'Ctrl+Alt+v',
+            -accelerator => "Ctrl+$::altkeyname+v",
             -command     => sub { ::paste('alternative'); },
         ],
         [ 'separator', '' ],
@@ -310,7 +310,7 @@ sub menu_search {
         ],
         [
             'command', '~Highlight Character, String or Regex...',
-            -accelerator => 'Ctrl+Alt+h',
+            -accelerator => "Ctrl+$::altkeyname+h",
             -command     => \&::hilitepopup,
         ],
         [
@@ -574,7 +574,7 @@ sub menu_txt {
         [
             'command',
             'Indent Selection ~1',
-            -accelerator => "Alt\x{2192},Ctrl+m",
+            -accelerator => "$::altkeyname\x{2192},Ctrl+m",
             -command     => sub {
                 ::indent( $textwindow, 'in' );
             }
@@ -582,7 +582,7 @@ sub menu_txt {
         [
             'command',
             'Indent Selection ~4',
-            -accelerator => 'Ctrl+Alt+m',
+            -accelerator => "Ctrl+$::altkeyname+m",
             -command     => sub {
                 $textwindow->addGlobStart;
                 ::indent( $textwindow, 'in' ) for ( 1 .. 4 );
@@ -592,7 +592,7 @@ sub menu_txt {
         [
             'command',
             'In~dent Selection -1',
-            -accelerator => "Alt\x{2190},Ctrl+Shift+m",
+            -accelerator => "$::altkeyname\x{2190},Ctrl+Shift+m",
             -command     => sub {
                 ::indent( $textwindow, 'out' );
             }

--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -903,7 +903,7 @@ sub composekeypopup {
     $::lglobal{composekeycombination} = $::composepopbinding;
     $::lglobal{composekeyshift}       = ( $::lglobal{composekeycombination} =~ /Shift-/ );
     $::lglobal{composekeycontrol}     = ( $::lglobal{composekeycombination} =~ /Control-/ );
-    $::lglobal{composekeyalt}         = ( $::lglobal{composekeycombination} =~ /Alt-/ );
+    $::lglobal{composekeyalt}         = ( $::lglobal{composekeycombination} =~ /$::altkeyname-/ );
     $::lglobal{composekeybase}        = $::lglobal{composekeycombination};
     $::lglobal{composekeybase} =~ s/.+-//;    # remove modifiers to find base key
 
@@ -915,7 +915,7 @@ sub composekeypopup {
         $::lglobal{composekeypop} = $top->Toplevel;
         $::lglobal{composekeypop}->title('Set Compose Key');
         $::lglobal{composekeypop}->Label( -text =>
-              "Press the key to use for starting Compose Sequences\nAlso select Shift, Control and/or Alt modifiers if required",
+              "Press the key to use for starting Compose Sequences\nAlso select Shift, Control and/or $::altkeyname modifiers if required",
         )->pack;
         my $f0 = $::lglobal{composekeypop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $f0->Checkbutton(
@@ -929,7 +929,7 @@ sub composekeypopup {
             -command  => \&composekeypopupbind,
         )->grid( -row => 1, -column => 2 );
         $f0->Checkbutton(
-            -text     => 'Alt',
+            -text     => $::altkeyname,
             -variable => \$::lglobal{composekeyalt},
             -command  => \&composekeypopupbind,
         )->grid( -row => 1, -column => 3 );
@@ -964,13 +964,15 @@ sub composekeypopupbind {
 
     # Combine the modifiers with the base key
     $::composepopbinding = '';
-    $::composepopbinding .= 'Shift-'   if $::lglobal{composekeyshift};
-    $::composepopbinding .= 'Control-' if $::lglobal{composekeycontrol};
-    $::composepopbinding .= 'Alt-'     if $::lglobal{composekeyalt};
+    $::composepopbinding .= 'Shift-'         if $::lglobal{composekeyshift};
+    $::composepopbinding .= 'Control-'       if $::lglobal{composekeycontrol};
+    $::composepopbinding .= "$::altkeyname-" if $::lglobal{composekeyalt};
     $::lglobal{composekeybase} = 'Alt_R' unless $::lglobal{composekeybase};    # sensible default
     $::composepopbinding .= $::lglobal{composekeybase};
 
-    ::keybind( "<$::composepopbinding>", sub { ::composepopup(); } );          # Rebind new combination
+    my $bind = $::composepopbinding;
+    $bind =~ s/$::altkeyname/$::altkey/;                                       # Pass internal form of altkey to binding routine (Meta instead of Command on Mac)
+    ::keybind( "<$bind>", sub { ::composepopup(); } );                         # Rebind new combination
 
     $::lglobal{composekeycombination} = $::composepopbinding;                  # Update dialog entry box
 }


### PR DESCRIPTION
Mac keyboards do not have an `Alt` key, but several shortcuts are set up to
use the `Alt` key. Use `Command` key (referred to internally as `Meta`) in
place of `Alt` on Macs.

Menu buttons should show Command/Alt as appropriate when
displaying shortcuts (for example `Search` menu, `Highlight Character, String or Regex`)
