### PR TITLE
Add `.xhtml` to list of extensions shown by File Open dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## Version 1.4.1-test3
+## Version 1.4.1
 
 - New Spell Query tool checks spelling, reporting queries in similar way to
   jeebies, bookloupe, etc. Similar buttons to old spell check dialog allow
@@ -24,6 +24,7 @@
   table row on a single text line.
 - Shortcuts and regex help now links to manual pages
 - Minor wording improvements for some highlighting buttons
+- File Open dialog now displays files with `.xhtml` extension
 - Improvements to installation procedure and instructions for Mac users
 - Cmd-up/down key bindings added to match usual Mac behavior
 - Optional command line argument `--home` added to specify the directory

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -18,8 +18,10 @@ sub file_open {    # Find a text file to open
     my $textwindow = shift;
     my ($name);
     return if ( ::confirmempty() =~ /cancel/i );
-    my $types = [ [ 'Text Files', [qw/.txt .text .ggp .htm .html .bk1 .bk2 .xml/] ],
-        [ 'All Files', ['*'] ], ];
+    my $types = [
+        [ 'Text Files', [qw/.txt .text .ggp .htm .html .bk1 .bk2 .xml .xhtml/] ],
+        [ 'All Files',  ['*'] ],
+    ];
     $name = $textwindow->getOpenFile(
         -filetypes  => $types,
         -title      => 'Open File',


### PR DESCRIPTION
Some users have `.xhtml` extension for their HTML5 files