### PR TITLE
Upgrade to ebookmaker 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@
 - New `Rejoin Rows` button in ASCII Table Effects dialog takes a table with
   one cell per line and a blank line to mark rows, and converts it to a
   table with double space separators for cells, and all the cells from each
-  table row on a single text line.
+  table row on a single text line
+- Latest ebookmaker version included - now creates epub3 and kf8 files in
+  addition to epub2 and mobi files
 - Shortcuts and regex help now links to manual pages
 - Minor wording improvements for some highlighting buttons
 - File Open dialog now displays files with `.xhtml` extension

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,11 +59,14 @@ to any previous versions._
    then return to re-try this step.
 7. Double click the `run_guiguts.bat` file in the same folder, and Guiguts
    should start up and be ready for use.
-8. See the [Guiguts Windows Installation](https://www.pgdp.net/wiki/PPTools/Guiguts/Install)
-   wiki page for information on installing the Aspell spell checker and an
-   image viewer to display scans and edit images. You can also find out how
-   to obtain and link to the kindlegen tool if you want your local version
-   of ebookmaker to create mobi files in addition to epub files.
+8. If you want to use the Spell Check tool, see the
+   [Guiguts Windows Installation](https://www.pgdp.net/wiki/PPTools/Guiguts/Install)
+   wiki page for information on installing the Aspell spell checker. If you
+   intend to use the new Spell Query tool instead, you do not need Aspell.
+   The same wiki page describes how to install an image viewer to display scans
+   and edit images. You can also find out how to obtain the Calibre e-book
+   software suite if you want your local version of ebookmaker to create Kindle
+   files in addition to epub files.
 9. Install [Java](#java) to be able to check your HTML and CSS from within
    Guiguts.
 
@@ -221,7 +224,8 @@ for a one-click start.
 
 ### Helper applications
 
-Homebrew provides some additional helper applications you might find useful:
+Homebrew provides some additional helper applications you might find useful
+(aspell is used for Spell Check, but not the new Spell Query tool):
 
 ```
 brew install aspell
@@ -234,11 +238,9 @@ See also the [Jeebies installation instructions](tools/jeebies/README.md).
 
 See also the [EBookMaker installation instructions](tools/ebookmaker/README.md).
 
-You will also need to obtain and link to the kindlegen tool if you want your
-local version of ebookmaker to create mobi files in addition to epub files.
-Kindlegen is included when you install [Kindle Previewer](https://www.amazon.com/gp/feature.html?docId=1000765261).
-You can tell Guiguts where kindlegen is installed using the Preferences ->
-Set File Paths dialog.
+You will also need to obtain the
+[Calibre e-book software suite](https://calibre-ebook.com/download) if you want your
+local version of ebookmaker to create Kindle files in addition to epub files.
 
 Install [Java](#java) to be able to check your HTML and CSS from within
 Guiguts.

--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -211,7 +211,6 @@ our $tidycommand        = '';
 our $validatecommand    = '';
 our $validatecsscommand = '';
 our $ebookmakercommand  = '';
-our $kindlegencommand   = '';
 our %charsuiteenabled   = ( 'Basic Latin' => 1 );    # All projects allow Basic Latin character suite
 our %pagenumbers;
 our %projectdict;

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -907,7 +907,7 @@ EOM
         for (
             qw /globallastpath globalspellpath globalspelldictopt globalviewerpath
             globalbrowserstart gutcommand jeebiescommand scannospath tidycommand
-            validatecommand validatecsscommand ebookmakercommand kindlegencommand/
+            validatecommand validatecsscommand ebookmakercommand/
         ) {
             if ( eval '$::' . $_ ) {
                 print $save_handle "\$$_", ' ' x ( 20 - length $_ ), "= '",

--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -794,21 +794,6 @@ sub filePathsPopup {
             -anchor => 'n',
             -fill   => 'x'
         );
-        $f8b->Label(
-            -text   => "Kindlegen:",
-            -width  => 22,
-            -anchor => 'w',
-        )->pack( -side => 'left' );
-        $f8b->Button(
-            -text    => 'Locate Kindlegen...',
-            -command => sub { ::locateExecutable( 'kindlegen', \$::kindlegencommand ); },
-            -width   => 24,
-        )->pack( -side => 'right' );
-        $f8b->Entry(
-            -textvariable => \$::kindlegencommand,
-            -relief       => 'sunken',
-            -background   => $::bkgcolor,
-        )->pack( -expand => 'y', -fill => 'x' );
         my $f9 = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
             -anchor => 'n',

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2385,8 +2385,8 @@ sub ebookmaker {
     my $err  = 0;
     my $warn = 0;
     while ( my $line = <$ebmout> ) {
-        $err++ if $line =~ "^ERROR:";
-        print "$line  -  " . $warn++
+        $err++ if $line =~ "^ERROR:" or $line =~ "^CRITICAL:";
+        $warn++
           if $line  =~ "^WARNING:"
           and $line !~ "No gnu dbm support found"                                # ignore some warnings
           and $line !~ "No pg-(header|footer) found, inserted a generated one"

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1192,25 +1192,6 @@ sub initialize {
             ::catfile( '\Program Files', 'Aspell', 'bin', 'aspell.exe' ) );
     }
 
-    if ($::OS_MAC) {
-        $::kindlegencommand = ::setdefaultpath(
-            $::kindlegencommand,
-            ::catfile(
-                '/Applications', 'Kindle Previewer 3.app',
-                'Contents', 'lib', 'fc', 'bin', 'kindlegen'
-            )
-        );
-    } else {
-        $::kindlegencommand = ::setdefaultpath(
-            $::kindlegencommand,
-            ::catfile(
-                File::HomeDir::home(), 'AppData', 'Local', 'Amazon',
-                'Kindle Previewer 3',  'lib',     'fc',    'bin',
-                'kindlegen.exe'
-            )
-        );
-    }
-
     my $textwindow = $::textwindow;
     $textwindow->tagConfigure( 'footnote', -background => 'cyan' );
     $textwindow->tagConfigure( 'scannos',  -background => $::highlightcolor );
@@ -2337,24 +2318,25 @@ sub ebookmaker {
     infoerror(
         "Files will appear in the directory $::globallastpath" . ( $makehtml ? "out" : "" ) );
 
-    # EBookMaker needs to use Tidy and Kindlegen, so temporarily append to the path
-    # local variable means global value will be restored at end of sub
-    local $ENV{PATH} = pathcatdir( $ENV{PATH}, ::dirname($::tidycommand) );
-
     # Set up options for which files ebookmaker will generate
-    my $makeoption   = "--make=html.images";
+    my $htmloption   = "";
+    my $epub2option  = "";
+    my $epub3option  = "";
     my $kindleoption = "";
-    unless ($makehtml) {
-        $makeoption = "--make=epub.images";
+    my $kf8option    = "";
 
-        # Only use kindlegen if it exists
-        if ( -e $::kindlegencommand ) {
-            $ENV{PATH} = pathcatdir( $ENV{PATH}, ::dirname($::kindlegencommand) );
+    if ($makehtml) {
+        $htmloption = "--make=html.images";
+    } else {
+        $epub2option = "--make=epub.images";
+        $epub3option = "--make=epub3.images";
+
+        # Only use Calibre to create mobi if it's on the path
+        if ( $ENV{PATH} =~ /calibre/i ) {
             $kindleoption = "--make=kindle.images";
+            $kf8option    = "--make=kf8.images";
         } else {
-            infoerror(
-                "For mobi files, use Set File Paths to locate kindlegen which you can obtain by installing Kindle Previewer 3"
-            );
+            infoerror("For Kindle files, install Calibre and ensure it is on your PATH");
         }
     }
 
@@ -2364,12 +2346,13 @@ sub ebookmaker {
     $outputdir =~ s/[\/\\]$//;                          # Remove trailing slash from output dir to avoid confusing ebookmaker
     my $configdir = ::dirname($::ebookmakercommand);    # Ebookmaker dir contains tidy.conf file
     $runner->run(
-        $::ebookmakercommand,   "--verbose",
-        "--max-depth=3",        $makeoption,
-        $kindleoption,          "--output-dir=$outputdir",
-        "--output-file=$fname", "--config-dir=$configdir",
-        "--title=$ttitle",      "--author=$tauthor",
-        "$filepath"
+        $::ebookmakercommand,      "--verbose",
+        "--max-depth=3",           $htmloption,
+        $epub2option,              $epub3option,
+        $kindleoption,             $kf8option,
+        "--output-dir=$outputdir", "--output-file=$fname",
+        "--config-dir=$configdir", "--title=$ttitle",
+        "--author=$tauthor",       "$filepath"
     );
 
     # Check for errors or warnings in ebookmaker output
@@ -2378,12 +2361,14 @@ sub ebookmaker {
     my $warn = 0;
     while ( my $line = <$ebmout> ) {
         $err++ if $line =~ "^ERROR:";
-        $warn++
+        print "$line  -  " . $warn++
           if $line  =~ "^WARNING:"
-          and $line !~ "No gnu dbm support found"                         # ignore some warnings
+          and $line !~ "No gnu dbm support found"                                # ignore some warnings
+          and $line !~ "No pg-(header|footer) found, inserted a generated one"
+          and $line !~ "no boilerplate found in file"
           and $line !~ '<table> lacks "summary" attribute'
           and $line !~ "elements having class .* have been rewritten.";
-        adderror($line);                                                  # Send all ebookmaker output to message log
+        adderror($line);                                                         # Send all ebookmaker output to message log
     }
     close $ebmout;
     unlink $tmpfile;

--- a/tools/ebookmaker/README.md
+++ b/tools/ebookmaker/README.md
@@ -9,9 +9,6 @@ https://github.com/gutenbergtools/ebookmaker
 
 We bundle a Windows binary of ebookmaker manually created by the 
 [ebm_builder](https://github.com/DistributedProofreaders/ebm_builder) tool.
-Also included is a tidy.conf file which is required by the ebookmaker process.
-If you intend to run the Windows binary outside of Guiguts, you may need to
-refer to the troubleshooting section below to direct it to the tidy.conf file.
 
 ### Installing the python version manually
 
@@ -85,10 +82,3 @@ been installed.
 EBookMaker requires Python 3.6 or later. If you have earlier versions of
 Python installed via Homebrew, you may get errors unless you uninstall them
 first.
-
-Ebookmaker requires a [tidy.conf file](https://github.com/gutenbergtools/ebookmaker/blob/master/ebookmaker/parsers/tidy.conf)
-to operate correctly. The default location it looks for this is the same
-directory as the main ebookmaker script resides. If ebookmaker is unable
-to find this file in your configuration, you can use the `--config-dir=<dir>`
-command line argument to point to the directory where a copy of tidy.conf
-is located.

--- a/tools/ebookmaker/package.sh
+++ b/tools/ebookmaker/package.sh
@@ -11,7 +11,7 @@ mkdir $DEST
 cp README.md $DEST
 
 if [[ $OS == "win" ]]; then
-    VERSION=0.11.30
+    VERSION=0.12.0
     URL=https://github.com/DistributedProofreaders/ebm_builder/releases/download/v$VERSION/ebookmaker-$VERSION.zip
     curl -L -o ebookmaker.zip $URL
     unzip ebookmaker.zip -d $DEST

--- a/tools/ebookmaker/package.sh
+++ b/tools/ebookmaker/package.sh
@@ -11,7 +11,7 @@ mkdir $DEST
 cp README.md $DEST
 
 if [[ $OS == "win" ]]; then
-    VERSION=0.12.0
+    VERSION=0.12.3
     URL=https://github.com/DistributedProofreaders/ebm_builder/releases/download/v$VERSION/ebookmaker-$VERSION.zip
     curl -L -o ebookmaker.zip $URL
     unzip ebookmaker.zip -d $DEST


### PR DESCRIPTION
New ebookmaker uses Calibre instead of kindlegen to convert epubs to Kindle
formats.

Although there will be ebookmaker 0.12.1, 0.12.2, etc., probably before the next GG release, I'd like to get these code changes merged in. Upgrading to later ebookmaker versions will just be a case of editing the version in `package.sh`.