### PR TITLE
Improve and simplify HTML conversion of ampersands

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -70,12 +70,7 @@ sub html_convert_simple_tag {
 sub html_convert_ampersands {
     my $textwindow = shift;
     ::working("Converting Ampersands");
-    ::named( '&(?![\w#])', '&amp;' );
-    ::named( '&$',         '&amp;' );
-    ::named( '& ',         '&amp; ' );
-    ::named( '&c\.',       '&amp;c.' );
-    ::named( '&c,',        '&amp;c.,' );
-    ::named( '&c ',        '&amp;c. ' );
+    ::named( '&', '&amp;' );
     $textwindow->FindAndReplaceAll( '-regexp', '-nocase', "(?<![a-zA-Z0-9/\\-\"])>", "&gt;" );
     $textwindow->FindAndReplaceAll( '-regexp', '-nocase',
         "(?![\\n0-9])<(?![a-zA-Z0-9/\\-\\n])", '&lt;' );


### PR DESCRIPTION
Various conversions of ampersands to the HTML entity were used, trapping
specific cases, such as `&c` followed by a period, comma or space, but not
every case that should be trapped. Since ampersand conversion is the first
operation in HTML conversion, there should be no ampersands other than
those in the text, i.e. none used for HTML entities, etc. Therefore it is simpler
and more comprehensive to just convert every ampersand to the named
entity.

Note that the same can't be done for `<` and `>` since these are used for
DP markup that will be in the text file prior to conversion, e.g. italic or
smallcap markup. This code is therefore left unchanged.

Fixes #975