### PR TITLE
Facilitate retention of settings between releases

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -37,7 +37,6 @@ use File::Spec::Functions qw(catdir);
 use File::Copy;
 use File::Compare;
 use File::Which;
-use Getopt::Long;
 use HTML::Entities;
 use HTML::TokeParser;
 use Image::Size;
@@ -323,34 +322,7 @@ local $SIG{__WARN__} = \&::warnerror;
 # }
 
 # Process command-line arguments before calling initialize().
-#
-# runtests must be set before initialize(), otherwise it will load
-# setting.rc which could influence the test results.
-#
-# homedirectory must be handled before initialize(), so that
-# homedirectory and guigutsdirectory are both set correctly.
-
-# Default values if not specified on command line
-$lglobal{runtests}      = 0;
-$lglobal{homedirectory} = '';
-
-GetOptions(
-    'home=s'   => \$lglobal{homedirectory},
-    'runtests' => \$lglobal{runtests}
-) or die("Error in command line arguments\n");
-
-if ( $lglobal{homedirectory} ) {
-    $lglobal{homedirectory} = ::rel2abs( $lglobal{homedirectory} );
-    ::infoerror( "Using home directory: " . $lglobal{homedirectory} );
-
-    if ( -e $lglobal{homedirectory} ) {
-        die "ERROR: --home directory must be a directory\n" unless -d $lglobal{homedirectory};
-    } else {
-        die "ERROR: --home directory could not be created\n" unless mkdir $lglobal{homedirectory};
-    }
-
-    die "ERROR: --home directory is not writeable\n" unless -w $lglobal{homedirectory};
-}
+processcommandline();
 
 initialize();    # Initialize a bunch of vars that need it.
 

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -865,7 +865,8 @@ sub menu_preferences_filepaths {
         [
             'command', 'Set ~File Paths...', -command => sub { ::filePathsPopup(); },
         ],
-        [ 'command', 'Set DP ~URLs...', -command => \&::setDPurls, ],
+        [ 'command', 'Set DP ~URLs...',                       -command => \&::setDPurls, ],
+        [ 'command', 'Use ~Settings From Another Release...', -command => \&::copysettings, ],
     ];
 }
 

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use POSIX qw /strftime /;
 use File::HomeDir qw /home/;
+use Getopt::Long;
 
 BEGIN {
     use Exporter();
@@ -408,7 +409,7 @@ sub path_defaultdict {
 #
 # Return path to default GG homedir location under user's home folder
 sub path_defaulthomedir {
-    if ($::OS_WIN) {
+    if ( $::OS_WIN or $::OS_MAC ) {
         return ::catdir( File::HomeDir::home(), "Documents", "GGprefs" );
     } else {
         return ::catdir( File::HomeDir::home(), ".GGprefs" );
@@ -3314,8 +3315,6 @@ sub BindMouseWheel {
 #
 # homedirectory must be handled before initialize(), so that
 # homedirectory and guigutsdirectory are both set correctly.
-use Getopt::Long;
-
 sub processcommandline {
 
     # Default values if not specified on command line

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -21,7 +21,8 @@ BEGIN {
       &scrolldismiss &updatedrecently &hidelinenumbers &restorelinenumbers &displaylinenumbers
       &enable_interrupt &disable_interrupt &set_interrupt &query_interrupt &soundbell &busy &unbusy
       &dieerror &warnerror &infoerror &poperror &BindMouseWheel &display_manual
-      &path_settings &path_htmlheader &path_defaulthtmlheader &path_labels &path_defaultlabels &path_userdict &path_defaultdict);
+      &path_settings &path_htmlheader &path_defaulthtmlheader &path_labels &path_defaultlabels &path_userdict &path_defaultdict
+      &processcommandline &copysettings);
 
 }
 
@@ -404,6 +405,16 @@ sub path_defaultdict {
     return ::catfile( 'data', "dict_$::booklang" . "_default.txt" );
 }
 
+#
+# Return path to default GG homedir location under user's home folder
+sub path_defaulthomedir {
+    if ($::OS_WIN) {
+        return ::catdir( File::HomeDir::home(), "Documents", "GGprefs" );
+    } else {
+        return ::catdir( File::HomeDir::home(), ".GGprefs" );
+    }
+}
+
 # system(LIST)
 # (but slightly more robust, particularly on Windows).
 sub run {
@@ -750,6 +761,13 @@ sub working {
 }
 
 sub initialize {
+
+    # Get location of guiguts.pl & make it the current directory
+    $::lglobal{guigutsdirectory} = ::dirname( ::rel2abs($0) );
+    chdir $::lglobal{guigutsdirectory};
+
+    sethomedir();
+
     $::top = ::tkinit( -title => $::window_title, );
     my $top = $::top;
     $top->minsize( 440, 90 );
@@ -790,11 +808,6 @@ sub initialize {
         -format => 'gif',
         -data   => $::icondata
     );
-    if ( $0 =~ m/\/|\\/ ) {
-        my $dir = $0;
-        $dir =~ s/(\/|\\)[^\/\\]+$/$1/;
-        chdir $dir if length $dir;
-    }
 
     # positionhash stores user's window position
     # geometryhash stores user's window position and size
@@ -935,11 +948,6 @@ sub initialize {
     $::manualhash{'versionbox'}        = '/Help_Menu#Guiguts_HELP_Menu:_Online_and_Built-in_Help';
     $::manualhash{'wfpop'}             = '/Tools_Menu#Word_Frequency';
     $::manualhash{'workpop'}           = '#Overview';
-
-    $::lglobal{guigutsdirectory} = ::dirname( ::rel2abs($0) )
-      unless defined $::lglobal{guigutsdirectory};
-    $::lglobal{homedirectory} = $::lglobal{guigutsdirectory}
-      unless $::lglobal{homedirectory};
 
     ::composeinitialize();
 
@@ -3296,6 +3304,154 @@ sub BindMouseWheel {
         $bindwidget->bind( '<4>' => sub { $listwidget->yview( 'scroll', -3, 'units' ); } );
         $bindwidget->bind( '<5>' => sub { $listwidget->yview( 'scroll', +3, 'units' ); } );
     }
+}
+
+#
+# Process command line, which has to be done before call to initialize() in guiguts.pl
+#
+# runtests must be set before initialize(), otherwise it will load
+# setting.rc which could influence the test results.
+#
+# homedirectory must be handled before initialize(), so that
+# homedirectory and guigutsdirectory are both set correctly.
+use Getopt::Long;
+
+sub processcommandline {
+
+    # Default values if not specified on command line
+    $::lglobal{runtests}      = 0;
+    $::lglobal{homedirectory} = '';
+
+    GetOptions(
+        'home=s'   => \$::lglobal{homedirectory},
+        'runtests' => \$::lglobal{runtests}
+    ) or die("Error in command line arguments\n");
+}
+
+#
+# Handle setting of homedir to store prefs, language data files, personal dictionary files, etc
+# Priority as follows:
+# 1. If set via command line, use if it is suitable
+# 2. If default homedir location exists, use it
+# 3. Use historical location under release
+sub sethomedir {
+
+    # If homedir already specified via command line, ensure it is suitable
+    if ( $::lglobal{homedirectory} ) {
+        $::lglobal{homedirectory} = ::rel2abs( $::lglobal{homedirectory} );
+        ::infoerror( "Using home directory: " . $::lglobal{homedirectory} );
+        if ( -e $::lglobal{homedirectory} ) {
+            die "ERROR: --home directory must be a directory\n" unless -d $::lglobal{homedirectory};
+        } else {
+            die "ERROR: --home directory could not be created\n"
+              unless mkdir $::lglobal{homedirectory};
+        }
+        die "ERROR: --home directory is not writeable\n" unless -w $::lglobal{homedirectory};
+    } else {    # Otherwise if user's global GG prefs dir exists, use that
+        my $defaulthomedirectory = path_defaulthomedir();
+        $::lglobal{homedirectory} = $defaulthomedirectory if -d $defaulthomedirectory;
+    }
+
+    # If still not set, use historical locations under the release directory
+    $::lglobal{homedirectory} = $::lglobal{guigutsdirectory}
+      unless $::lglobal{homedirectory};
+}
+
+#
+# Copy various settings files from another release into the default home directory location
+sub copysettings {
+    my $top = $::top;
+
+    # User chooses release to copy from
+    my $source = $top->chooseDirectory(
+        -title =>
+          "Choose top-level Guiguts release folder with settings you want to copy. Cancel now if you have unsaved changes!",
+        -initialdir => "$::lglobal{guigutsdirectory}",
+    );
+    return unless $source and -d $source;
+
+    # Check user hasn't chosen global homedir by mistake
+    if ( $source eq path_defaulthomedir() ) {
+        $top->messageBox(
+            -icon    => 'error',
+            -type    => 'Ok',
+            -title   => 'Bad Folder',
+            -message => "You must choose a Guiguts release folder"
+        );
+        return;
+    }
+
+    # Check that user has selected a suitable directory, i.e. contains appropriate files/folders
+    my $settings = 'setting.rc';
+    my $header   = 'header.txt';
+    for my $file ( $settings, $header ) {
+        unless ( -f ::catfile( $source, $file ) ) {
+            $top->messageBox(
+                -icon    => 'error',
+                -type    => 'Ok',
+                -title   => 'Bad Folder',
+                -message => "$source does not contain a '$file' file"
+            );
+            return;
+        }
+    }
+    my $datadir = 'data';
+    unless ( -d ::catdir( $source, $datadir ) ) {
+        $top->messageBox(
+            -icon    => 'error',
+            -type    => 'Ok',
+            -title   => 'Bad Folder',
+            -message => "$source does not contain a '$datadir' folder"
+        );
+        return;
+    }
+
+    # Ensure we have a folder to copy into
+    my $dest = path_defaulthomedir();
+    if ( -d $dest ) {    # If homedir already exists, is it OK to overwrite files in it?
+        my $ans = $top->messageBox(
+            -icon    => 'warning',
+            -type    => 'YesNo',
+            -default => 'yes',
+            -title   => 'Overwrite Warning',
+            -message =>
+              "You already have a global settings folder: $dest - are you sure you want to overwrite the settings there with the ones stored under $source?"
+        );
+        return if $ans =~ /no/i;
+    } else {             # If it doesn't exist, create it
+        die "ERROR: settings directory could not be created\n" unless mkdir $dest;
+    }
+    die "ERROR: settings directory is not writeable\n" unless -w $dest;
+
+    # Copy any top level files first
+    for my $file ( $settings, $header ) {
+        ::copy( ::catfile( $source, $file ), ::catfile( $dest, $file ) );
+    }
+
+    # Now copy user's labels files and dictionary files
+    my $datasource = ::catdir( $source, $datadir );
+    opendir( my $dh, $datasource ) || die "Can't opendir $datasource: $!";
+    my @files = sort grep { -f "$datasource/$_" } readdir($dh);
+    closedir $dh;
+    for my $file (@files) {
+        next if $file =~ /labels.*default\.rc/;    # Don't copy default labels files
+        ::copy( ::catfile( $datasource, $file ), ::catfile( $dest, $file ) )
+          if $file =~ /labels_.*\.rc/ or $file =~ /dict_.*_user\.txt/;
+    }
+
+    # Need to exit immediately to stop newly copied setting.rc file being overwritten.
+    # This could happen if the global settings folder already existed, so this
+    # execution of the program was already using the setting.rc from there.
+    # Now the user has overwritten that setting.rc by copying from a different release,
+    # we must not re-overwrite it from within this program.
+    $top->messageBox(
+        -icon    => 'warning',
+        -type    => 'Ok',
+        -title   => 'Restart Necessary',
+        -message =>
+          "Program will now exit. Restart Guiguts to use the settings you have copied to $dest"
+    );
+    exit;
 }
 
 1;


### PR DESCRIPTION
Currently, users who want to retain settings, such as font size, have to copy
or edit the `setting.rc` file using the file from their previous release into
their new release. This also applies to customised `header.txt` files, language
label files and user dictionaries.

Building on #959, which allowed the user to specify a prefs folder with
a `--home` argument, this commit implements a default prefs folder as
follows:

1. If the --home argument is specified, it takes priority.
2. If not, then a default prefs directory is used if it already exists
3. If the default prefs directory doesn't exists, prefs are stored under the
release as was done historically.

To support the user in their one-off setup of the default prefs directory,
a new option in the Prefs->Set File Paths menu copies relevant files into
the default prefs directory, creating it if it doesn't exist.