### PR TITLE
Allow broader range of names for user-defined scannos folder

### DIFF
--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -51,8 +51,12 @@ sub setdefaultpath {
             if ( $oldpath && -e $oldpath ) {
                 my $oldtail = '';
                 $index = index( $oldpath, 'tools' );
-                $index = index( $oldpath, 'scannos' ) if $index < 0;
-                if ( $index >= 0 ) {                     # Old path was in tools or scannos under the release
+
+                # Extra basename condition for scannos permits user to name their custom folder anything but "scannos",
+                # Without that, names ending in "scannos", like "myscannos" would match the default name and get reset
+                $index = index( $oldpath, 'scannos' )
+                  if $index < 0 and basename($oldpath) eq "scannos";
+                if ( $index >= 0 ) {    # Old path was in tools or scannos under the release
                     my $oldtail = substr( $oldpath, $index );
                     return $oldpath unless $newtail eq $oldtail;    # Old path was different so keep it
                 } else {


### PR DESCRIPTION
Due to `scannos` being a folder directly under the release (as opposed to
an executable in a subfolder of `tools`, like most of the other settings that
are configurable using `Set File Paths`, there are limitations on the name
a user can choose for their own customised scannos folder.

Previously, the user could not choose a folder name that ended in `scannos`,
e.g. `custom_scannos`, or the next time GG was run, the program reset it to
the default location under the release. The name `scannos_custom` was OK.

Slight adjustment to code now allows names like `custom_scannos`, or
`myscannos`. The only name that does not work is precisely `scannos`, since
it would be hard to know if that was under a release or not.

The manual already described the previous restriction and will be edited to
reflect the new, lesser restriction.