### PR TITLE
Improve default tool locations on Macs

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1177,6 +1177,7 @@ sub initialize {
 
     # If XnView or Aspell are installed under "Program Files (x86)",
     # set that as the default, otherwise use "Program Files"
+    # Suitable for Windows installation locations
     my $trypath = ::catfile( '\Program Files (x86)', 'XnView', 'xnview.exe' );
     if ( -e $trypath ) {
         $::globalviewerpath = ::setdefaultpath( $::globalviewerpath, $trypath );
@@ -1190,6 +1191,14 @@ sub initialize {
     } else {
         $::globalspellpath = ::setdefaultpath( $::globalspellpath,
             ::catfile( '\Program Files', 'Aspell', 'bin', 'aspell.exe' ) );
+    }
+
+    # Override to more likely default locations for Mac
+    if ($::OS_MAC) {
+        $::globalviewerpath = ::setdefaultpath( $::globalviewerpath,
+            ::catfile( '/Applications', 'XnViewMP.app', 'Contents', 'MacOS', 'XnViewMP' ) );
+        $::globalspellpath =
+          ::setdefaultpath( $::globalspellpath, ::catfile( '/opt', 'homebrew', 'bin', 'aspell' ) );
     }
 
     if ($::OS_MAC) {

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1206,8 +1206,15 @@ sub initialize {
     if ($::OS_MAC) {
         $::globalviewerpath = ::setdefaultpath( $::globalviewerpath,
             ::catfile( '/Applications', 'XnViewMP.app', 'Contents', 'MacOS', 'XnViewMP' ) );
-        $::globalspellpath =
-          ::setdefaultpath( $::globalspellpath, ::catfile( '/opt', 'homebrew', 'bin', 'aspell' ) );
+
+        # M1 and Intel-based Macs have Aspell installed in different locations
+        $trypath = ::catfile( '/opt', 'homebrew', 'bin', 'aspell' );
+        if ( -e $trypath ) {
+            $::globalspellpath = ::setdefaultpath( $::globalspellpath, $trypath );
+        } else {
+            $::globalspellpath =
+              ::setdefaultpath( $::globalspellpath, ::catfile( '/usr', 'local', 'bin', 'aspell' ) );
+        }
     }
 
     if ($::OS_MAC) {


### PR DESCRIPTION
XnView and Aspell had Windows-specific default install locations.
Override with better possibilities for Macs

Fixes #971