### PR TITLE
Make `<Shift>` `Next Occurrence` button reverse direction

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1245,7 +1245,7 @@ sub searchpopup {
                 -padx   => 2,
                 -anchor => 'w'
             );
-            my $nextoccurrencebutton = $sf5->Button(
+            $::lglobal{nextoccurrencebutton} = $sf5->Button(
                 -activebackground => $::activecolor,
                 -command          => sub {
                     searchtext('');
@@ -1257,6 +1257,7 @@ sub searchpopup {
                 -padx   => 2,
                 -anchor => 'w'
             );
+            search_shiftreverse( $::lglobal{nextoccurrencebutton} );
             my $lastbutton = $sf5->Button(
                 -activebackground => $::activecolor,
                 -command          => sub {


### PR DESCRIPTION
In the Stealth Scannos dialog (a version of the S&R dialog) the Search
button reverses direction temporarily if the user Shift-clicks instead of
clicking.
The Next Occurrence button performs a similar task and should have the
same reverse feature.

Fixes #985