### PR TITLE
Fix virtual event crossover between WF and ErrorCheck

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -263,9 +263,9 @@ sub errorcheckpop_up {
     );
 
     # Alt/command + button 1 pops the Search dialog prepopulated with the queried word
-    $::lglobal{errorchecklistbox}->eventAdd( '<<search>>' => "<$::altkey-ButtonRelease-1>" );
+    $::lglobal{errorchecklistbox}->eventAdd( '<<errsearch>>' => "<$::altkey-ButtonRelease-1>" );
     $::lglobal{errorchecklistbox}->bind(
-        '<<search>>',
+        '<<errsearch>>',
         sub {
             errorchecksetactive();
             my $line = $::lglobal{errorchecklistbox}->get('active');


### PR DESCRIPTION
Apparently virtual events, e.g. `<<search>>` are "shared by all widgets of the same MainWindow" according to the Perl/Tk docs. Because both Word Frequency and ErrorCheck had a `<<search>>` event, if you popped WF first, then dismissed it, then popped ErrorCheck, e.g. to run bookloupe, when you right-clicked an entry in the list widget, it executed the search routine and popped the S&R dialog, since in the WF dialog, right-clicking was bound to `<<search>>`. However in the ErrorCheck dialog, right-clicking should `<<remove>>` the entry not do a search.

Fixed by giving the virtual event a unique name - you learn something every day :)