### PR TITLE
Fix Accelerator key duplicate in HTML menu

### DIFF
--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -729,7 +729,7 @@ sub menu_html {
         ],
         [
             'command',
-            'Nu ~XHTML Checker',
+            'Nu X~HTML Checker',
             -command => sub {
                 ::errorcheckpop_up( $textwindow, $top, 'Nu XHTML Check' );
             }
@@ -774,6 +774,11 @@ sub menu_html {
         [
             'command', 'EB~ookMaker epub/mobi Generation', -command => sub { ::ebookmaker("epub"); }
         ],
+
+        # Uncomment for option to generate HTML5 using ebookmaker - files are written to "out" subfolder
+        # [
+        # 'command', 'HTML~5 Generation', -command => sub { ::ebookmaker("html"); }
+        # ],
     ];
 }
 


### PR DESCRIPTION
The `x` key was used for `HTML Auto Index` and `XHTML Checker`.

Also leave commented-out additional menu option to generate HTML5 using ebookmaker, for convenience during future dev/testing.