### PR TITLE
Avoid undefined variable when setting HTML attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@
   not be used
 - Default locations for Aspell and XnView were unsuitable for Mac systems
 - `Set File Paths/Locate Scannos` button failed on Mac systems
+- Right-clicking to configure buttons at top of HTML markup dialog could
+  generate multiple errors
 
 
 ## Version 1.4.0

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -2668,15 +2668,16 @@ sub markupconfig {
             ::killpopup('markupconfigpop');
         }
     );
+    $::htmlentryattribhash{$typ} //= '';            # Avoid settings file being written with this variable undefined
     ::dialogboxcommonsetup(
         'markupconfigpop',
         \$::htmlentryattribhash{$typ},
         'Class name or attributes: '
     );
 
-    markupconfiglabel( $w, $typ );    # Adjust label to show presence of class/attributes
+    markupconfiglabel( $w, $typ );                  # Adjust label to show presence of class/attributes
 
-    ::savesettings();                 # Ensure new definition gets saved in setting file
+    ::savesettings();                               # Ensure new definition gets saved in setting file
 
     # stop class callback being called - possible due to binding reordering in markupbindconfig
     $w->break;


### PR DESCRIPTION
When right-clicking (or ctrl-clicking) a button at the top of the HTML markup dialog to configure it, a reference to an htmlentryattribhash element gets passed to the dialog routine.
This brings it into existence, but initially it's undefined. If GG tries to write the settings file while the dialog is popped (e.g. if GG loses & gains focus) or if user cancels dialog, the undefined variable gives an error when writing to the settings file.
Solved by initialising it to empty string if it's undefined.

Fixes #992