### PR TITLE
Improve Set File Paths on Mac

### DIFF
--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -582,6 +582,8 @@ sub locateExecutable {
             $types = [ [ 'All Files', ['*'] ] ];
         }
     }
+    my $initdir = ::dirname( ${$exepathref} );
+    $initdir = $::lglobal{guigutsdirectory} unless -d $initdir;
     $::lglobal{pathtemp} = $textwindow->getOpenFile(
         -filetypes  => $types,
         -title      => "Where is your $exename executable?",

--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -587,7 +587,7 @@ sub locateExecutable {
     $::lglobal{pathtemp} = $textwindow->getOpenFile(
         -filetypes  => $types,
         -title      => "Where is your $exename executable?",
-        -initialdir => ::dirname( ${$exepathref} ),
+        -initialdir => $initdir,
     );
     ${$exepathref} = $::lglobal{pathtemp}
       if $::lglobal{pathtemp};

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1207,13 +1207,27 @@ sub initialize {
         $::globalviewerpath = ::setdefaultpath( $::globalviewerpath,
             ::catfile( '/Applications', 'XnViewMP.app', 'Contents', 'MacOS', 'XnViewMP' ) );
 
-        # M1 and Intel-based Macs have Aspell installed in different locations
+        # M1 and Intel-based Macs have some tools installed in different locations
         $trypath = ::catfile( '/opt', 'homebrew', 'bin', 'aspell' );
         if ( -e $trypath ) {
             $::globalspellpath = ::setdefaultpath( $::globalspellpath, $trypath );
         } else {
             $::globalspellpath =
               ::setdefaultpath( $::globalspellpath, ::catfile( '/usr', 'local', 'bin', 'aspell' ) );
+        }
+        $trypath = ::catfile( '/opt', 'homebrew', 'bin', 'bookloupe' );
+        if ( -e $trypath ) {
+            $::gutcommand = ::setdefaultpath( $::gutcommand, $trypath );
+        } else {
+            $::gutcommand =
+              ::setdefaultpath( $::gutcommand, ::catfile( '/usr', 'local', 'bin', 'bookloupe' ) );
+        }
+        $trypath = ::catfile( '/opt', 'homebrew', 'bin', 'tidy' );
+        if ( -e $trypath ) {
+            $::tidycommand = ::setdefaultpath( $::tidycommand, $trypath );
+        } else {
+            $::tidycommand =
+              ::setdefaultpath( $::tidycommand, ::catfile( '/usr', 'local', 'bin', 'tidy' ) );
         }
     }
 


### PR DESCRIPTION
1. If the current setting for a tool's directory doesn't exist, open the path-choosing dialog in the main GG directory to avoid a Tk error.
2. Set better defaults for bookloupe and tidy's locations on Macs.