### PR TITLE
Use Spell Query for Word Frequency spell check

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -6,7 +6,7 @@ BEGIN {
     use Exporter();
     our ( @ISA, @EXPORT );
     @ISA    = qw(Exporter);
-    @EXPORT = qw(&errorcheckpop_up);
+    @EXPORT = qw(&errorcheckpop_up &spellquerycleardict);
 }
 
 my @errorchecklines;
@@ -1257,6 +1257,7 @@ sub booklouperun {
         my $textwindow = $::textwindow;
 
         return unless spellqueryinitialize();
+        spellqueryclearcounts();
 
         open my $logfile, ">", $errname or die "Error opening Spell Query output file: $errname";
 
@@ -1365,12 +1366,11 @@ sub booklouperun {
 
     #
     # Load the Spell Query default global dictionary and optional user global and project dictionaries
+    # Dictionary hash will have been cleared if new project loaded or language changed
     # Return true on success
     sub spellqueryinitialize {
 
-        # Clear any existing words in dictionary and frequency count
-        delete $sqglobaldict{$_}  for keys %sqglobaldict;
-        delete $sqbadwordfreq{$_} for keys %sqbadwordfreq;
+        return 1 if %sqglobaldict;    # Don't reload dictionaries if already loaded
 
         # Load dictionaries for current languages
         for my $lang ( ::list_lang() ) {
@@ -1448,6 +1448,19 @@ sub booklouperun {
         return $sqbadwordfreq{$1} if $line =~ /^\d+:\d+ +- (.+)/;
         return 0;
     }
+
+    #
+    # Clear the spell query dictionary
+    sub spellquerycleardict {
+        delete $sqglobaldict{$_} for keys %sqglobaldict;
+    }
+
+    #
+    # Clear the spell query frequency counts
+    sub spellqueryclearcounts {
+        delete $sqbadwordfreq{$_} for keys %sqbadwordfreq;
+    }
+
 }    # end of variable-enclosing block
 
 #

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -6,7 +6,7 @@ BEGIN {
     use Exporter();
     our ( @ISA, @EXPORT );
     @ISA    = qw(Exporter);
-    @EXPORT = qw(&errorcheckpop_up &spellquerycleardict);
+    @EXPORT = qw(&errorcheckpop_up &spellquerycleardict &spellqueryinitialize &spellquerywfwordok);
 }
 
 my @errorchecklines;
@@ -1302,6 +1302,18 @@ sub booklouperun {
             $step++;
         }
         close $logfile;
+    }
+
+    #
+    # Return true if word from Word Frequency list is OK
+    # Word may contain non-word characters (e.g. hyphen ) - OK if all the parts are OK
+    sub spellquerywfwordok {
+        my $wfword = shift;
+
+        for my $wd ( split( /\W/, $wfword ) ) {
+            return 0 unless spellquerywordok($wd);    # part not found
+        }
+        return 1;                                     # all parts ok
     }
 
     #

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -344,6 +344,7 @@ sub clearvars {
         }
     }
     %::reghints = ();
+    ::spellquerycleardict();
     %{ $::lglobal{seenwordsdoublehyphen} } = ();
     $::lglobal{seenwords}     = ();
     $::lglobal{seenwordpairs} = ();

--- a/src/lib/Guiguts/StatusBar.pm
+++ b/src/lib/Guiguts/StatusBar.pm
@@ -596,6 +596,7 @@ sub setlang {
                     $::booklang = $::lglobal{booklang};
                     update_lang_button();
                     ::readlabels();
+                    ::spellquerycleardict();
                 }
                 ::killpopup('setlangpop');
             }


### PR DESCRIPTION
Only load SQ dictionaries if something has changed.
If new project loaded, or user changes language settings, need to
load SQ dictionaries, otherwise, can just use the hash already
populated.

Additional wrapper routine needed because WF's wordlist includes
hyphenated words and other pairs of words.