### PR TITLE
Detect end-of-line he/be errors correctly

### DIFF
--- a/tools/jeebies/jeebies.c
+++ b/tools/jeebies/jeebies.c
@@ -85,7 +85,6 @@ void procfile(char *);
 char *getaword(char *, char *);
 char *getawordwithpunct(char *, char *);
 int matchword(char *, char *);
-char *flgets(char *, int, FILE *);
 void lowerit(char *);
 int gcisalpha(unsigned char);
 int gcisdigit(unsigned char);
@@ -179,7 +178,7 @@ void procfile(char *filename)
         fprintf(stdout, "jeebies: cannot open %s\n", filename);
         exit(1);
         }
-    while (flgets(aline, LINEBUFSIZE-1, infile)) {
+    while (fgets(aline, LINEBUFSIZE-1, infile)) {
         lowerit(aline);
         for (s = aline; *s;) {
             s = getaword(s, inword);
@@ -228,7 +227,7 @@ void procfile(char *filename)
     if (pswit[TOLERANT_SWITCH])
         threshold = 6.0;
 
-    while (flgets(aline, LINEBUFSIZE-1, infile)) {
+    while (fgets(aline, LINEBUFSIZE-1, infile)) {
         linecnt++;
         s = t = aline;
         isemptyline = 1;      /* assume the line is empty until proven otherwise */
@@ -421,37 +420,6 @@ binsch:
             
 
 }
-    
-/* flgets - get one line from the input stream                 */
-/* Returns a pointer to the line.                              */
-/* Do not replace with fgets, which retains newline characters */
-/* and breaks subsequent processing when phrase spans lines    */
-
-char *flgets(char *theline, int maxlen, FILE *thefile)
-{
-    char c;
-    int len, cint;
-
-    *theline = 0;
-    len = 0;
-    c = cint = fgetc(thefile);
-    do {
-        if (cint == EOF)
-            return (NULL);
-        if (c == 10)  /* end of line */
-            break;
-        if (c != 13) {
-            theline[len] = c;
-            len++;
-            theline[len] = 0;
-            }
-        c = cint = fgetc(thefile);
-    } while(len < maxlen);
-    return(theline);
-}
-
-
-
 
 
 /* getaword - extracts the first/next "word" from the line, and puts */

--- a/tools/jeebies/jeebies.c
+++ b/tools/jeebies/jeebies.c
@@ -85,6 +85,7 @@ void procfile(char *);
 char *getaword(char *, char *);
 char *getawordwithpunct(char *, char *);
 int matchword(char *, char *);
+char *flgets(char *, int, FILE *);
 void lowerit(char *);
 int gcisalpha(unsigned char);
 int gcisdigit(unsigned char);
@@ -178,7 +179,7 @@ void procfile(char *filename)
         fprintf(stdout, "jeebies: cannot open %s\n", filename);
         exit(1);
         }
-    while (fgets(aline, LINEBUFSIZE-1, infile)) {
+    while (flgets(aline, LINEBUFSIZE-1, infile)) {
         lowerit(aline);
         for (s = aline; *s;) {
             s = getaword(s, inword);
@@ -227,7 +228,7 @@ void procfile(char *filename)
     if (pswit[TOLERANT_SWITCH])
         threshold = 6.0;
 
-    while (fgets(aline, LINEBUFSIZE-1, infile)) {
+    while (flgets(aline, LINEBUFSIZE-1, infile)) {
         linecnt++;
         s = t = aline;
         isemptyline = 1;      /* assume the line is empty until proven otherwise */
@@ -420,6 +421,37 @@ binsch:
             
 
 }
+    
+/* flgets - get one line from the input stream                 */
+/* Returns a pointer to the line.                              */
+/* Do not replace with fgets, which retains newline characters */
+/* and breaks subsequent processing when phrase spans lines    */
+
+char *flgets(char *theline, int maxlen, FILE *thefile)
+{
+    char c;
+    int len, cint;
+
+    *theline = 0;
+    len = 0;
+    c = cint = fgetc(thefile);
+    do {
+        if (cint == EOF)
+            return (NULL);
+        if (c == 10)  /* end of line */
+            break;
+        if (c != 13) {
+            theline[len] = c;
+            len++;
+            theline[len] = 0;
+            }
+        c = cint = fgetc(thefile);
+    } while(len < maxlen);
+    return(theline);
+}
+
+
+
 
 
 /* getaword - extracts the first/next "word" from the line, and puts */

--- a/tools/jeebies/jeebies.c
+++ b/tools/jeebies/jeebies.c
@@ -228,6 +228,9 @@ void procfile(char *filename)
         threshold = 6.0;
 
     while (fgets(aline, LINEBUFSIZE-1, infile)) {
+        /* Terminate string at first end-of-line character */
+        /* or newline characters  break algorithm when phrase crosses line boundary */
+        aline[strcspn(aline, "\r\n")] = '\0';
         linecnt++;
         s = t = aline;
         isemptyline = 1;      /* assume the line is empty until proven otherwise */


### PR DESCRIPTION
Previous PR #1012 broke the detection of he/be errors across line boundaries. The replacement of `flgets` with `fgets` didn't take account of the fact that `fgets` keeps the newline character.

Maybe I should have resisted the temptation to tidy up :)

Rather than process the line `fgets` returns, or alter the he/be processing to cope with line endings, it seems safest and simplest to go back to `flgets`