### PR TITLE
Add W3C epubcheck tool to Guiguts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   English, French and German dictionaries are included with the release.
 - Word Frequency's Check Spelling button now uses Spell Query instead of
   Aspell.
+- New W3C epubcheck tool added to HTML menu. User selects the epub to be
+  checked, and results are shown in standard errorcheck dialog
 - Combining Characters now available in Compose Sequences, e.g. `+~` for 
   combining tilde above; `_~` for combining tilde below
 - Additional compose sequences added for precomposed vowels with macron and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   English, French and German dictionaries are included with the release.
 - Word Frequency's Check Spelling button now uses Spell Query instead of
   Aspell.
-- New W3C epubcheck tool added to HTML menu. User selects the epub to be
+- New W3C EPUBCheck tool added to HTML menu. User selects the epub to be
   checked, and results are shown in standard errorcheck dialog
 - Combining Characters now available in Compose Sequences, e.g. `+~` for 
   combining tilde above; `_~` for combining tilde below

--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -211,6 +211,7 @@ our $jeebiescommand     = '';
 our $tidycommand        = '';
 our $validatecommand    = '';
 our $validatecsscommand = '';
+our $epubcheckcommand   = '';
 our $ebookmakercommand  = '';
 our %charsuiteenabled   = ( 'Basic Latin' => 1 );    # All projects allow Basic Latin character suite
 our %pagenumbers;

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -655,7 +655,10 @@ sub errorcheckrun {    # Runs error checks
             -filetypes  => $types,
             -initialdir => ::getsafelastpath()
         );
-        return 1 unless $tmpfname;
+        unless ($tmpfname) {
+            $top->Unbusy;
+            return 1;
+        }
     } elsif ( $errorchecktype ne 'Spell Query' ) {    # No external tool, so no temp file needed
         savetoerrortmpfile( $tmpfname, $striptext );
     }

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -15,7 +15,7 @@ my $APOS = "\x{2019}";    # Curly apostrophe/right single quote
 
 # General error check window
 # Handles Bookloupe, Jeebies, HTML & CSS Validate, Tidy, Link Check
-# pphtml, pptxt, ppvimage, Spell Query, epubcheck and Load External Checkfile.
+# pphtml, pptxt, ppvimage, Spell Query, EPUBCheck and Load External Checkfile.
 sub errorcheckpop_up {
     my ( $textwindow, $top, $errorchecktype ) = @_;
     my ( $line, $lincol );
@@ -608,7 +608,7 @@ sub errorcheckrun {    # Runs error checks
     }
     $textwindow->focus;
     ::update_indicators();
-    unless ( $errorchecktype eq 'epubcheck' ) {    # Checks an epub, not the currently loaded file
+    unless ( $errorchecktype eq 'EPUBCheck' ) {    # Checks an epub, not the currently loaded file
         return 1 if ::nofileloadedwarning();
     }
 
@@ -629,9 +629,9 @@ sub errorcheckrun {    # Runs error checks
                 \$::validatecsscommand, $jartypes );
             return 1 unless $::validatecsscommand;
         }
-    } elsif ( $errorchecktype eq 'epubcheck' ) {
+    } elsif ( $errorchecktype eq 'EPUBCheck' ) {
         unless ($::epubcheckcommand) {
-            ::locateExecutable( 'W3C epubcheck (epubcheck.jar)', \$::epubcheckcommand, $jartypes );
+            ::locateExecutable( 'W3C EPUBCheck (epubcheck.jar)', \$::epubcheckcommand, $jartypes );
             return 1 unless $::epubcheckcommand;
         }
     }
@@ -646,9 +646,9 @@ sub errorcheckrun {    # Runs error checks
       ? "^(/[$::allblocktypes](?=[\[\n]))|([$::allblocktypes]/(?=[\n]))"
       : "";
 
-    # For epubcheck, instead of saving current file as a temporary file,
+    # For EPUBCheck, instead of saving current file as a temporary file,
     # user chooses an epub file to check
-    if ( $errorchecktype eq 'epubcheck' ) {
+    if ( $errorchecktype eq 'EPUBCheck' ) {
         my $types = [ [ 'Epub Files', ['.epub'] ], [ 'All Files', ['*'] ], ];
         $tmpfname = $::lglobal{errorcheckpop}->getOpenFile(
             -title      => 'File Name?',
@@ -669,7 +669,7 @@ sub errorcheckrun {    # Runs error checks
         my $runner = ::runner::tofile( $errname, $errname );    # stdout & stderr
         $runner->run( "java", "-jar", $::validatecsscommand, "--profile=$::cssvalidationlevel",
             "file:$tmpfname" );
-    } elsif ( $errorchecktype eq 'epubcheck' ) {
+    } elsif ( $errorchecktype eq 'EPUBCheck' ) {
         my $runner = ::runner::tofile( $errname, $errname );    # stdout & stderr
         $runner->run( "java", "-Xss2048k", "-jar", $::epubcheckcommand, $tmpfname );
     } elsif ( $errorchecktype eq 'pphtml' ) {
@@ -693,7 +693,7 @@ sub errorcheckrun {    # Runs error checks
         spellqueryrun($errname);
     }
     $top->Unbusy;
-    unlink $tmpfname unless $errorchecktype eq 'epubcheck';    # Don't delete the epub file
+    unlink $tmpfname unless $errorchecktype eq 'EPUBCheck';    # Don't delete the epub file
     return 0;
 }
 

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -11,7 +11,7 @@ BEGIN {
       &clearvars &savefile &_exit &file_mark_pages &_recentupdate &file_guess_page_marks
       &oppopupdate &opspop_up &confirmempty &openfile &readsettings &savesettings &file_export_pagemarkup
       &file_import_markup &file_import_ocr &operationadd &isedited &setedited &charsuitespopup &charsuitecheck &charsuitefind &charsuiteenable
-      &cpcharactersubs);
+      &cpcharactersubs &getsafelastpath);
 }
 
 sub file_open {    # Find a text file to open
@@ -908,7 +908,7 @@ EOM
         for (
             qw /globallastpath globalspellpath globalspelldictopt globalviewerpath
             globalbrowserstart gutcommand jeebiescommand scannospath tidycommand
-            validatecommand validatecsscommand ebookmakercommand/
+            validatecommand validatecsscommand epubcheckcommand ebookmakercommand/
         ) {
             if ( eval '$::' . $_ ) {
                 print $save_handle "\$$_", ' ' x ( 20 - length $_ ), "= '",

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -774,6 +774,13 @@ sub menu_html {
         [
             'command', 'EB~ookMaker epub/mobi Generation', -command => sub { ::ebookmaker("epub"); }
         ],
+        [
+            'command',
+            'W3C epu~bcheck',
+            -command => sub {
+                ::errorcheckpop_up( $textwindow, $top, 'epubcheck' );
+            }
+        ],
 
         # Uncomment for option to generate HTML5 using ebookmaker - files are written to "out" subfolder
         # [

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -776,9 +776,9 @@ sub menu_html {
         ],
         [
             'command',
-            'W3C epu~bcheck',
+            'W3C EPU~BCheck',
             -command => sub {
-                ::errorcheckpop_up( $textwindow, $top, 'epubcheck' );
+                ::errorcheckpop_up( $textwindow, $top, 'EPUBCheck' );
             }
         ],
 

--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -785,6 +785,29 @@ sub filePathsPopup {
             -relief       => 'sunken',
             -background   => $::bkgcolor,
         )->pack( -expand => 'y', -fill => 'x' );
+        my $f7a = $::lglobal{filepathspop}->Frame->pack(
+            -side   => 'top',
+            -anchor => 'n',
+            -fill   => 'x'
+        );
+        $f7a->Label(
+            -text   => "W3C epubcheck:",
+            -width  => 22,
+            -anchor => 'w',
+        )->pack( -side => 'left' );
+        $f7a->Button(
+            -text    => 'Locate epubcheck...',
+            -command => sub {
+                ::locateExecutable( 'W3C epubcheck (epubcheck.jar)',
+                    \$::epubcheckcommand, $jartypes );
+            },
+            -width => 24,
+        )->pack( -side => 'right' );
+        $f7a->Entry(
+            -textvariable => \$::epubcheckcommand,
+            -relief       => 'sunken',
+            -background   => $::bkgcolor,
+        )->pack( -expand => 'y', -fill => 'x' );
         my $f8 = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
             -anchor => 'n',

--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -791,14 +791,14 @@ sub filePathsPopup {
             -fill   => 'x'
         );
         $f7a->Label(
-            -text   => "W3C epubcheck:",
+            -text   => "W3C EPUBCheck:",
             -width  => 22,
             -anchor => 'w',
         )->pack( -side => 'left' );
         $f7a->Button(
-            -text    => 'Locate epubcheck...',
+            -text    => 'Locate EPUBCheck...',
             -command => sub {
-                ::locateExecutable( 'W3C epubcheck (epubcheck.jar)',
+                ::locateExecutable( 'W3C EPUBCheck (epubcheck.jar)',
                     \$::epubcheckcommand, $jartypes );
             },
             -width => 24,

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1197,6 +1197,8 @@ sub initialize {
         ::catfile( $::lglobal{guigutsdirectory}, 'tools', 'W3C', 'vnu.jar' ) );
     $::validatecsscommand = ::setdefaultpath( $::validatecsscommand,
         ::catfile( $::lglobal{guigutsdirectory}, 'tools', 'W3C', 'css-validator.jar' ) );
+    $::epubcheckcommand = ::setdefaultpath( $::epubcheckcommand,
+        ::catfile( $::lglobal{guigutsdirectory}, 'tools', 'W3C', 'epubcheck', 'epubcheck.jar' ) );
     $::gutcommand = ::setdefaultpath( $::gutcommand,
         ::catfile( $::lglobal{guigutsdirectory}, 'tools', 'bookloupe', 'bookloupe.exe' ) );
     $::jeebiescommand = ::setdefaultpath( $::jeebiescommand,

--- a/tools/W3C/package.sh
+++ b/tools/W3C/package.sh
@@ -22,3 +22,10 @@ mv dist/vnu.jar $DEST
 mv dist/LICENSE $DEST/vnu-LICENSE
 rm -rf dist vnu.zip
 
+# epubcheck.jar is the same for all systems
+VERSION=4.2.6
+URL=https://github.com/w3c/epubcheck/releases/download/v$VERSION/epubcheck-$VERSION.zip
+curl -L -o epubcheck.zip $URL
+unzip epubcheck.zip -d .
+mv epubcheck-$VERSION $DEST/epubcheck
+rm -f epubcheck.zip 


### PR DESCRIPTION
We already bundle the HTML and CSS validators. The epubcheck tool validates epub files. It is therefore slightly different to the other tools in that the user has to select a file to be checked, rather than it checking the currently loaded file.

Packaging seems to work fine when generating a release.