### PR TITLE
Refresh SQ correctly on adding  `good_words`

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -103,9 +103,13 @@ sub errorcheckpop_up {
         $::lglobal{spellqueryballoon} = $top->Balloon() unless $::lglobal{spellqueryballoon};
         $ptopframeb->Button(
             -activebackground => $::activecolor,
-            -command          => \&::spelladdgoodwords,
-            -text             => 'Add good_words.txt',
-            -width            => 16
+            -command          => sub {
+                ::spelladdgoodwords();                                     # Add good words to project dictionary
+                spellquerycleardict();                                     # Clear cache, so project dictionary will be reloaded below
+                errorcheckpop_up( $textwindow, $top, $errorchecktype );    # Rerun Spell Query
+            },
+            -text  => 'Add good_words.txt',
+            -width => 16
         )->grid( -row => 1, -column => $gcol - 1 );
         my $btnskip = $ptopframeb->Button(
             -activebackground => $::activecolor,


### PR DESCRIPTION
1. When `good_words.txt` was added to the project dictionary, the cached dictionaries weren't being cleared.
Overlooked when #1015 introduced caching.

2. When `good_words.txt` were added, user immediately had to re-run SQ to remove the good words from the list of queries. Now re-run SQ automatically.

Fixes #1030