### PR TITLE
Avoid undefined variable from bad bin file

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -1203,7 +1203,7 @@ sub interpretbinfile {
     my $markindex;
     foreach my $mark ( sort keys %::pagenumbers ) {
         $markindex = $::pagenumbers{$mark}{offset};
-        if ( $markindex eq '' ) {
+        unless ($markindex) {
             delete $::pagenumbers{$mark};
             next;
         }


### PR DESCRIPTION
Previous check for an empty `offset` field in the pagenumbers hash read from a bin file was not sufficient.

Check now triggers on `offset` being empty, zero (minimum valid offset is 1.0) or undefined (seen in the wild).