### PR TITLE
Retrieve Nu validator by tag not release

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,9 +17,10 @@ Github.
 4. Commit the version update changes and tag the release
    (ie: `git tag r<version>`) and push it up to github
 
-5. From a Linux or MacOS system, or a Windows system with MinGW installed,
-   confirm that you are working from a clean git checkout. Then build the
-   three releases using `make` or `make all` or
+5. From a Linux or MacOS system, or a Windows system with MSYS2 (Mingw64)
+   installed, ensure that you also have Python and the Java Development
+   Kit installed. Confirm that you are working from a clean git checkout.
+   Then build the three releases using `make` or `make all` or
    ```
    make win
    make mac

--- a/tools/W3C/package.sh
+++ b/tools/W3C/package.sh
@@ -14,13 +14,15 @@ cp README.md $DEST
 curl -L -o $DEST/css-validator.jar https://github.com/w3c/css-validator/releases/download/cssval-20211112/css-validator.jar
 
 # vnu.jar is the same for all systems
-VERSION=20.6.30
-URL=https://github.com/validator/validator/releases/download/$VERSION/vnu.jar_$VERSION.zip
-curl -L -o vnu.zip $URL
-unzip vnu.zip -d .
-mv dist/vnu.jar $DEST
-mv dist/LICENSE $DEST/vnu-LICENSE
-rm -rf dist vnu.zip
+TAG=22.9.29
+VDEST=$DEST/validator
+git clone --branch $TAG https://github.com/validator/validator.git $VDEST
+pushd $VDEST
+python ./checker.py update-shallow build jar
+mv build/dist/vnu.jar $DEST
+mv LICENSE $DEST/vnu-LICENSE
+popd
+rm -rf $VDEST
 
 # epubcheck.jar is the same for all systems
 VERSION=4.2.6


### PR DESCRIPTION
Nu validator is not being released regularly, just tagged. Git clone tagged version and build `vnu.jar`

Note for Windows development: requires Mingw64 shell since Mingw32 shell cannot deal with a file created during the build process with a Unicode character in the filename. When attempting to tidy after the build, the `rm -rf` fails claiming the `docs` dir is not empty, because `rm` can't delete a file in the dir.