### PR TITLE
Avoid uninitialized variable error calling ebookmaker

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2350,7 +2350,7 @@ sub ebookmaker {
     my $tauthor = 'Unknown';
     my $tbeg    = $textwindow->search( '-exact', '--', '<title>',  '1.0', '20.0' );
     my $tend    = $textwindow->search( '-exact', '--', '</title>', '1.0', '20.0' );
-    if ( $tbeg & $tend ) {
+    if ( $tbeg and $tend ) {
         my $tstring = $textwindow->get( $tbeg . '+7c', $tend );    # Get whole title/author string
         $tstring =~ s/\s+/ /g;                                     # Join into one line, single spaced
         if (


### PR DESCRIPTION
Unlikely to happen in the wild, unless HTML file has no `<title>` field.  Caused by wrong type of "and" in #571 18 months ago.

Interesting to speculate whether specific valid locations of the `<title>` and `</title>` fields could have bitwise-anded together to give "false" and therefore not pick up the author name. But not interesting enough that I want to try to make it happen.