### PR TITLE
Improve "word" selection

### DIFF
--- a/src/lib/Guiguts/TextUnicode.pm
+++ b/src/lib/Guiguts/TextUnicode.pm
@@ -390,11 +390,11 @@ sub SelectTo {
         }
     } elsif ( $mode eq 'word' ) {
         if ( $w->compare( $cur, '<', 'anchor' ) ) {
-            $first = $w->index( $w->safeword("$cur + 1c wordstart") );
-            $last  = $w->index( $w->safeword('anchor - 1c wordend') );
+            $first = $w->index( $w->safeword( "$cur + 1c wordstart", 'strictword' ) );
+            $last  = $w->index( $w->safeword( 'anchor - 1c wordend', 'strictword' ) );
         } else {
-            $first = $w->index( $w->safeword('anchor + 1c wordstart') );
-            $last  = $w->index( $w->safeword("$cur wordend") );
+            $first = $w->index( $w->safeword( 'anchor + 1c wordstart', 'strictword' ) );
+            $last  = $w->index( $w->safeword( "$cur wordend",          'strictword' ) );
         }
     } elsif ( $mode eq 'line' ) {
         if ( $w->compare( $cur, '<', 'anchor' ) ) {
@@ -521,15 +521,17 @@ sub KeySelect {
 #
 # Note this version interprets "wordend" as the beginning of the next word,
 # not the end of the current word since this is more common in modern editors
+# This can be overridden by passing a true value for the optional "strictword" argument
 #
 # A sequence of word characters counts as a "word", as does a sequence of
 # non-word non-space characters. Apostrophes count as word characters
 #
 # Start & end of line always count as word breaks
 sub safeword {
-    my $w   = shift;
-    my $pos = shift;
-    my $new = '';
+    my $w          = shift;
+    my $pos        = shift;
+    my $strictword = shift;
+    my $new        = '';
 
     # Word characters include straight & curly apostrophes, although this means
     # that close single quotes also count as word characters.
@@ -604,11 +606,12 @@ sub safeword {
         # Must be before non-space character
         # Find end of sequence of word or non-word characters by searching
         # for the opposite character (non-word or word) or a space
-        # Then skip spaces
+        # Then skip spaces (unless "strictword" mode)
         else {
             my $reg = $ch =~ $REGWORD ? $REGNONW : $REGWORD;
             $new = $w->search( '-regexp', '--', "($reg| )", "$pos", "$pos lineend" );
-            $new = $w->search( '-regexp', '--', '[^ ]',     "$new", "$pos lineend" ) if $new;
+            $new = $w->search( '-regexp', '--', '[^ ]',     "$new", "$pos lineend" )
+              if $new and not $strictword;
             $new = $w->index("$pos lineend") if not $new;
         }
         return $new;

--- a/src/lib/Guiguts/TextUnicode.pm
+++ b/src/lib/Guiguts/TextUnicode.pm
@@ -354,6 +354,23 @@ sub Button1 {
 }
 
 #
+# Modified selectWord/Line routines from Text.pm bound to double/triple click
+# Originals end with
+#   Tk::catch { $w->markSet('insert','sel.first') }
+# but that overrides SelectTo's positioning of cursor to improve subsequent selection extension
+sub selectWord {
+    my ($w) = @_;
+    my $Ev = $w->XEvent;
+    $w->SelectTo( $Ev->xy, 'word' );
+}
+
+sub selectLine {
+    my ($w) = @_;
+    my $Ev = $w->XEvent;
+    $w->SelectTo( $Ev->xy, 'line' );
+}
+
+#
 # Modified selection routine from Text.pm to deal with block selections
 # Also uses safeword() - see below
 #
@@ -441,7 +458,14 @@ sub SelectTo {
         $w->markSet( 'selend',   $last );
         $w->idletasks;
     }
-    if ( $w->compare( $cur, '<', $last ) ) {
+
+    # Change to default behavior of Text.pm:
+    # When user selects word or line via double/triple click, force the anchor to the start
+    # and the cursor to the end for more predictable selection extension behavior.
+    if ( $mode eq 'word' or $mode eq 'line' ) {
+        $w->markSet( 'anchor', $first );
+        $w->markSet( 'insert', $last );
+    } elsif ( $w->compare( $cur, '<', $last ) ) {
         $w->markSet( 'insert', $cur );
     } else {
         $w->markSet( 'insert', $last );


### PR DESCRIPTION
As part of [#941](https://github.com/DistributedProofreaders/guiguts/issues/941) which made navigation, selecting and deleting
by word chunks more consistent, double-clicking a word selected from the previous word start to the next one (similar
 to MS Word).

This was unpopular with users, so wind this back to only select the word itself, not any trailing spaces.

Also, after word (or line) select using double/triple click, the anchor for the selection was left at the click point (ie mid-word) which led to weirdness when subsequently extending the selection using Shift+arrow keys.

Now force the anchor to the start and the cursor to the end and it behaves more logically.

