### PR TITLE
Exit busy mode if aborting epub creation

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2328,7 +2328,6 @@ sub seeindex {
 sub ebookmaker {
     my $makehtml   = shift =~ m/html/i;
     my $textwindow = $::textwindow;
-    ::busy();    # Change cursor to show user something is happening
     unless ($::ebookmakercommand) {
         ::locateExecutable( 'EBookMaker', \$::ebookmakercommand );
         return unless $::ebookmakercommand;
@@ -2344,6 +2343,8 @@ sub ebookmaker {
         )->Show;
         return;
     }
+
+    ::busy();    # Change cursor to show user something is happening
 
     # Get title and author information
     my $ttitle  = $fname;      # Title defaults to base filename


### PR DESCRIPTION
If user tries to create epub from a text file, they get an error dialog. However, the busy cursor was being set up too early in the routine and not reset if routine exited prematurely.
Move busy setup to after the preliminary checks.

Fixes #1048 