### PR TITLE
Make `.gz` default extension for TIA OCR import

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -1100,7 +1100,8 @@ sub file_import_markup {
         return if ( ::confirmempty() =~ /cancel/i );
 
         my $directory = '';
-        my $name      = $textwindow->getOpenFile( -title => 'Open OCR File' );
+        my $types     = [ [ 'Gzip Files', ['.gz'] ], [ 'All Files', ['*'] ], ];
+        my $name      = $textwindow->getOpenFile( -title => 'Open OCR File', -filetypes => $types );
         return unless defined($name) and length($name);
         clearvars($textwindow);
         clearpopups();


### PR DESCRIPTION
Having `.gz` filetypes showing by default makes it easier for the user to find the file they want. They can always change to All Files if they have a different extension for some reason.