### PR TITLE
Use `figure`/`figcaption` instead of `div` for illos

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1840,7 +1840,7 @@ sub htmlimageok {
     my $alt = $::lglobal{alttext}->get;
     $alt =~ s/"/&quot;/g;
     $alt       = " alt=\"$alt\"";
-    $selection = "  <div class=\"caption\">$selection</div>\n"
+    $selection = "  <figcaption class=\"caption\">$selection</figcaption>\n"
       if $selection;
     $::lglobal{preservep} = '' unless $selection;
     my $title = $::lglobal{titltext}->get || '';
@@ -1863,9 +1863,9 @@ sub htmlimageok {
     $illowsuffix = 'e' if $::htmlimagewidthtype eq 'em';
     $illowsuffix = 'x' if $::htmlimagewidthtype eq 'px';
     my $classname = "illow$illowsuffix$widthcn";
-    my $divclass  = ( $::htmlimagewidthtype eq 'px' ? "" : " $classname" );
+    my $figclass  = ( $::htmlimagewidthtype eq 'px' ? "" : " $classname" );
 
-    # Replace [Illustration] with div, img and caption
+    # Replace [Illustration] with figure, img and figcaption
     $textwindow->addGlobStart;
     $textwindow->delete( 'thisblockstart', 'thisblockend' );
 
@@ -1879,10 +1879,10 @@ sub htmlimageok {
     $style = " style=\"width: ${width}px;\""        if $::htmlimagewidthtype eq 'px';
     my $wclass = $::htmlimagewidthtype eq 'px' ? '' : ' class="w100"';
     $textwindow->insert( 'thisblockstart',
-            "<div class=\"fig$::lglobal{htmlimgalignment}$divclass\" id=\"$idname\"$style>\n"
+            "<figure class=\"fig$::lglobal{htmlimgalignment}$figclass\" id=\"$idname\"$style>\n"
           . "  <img$wclass src=\"$name\"$sizexy$alt$title"
           . voidclosure() . "\n"
-          . "$selection</div>"
+          . "$selection</figure>"
           . $::lglobal{preservep} );
 
     # Write class into CSS block (sorted) - first find end of CSS


### PR DESCRIPTION
Now GG is producing HTML5, take advantage of the new `figure` and `figcaption` elements. One advantage should be that the caption should not get separated from the illo by a page break in epub format.

Fixes #1045 