### PR TITLE
Sq lang names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## Version 1.5.2
+
+### Bug Fixes
+
+- Aspell dictionary names containing non-word characters, e.g. `de-1901`
+  could not be used. Note the fix means multiple languages can now only
+  be separated by spaces, commas, or plus signs, e.g. `en, fr`
+
+
 ## Version 1.5.1
 
 - HTML5 `figure` and `figcaption` elements now used for illos

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -431,9 +431,9 @@ sub main_lang {
 }
 
 # Return the languages for this book as a list
-# Allow any non-word character as a separator
+# Allow space, comma or plus sign as a separator
 sub list_lang {
-    return split( /\W+/, $::booklang );
+    return split( /[+, ]+/, $::booklang );
 }
 
 # system(LIST)


### PR DESCRIPTION
Previously any non-word character in the list of languages for a
project was used as a separator. However, some Aspell dictionaries
have hyphens, e.g. "de-1901" or underscores.
Therefore restrict the characters used as separators to spaces, commas
or plus signs.