### PR TITLE
Accept decade/year/shilling/pence abbr. in SQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## Version 1.5.2
 
+- Spell query no longer queries year/decade/shillings/pence abbreviations,
+  e.g. '62, '60s, 1860s, 12s, 6d
+
 ### Bug Fixes
 
 - Aspell dictionary names containing non-word characters, e.g. `de-1901`

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -1435,6 +1435,14 @@ sub booklouperun {
         return 1 if $wd =~ /^\d*[04-9]th$/i;         # ...0th, ...4th, ...5th, etc
         return 1 if $wd =~ /^\d*1[123]th$/i;         # ...11th, ...12th, ...13th
 
+        # Allow decades/years
+        return 1 if $wd =~ /^['$APOS]?\d\ds$/;       # e.g. '20s or 20s (abbreviation for 1820s)
+        return 1 if $wd =~ /^['$APOS]\d\d$/;         # e.g. '62 (abbreviation for 1862)
+        return 1 if $wd =~ /^1\d{3}s$/;              # e.g. 1820s
+
+        # Allow abbreviations for shillings and pence (not pounds because 20l is common scanno for the number 201)
+        return 1 if $wd =~ /^\d{1,2}[sd]$/;          # e.g. 15s or 6d (up to 2 digits of old English shillings and pence)
+
         return 1 if $wd =~ /^sc$/i;                  # <sc> DP markup
 
         return 0;


### PR DESCRIPTION
Spell query now accepts dates such as `'62`; decades such as `'60s` or `1860s`; up to 2-digit shillings/pence such as `15s` or `6d`.

Fixes #1055