### PR TITLE
Don't report ebookmaker control classes as undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 - Spell query no longer queries year/decade/shillings/pence abbreviations,
   e.g. '62, '60s, 1860s, 12s, 6d
+- The pphtml tool no longer reports ebookmaker control classes, e.g.
+  `x-ebookmaker-drop` as undefined or unused
 
 ### Bug Fixes
 

--- a/src/lib/ppvchecks/pphtml.pl
+++ b/src/lib/ppvchecks/pphtml.pl
@@ -341,7 +341,7 @@ sub runProgram {
                     $found++;
                 }
             }
-            if ( not $found ) {
+            if ( ( not $found ) and ( $cssdef !~ /^x-ebookmaker/ ) ) {    # Don't report ebookmaker control classes
                 printf LOGFILE ( "%d:0 CSS possibly not used: %s\n", $cssline[$idx], $cssdef );
             }
         }
@@ -359,7 +359,9 @@ sub runProgram {
                     $found++;
                 }
             }
-            if ( ( not $found ) and ( not $cssused eq "blockquote" ) ) {
+            if (    ( not $found )
+                and ( $cssused ne "blockquote" )
+                and ( $cssused !~ /^x-ebookmaker/ ) ) {    # Don't report ebookmaker control classes
                 printf LOGFILE ( "%d:0 CSS possibly not defined: %s\n", $classes_line{$cssused},
                     $cssused );
             }


### PR DESCRIPTION
Classes are used to signal to ebookmaker to drop elements or that they are important. Such classes begin with `x-ebookmaker`. They typically have no CSS linked to them, so either end up being reported as undefined or unused by pphtml, causing concern to diligent PPers trying to avoid warnings from tools.

Fixes #1058 