### PR TITLE
Fix bug in `Apply Poetry Markup to Selection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Aspell dictionary names containing non-word characters, e.g. `de-1901`
   could not be used. Note the fix means multiple languages can now only
   be separated by spaces, commas, or plus signs, e.g. `en, fr`
+- `Apply Poetry Markup to Selection` could delete some characters when the 
+  poem text had not been indented
 
 
 ## Version 1.5.1


### PR DESCRIPTION
If the whole poem hadn't been indented in the text file, but some individual lines were indented due to poem structure, characters were lost from the start of a non-indented line which followed an indented one.

Error in logic checking if regex group set - needed to check if substitution actually made.

Also improved handling of blank lines, particularly at the start/end of the selection - it used to erroneously open/close a stanza div.

Fixes #1056