### PR TITLE
Add optional ruler/column numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
   e.g. '62, '60s, 1860s, 12s, 6d
 - The pphtml tool no longer reports ebookmaker control classes, e.g.
   `x-ebookmaker-drop` as undefined or unused
+- A ruler showing column numbers can be displayed at top of text window to
+  aid with text alignment; it indicates the current column. Ruler can be
+  shown/hidden using the Preferences menu, or using Shift+Right-click on
+  the Row/Col display in the Status Bar. Highlight Alignment Column now
+  highlights the column before the cursor rather than after the cursor to
+  match the new ruler.
 
 ### Bug Fixes
 

--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -203,6 +203,7 @@ our $utffontname           = 'Courier New';
 our $utffontsize           = 14;
 our $utffontweight         = 'normal';
 our $verboseerrorchecks    = 0;
+our $viscolnm              = 0;
 our $vislnnm               = 0;
 our $wfstayontop           = 0;
 

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -901,7 +901,7 @@ EOM
             txtfontname txtfontsize txtfontweight txtfontsystemuse
             twowordsinhyphencheck utfcharentrybase utffontname utffontsize utffontweight
             urlprojectpage urlprojectdiscussion
-            verboseerrorchecks vislnnm wfstayontop/
+            verboseerrorchecks viscolnm vislnnm wfstayontop/
         ) {
             print $save_handle "\$$_", ' ' x ( 25 - length $_ ), "= '", eval '$::' . $_, "';\n";
         }

--- a/src/lib/Guiguts/Highlight.pm
+++ b/src/lib/Guiguts/Highlight.pm
@@ -412,12 +412,12 @@ sub hilite_alignment {
     $textwindow->tagRemove( 'alignment', '1.0', 'end' );    # Remove any existing tags
     my $top = $textwindow->index('@0,0');                   # Find top line visible on screen (line at pixel 0,0)
     my ( $line, $col ) = split( /\./, $top );
-    $col = $::lglobal{highlightalignmentcolumn};            # Set column from saved global
+    $col = $::lglobal{highlightalignmentcolumn} - 1;        # Highlight column immediately preceding cursor for consistency with ruler
 
     # Add tags to each subsequent line that is visible on-screen, unless line is too short
     while ( $textwindow->compare( "$line.0", "<", "end" ) and $textwindow->dlineinfo("$line.0") ) {
-        $textwindow->tagAdd( 'alignment', "$line.$col" )
-          unless $textwindow->get("$line.$col") eq "\n";
+        my ( $ldummy, $maxcol ) = split( /\./, $textwindow->index("$line.0 lineend") );
+        $textwindow->tagAdd( 'alignment', "$line.$col" ) unless $col < 0 or $col >= $maxcol;
         $line++;
     }
 }

--- a/src/lib/Guiguts/LineNumberText.pm
+++ b/src/lib/Guiguts/LineNumberText.pm
@@ -1,4 +1,11 @@
-#$Id: LineNumberText.pm 1120 2012-02-20 06:30:00Z hmonroe $
+# LineNumberText
+# Implements a TextUnicode widget with scrollbars, line numbers and column numbers
+#
+# Advertises "scrolled" (the TextUnicode widget) and "corner" (the resizing corner)
+#
+# May originally have worked with Text widget instead of TextUnicode, but the rest
+# of Guiguts relies on the TextUnicode widget too much for a Text widget to work now
+#
 package Guiguts::LineNumberText;
 use strict;
 use warnings;
@@ -13,52 +20,70 @@ sub Populate {
     $self->SUPER::Populate($args);
     $self->{'minwidth'}       = 5;
     $self->{'linenumshowing'} = 0;
-    my $widget;
-    if ( $widget = delete $args->{-widget} ) {
-        $widget = 'TextUnicode';
-    } else {
-        $widget = 'Text';
-    }
-    my $ltext = $self->ROText(
+    $self->{'colnumshowing'}  = 0;
+
+    # Create read-only text widget to display line numbers
+    $self->{'ltext'} = my $ltext = $self->ROText(
         -takefocus => 0,
         -cursor    => 'X_cursor',
-        -bd        => 2,
+        -bd        => 2,                     # border doesn't show, but keeps it aligned with main text window which has border
         -relief    => 'flat',
         -width     => $self->{'minwidth'},
         -wrap      => 'none',
     );
     $ltext->{_MENU_} = ();
-    $self->{'ltext'} = $ltext;
-    $ltext->tagConfigure( 'CURLINE', -data    => 1 );
-    $ltext->tagConfigure( 'RIGHT',   -justify => 'right' );
-    my $ftext = $self->Scrolled($widget)->grid( -row => 0, -column => 1, -sticky => 'nsew' );
-    $self->{'rtext'} = my $rtext = $ftext->Subwidget('scrolled');
-    $self->gridColumnconfigure( 1, -weight => 1 );
-    $self->gridRowconfigure( 0, -weight => 1 );
-    $self->Advertise( 'yscrollbar', $ftext->Subwidget('yscrollbar') );
-    $self->Advertise( 'xscrollbar', $ftext->Subwidget('xscrollbar') );
-    $self->Advertise( 'corner',     $ftext->Subwidget('corner') );
-    $self->Advertise( 'frame',      $ftext );
-    $self->Advertise( 'scrolled',   $rtext );
-    $self->Advertise( 'text',       $rtext );
-    $self->Advertise( 'linenum',    $ltext );
+    $ltext->tagConfigure( 'RIGHT', -justify => 'right' );
 
-    # Set scrolling command to run the lineupdate..
-    my $yscroll       = $self->Subwidget('yscrollbar');
-    my $scrollcommand = $yscroll->cget( -command );
-    $yscroll->configure(
-        -command => sub {
-            $scrollcommand->Call(@_);
-            $self->_lineupdate;
-        }
+    # Create scrolled TextUnicode widget - the main text window
+    # ftext is the container widget, and rtext is the actual text window
+    # Placed in grid at (1,1) to give space for row/col number widgets at (0,0) for left/above or (2,2) for right/below
+    $self->{'ftext'} = my $ftext =
+      $self->Scrolled('TextUnicode')->grid( -row => 1, -column => 1, -sticky => 'nsew' );
+    $self->{'rtext'} = my $rtext = $ftext->Subwidget('scrolled');
+
+    # Grid weights ensure text window resizes with main window, but row/col number widgets remain fixed size
+    $self->gridColumnconfigure( 1, -weight => 1 );
+    $self->gridRowconfigure( 1, -weight => 1 );
+
+    # Create read-only text widget to display column numbers
+    $self->{'ctext'} = my $ctext = $self->ROText(
+        -takefocus => 0,
+        -cursor    => 'X_cursor',
+        -bd        => 2,            # border doesn't show, but keeps it aligned with main text window which has border
+        -relief    => 'flat',
+        -height    => 1,
+        -wrap      => 'none',
     );
+    $ctext->{_MENU_} = ();
+
+    $self->Advertise( 'corner',   $ftext->Subwidget('corner') );
+    $self->Advertise( 'scrolled', $rtext );
+
+    # Set scrolling commands to update the line/col numbers
+    for my $sub ( 'xscrollbar', 'yscrollbar' ) {
+        my $swgt          = $ftext->Subwidget($sub);
+        my $scrollcommand = $swgt->cget( -command );
+        $swgt->configure(
+            -command => sub {
+                $scrollcommand->Call(@_);
+                $self->_lincolupdate;
+            }
+        );
+    }
+
+    # What to do with configure/cget requests - also contains default values
     $self->ConfigSpecs(
-        -linenumside      => [ 'METHOD',  undef,       undef,       'left' ],
+        -linenumside      => [ 'METHOD',  undef,       undef,       'left' ],       # Change to 'right' to have line numbers on right
         -linenumbg        => [ 'METHOD',  'numlinebg', 'numLinebg', '#eaeaea' ],
         -linenumfg        => [ 'METHOD',  'numlinefg', 'numLinefg', '#000000' ],
         -curlinehighlight => [ 'PASSIVE', undef,       undef,       1 ],
         -curlinebg        => [ 'METHOD',  undef,       undef,       '#00ffff' ],
         -curlinefg        => [ 'METHOD',  undef,       undef,       '#000000' ],
+        -colnumpos        => [ 'METHOD',  undef,       undef,       'top' ],        # Change to 'bottom' to have column numbers at bottom
+        -colnumbg         => [ 'METHOD',  'numcolbg',  'numColbg',  '#eaeaea' ],
+        -colnumfg         => [ 'METHOD',  'numcolfg',  'numColfg',  '#000000' ],
+        -curcolbg         => [ 'METHOD',  undef,       undef,       '#eaeaea' ],    # Change for a different current column colour like current line
+        -curcolfg         => [ 'METHOD',  undef,       undef,       '#000000' ],
         -background       => [ $ftext,    undef,       undef,       undef ],
         -foreground       => [ $ftext,    undef,       undef,       undef ],
         -scrollbars       => [ $ftext,    undef,       undef,       'se' ],
@@ -70,42 +95,43 @@ sub Populate {
     );
     $self->Delegates( 'DEFAULT' => 'scrolled' );
 
-    #Bindings
-    $ltext->bind( '<FocusIn>',   sub { $rtext->focus } );
-    $ltext->bind( '<Map>',       sub { $self->_lineupdate } );
-    $rtext->bind( '<Configure>', sub { $self->_lineupdate } );
-    $rtext->bind( '<KeyPress>',  sub { $self->_lineupdate } );
+    # Bindings - Redirect attempts to focus on line/col numbers to main text window
+    $ctext->bind( '<FocusIn>', sub { $rtext->focus } );
+    $ltext->bind( '<FocusIn>', sub { $rtext->focus } );
+
+    # Almost any kind of change needs line/col number update
+    $ltext->bind( '<Map>',       sub { $self->_lincolupdate } );
+    $rtext->bind( '<Configure>', sub { $self->_lincolupdate } );
+    $rtext->bind( '<KeyPress>',  sub { $self->_lincolupdate } );
     $rtext->bind(
         '<ButtonPress>',
         sub {
             $self->{'rtext'}->{'origx'} = undef;
-            $self->_lineupdate;
+            $self->_lincolupdate;
         }
     );
-    $rtext->bind( '<Return>',          sub { $self->_lineupdate } );
-    $rtext->bind( '<ButtonRelease-2>', sub { $self->_lineupdate } );
-    $rtext->bind( '<B2-Motion>',       sub { $self->_lineupdate } );
-    $rtext->bind( '<B1-Motion>',       sub { $self->_lineupdate } );
-    $rtext->bind( '<<autoscroll>>',    sub { $self->_lineupdate } );
-    $rtext->bind( '<MouseWheel>',      sub { $self->_lineupdate } );
+    $rtext->bind( '<Return>',          sub { $self->_lincolupdate } );
+    $rtext->bind( '<ButtonRelease-2>', sub { $self->_lincolupdate } );
+    $rtext->bind( '<B2-Motion>',       sub { $self->_lincolupdate } );
+    $rtext->bind( '<B1-Motion>',       sub { $self->_lincolupdate } );
+    $rtext->bind( '<<autoscroll>>',    sub { $self->_lincolupdate } );
+    $rtext->bind( '<MouseWheel>',      sub { $self->_lincolupdate } );
     if ( $Tk::platform eq 'unix' ) {
-        $rtext->bind( '<4>', sub { $self->_lineupdate } );
-        $rtext->bind( '<5>', sub { $self->_lineupdate } );
+        $rtext->bind( '<4>', sub { $self->_lincolupdate } );
+        $rtext->bind( '<5>', sub { $self->_lincolupdate } );
     }
+
+    # These methods (either from Text base widget or TextUnicode) also need line/col updates
     my @textMethods = qw/insert delete Delete deleteBefore Contents deleteSelected
       deleteTextTaggedwith deleteToEndofLine FindAndReplaceAll GotoLineNumber
       Insert InsertKeypress InsertSelection insertTab openLine yview ReplaceSelectionsWith
-      Transpose see/;
-    if ( ref($rtext) eq 'TextUnicode' ) {
-        push( @textMethods,
-            'Load', 'SaveUTF', 'IncludeFile', 'ntinsert', 'ntdelete', 'replacewith' );
-    }
+      Transpose see Load SaveUTF IncludeFile ntinsert ntdelete replacewith/;
     for my $method (@textMethods) {
         no strict 'refs';
         *{$method} = sub {
             my $cw  = shift;
             my @arr = $cw->{'rtext'}->$method(@_);
-            $cw->_lineupdate;
+            $cw->_lincolupdate;
             @arr;
         };
     }
@@ -114,6 +140,8 @@ sub Populate {
 
 # Configure methods
 # ------------------------------------------
+
+# For line numbers
 sub linenumside {
     my ( $w, $side ) = @_;
     return unless defined $side;
@@ -141,14 +169,44 @@ sub curlinefg {
     return shift->{'ltext'}->tagConfigure( 'CURLINE', -foreground => @_ );
 }
 
+# For column numbers
+sub colnumpos {
+    my ( $w, $pos ) = @_;
+    return unless defined $pos;
+    $pos = lc($pos);
+    return unless ( $pos eq 'top' or $pos eq 'bottom' );
+    $w->{'colpos'} = $pos;
+    $w->hidecolnum;
+    $w->showcolnum;
+    return;
+}
+
+sub colnumbg {
+    return shift->{'ctext'}->configure( -bg => @_ );
+}
+
+sub colnumfg {
+    return shift->{'ctext'}->configure( -fg => @_ );
+}
+
+# Raise current column number - the dark border to right (and below) looks a bit like an insert cursor at the current column
+sub curcolbg {
+    return
+      shift->{'ctext'}
+      ->tagConfigure( 'CURCOL', -background => @_, -relief => 'raised', -borderwidth => 2 );
+}
+
+sub curcolfg {
+    return shift->{'ctext'}->tagConfigure( 'CURCOL', -foreground => @_ );
+}
+
 # Public Methods
 # ------------------------------------------
 sub showlinenum {
     my ($w) = @_;
     return if ( $w->{'linenumshowing'} );
-    my $col;
-    ( $w->{'side'} eq 'right' ) ? ( $col = 2 ) : ( $col = 0 );
-    $w->{'ltext'}->grid( -row => 0, -column => $col, -sticky => 'ns' );
+    my $col = ( $w->{'side'} eq 'right' ) ? 2 : 0;
+    $w->{'ltext'}->grid( -row => 1, -column => $col, -sticky => 'ns' );
     $w->{'linenumshowing'} = 1;
     return;
 }
@@ -161,28 +219,48 @@ sub hidelinenum {
     return;
 }
 
+sub showcolnum {
+    my ($w) = @_;
+    return if ( $w->{'colnumshowing'} );
+    my $row = ( $w->{'colpos'} eq 'top' ) ? 0 : 2;
+    $w->{'ctext'}->grid( -row => $row, -column => 1, -sticky => 'ew' );
+    $w->{'colnumshowing'} = 1;
+    return;
+}
+
+sub hidecolnum {
+    my ($w) = @_;
+    return unless ( $w->{'colnumshowing'} );
+    $w->{'ctext'}->gridForget;
+    $w->{'colnumshowing'} = 0;
+    return;
+}
+
 #Private Methods
 # ------------------------------------------
-sub _lineupdate {
+sub _lincolupdate {
     my ($w) = @_;
     return
-      unless ( $w->{'ltext'}->ismapped );    # Don't bother continuing if line numbers cannot be displayed
+      unless ( $w->{'ltext'}->ismapped or $w->{'ctext'}->ismapped );    # Don't bother continuing if line/col numbers cannot be displayed
     my @xsave = $w->{'rtext'}->xview;
-    my $idx1  = $w->{'rtext'}->index('@0,0');    # First visible line in text widget
-    $w->{'rtext'}->see($idx1);
+    my $idx1  = $w->{'rtext'}->index('@0,0');                           # First visible line in text widget
     my ( $dummy, $ypix ) = $w->{'rtext'}->dlineinfo($idx1);
     my $theight = $w->{'rtext'}->height;
-    my $oldy    = my $lastline = -99;            #ensure at least one number gets shown
-    $w->{'ltext'}->delete( '1.0', 'end' );
+    my $oldy    = my $lastline = -99;                                   # Ensure at least one number gets shown
     my @LineNum;
-    my $insertidx    = $w->{'rtext'}->index('insert');
-    my ($insertLine) = split( /\./, $insertidx );
-    my $font         = $w->{'ltext'}->cget( -font );
-    my $ltextline    = 0;
+    my $insertidx = $w->{'rtext'}->index('insert');
+    my ( $insertLine, $insertCol ) = split( /\./, $insertidx );
+    my $ltextline = 0;
+    my $leftcol   = 0;                                                  # Max value of leftmost column number
 
+    # Find row,column index of leftmost visible column character for each row
+    # If no character there (line too short) column 0 is returned, so need to
+    # check every row to find if there's a non-zero left-column number
+    # Use y coordinate to get line number of visible rows
     while (1) {
         my $idx = $w->{'rtext'}->index( '@0,' . "$ypix" );
-        ( my $realline ) = split( /\./, $idx );
+        my ( $realline, $realcol ) = split( /\./, $idx );
+        $leftcol = $realcol if $realcol > 0;
         my ( $x, $y, $wi, $he ) = $w->{'rtext'}->dlineinfo($idx);
         last unless defined $he;
         last if ( $oldy == $y );    #line is the same as the last one
@@ -201,34 +279,59 @@ sub _lineupdate {
         $lastline = $realline;
     }
 
-    #ensure proper width for large line numbers (over 5 digits)
-    my $neededwidth = length($lastline) + 1;
-    my $ltextwidth  = $w->{'ltext'}->cget( -width );
-    if ( $neededwidth > $ltextwidth ) {
-        $w->{'ltext'}->configure( -width => $neededwidth );
-    } elsif ( $ltextwidth > $w->{'minwidth'}
-        && $neededwidth <= $w->{'minwidth'} ) {
-        $w->{'ltext'}->configure( -width => $w->{'minwidth'} );
-    } elsif ( $neededwidth < $ltextwidth
-        and $neededwidth > $w->{'minwidth'} ) {
-        $w->{'ltext'}->configure( -width => $neededwidth );
+    if ( $w->{'ltext'}->ismapped ) {
+
+        # Ensure proper width for large line numbers (over 5 digits)
+        my $neededwidth = length($lastline) + 1;
+        my $ltextwidth  = $w->{'ltext'}->cget( -width );
+        if ( $neededwidth > $ltextwidth ) {
+            $w->{'ltext'}->configure( -width => $neededwidth );
+        } elsif ( $ltextwidth > $w->{'minwidth'}
+            && $neededwidth <= $w->{'minwidth'} ) {
+            $w->{'ltext'}->configure( -width => $w->{'minwidth'} );
+        } elsif ( $neededwidth < $ltextwidth
+            and $neededwidth > $w->{'minwidth'} ) {
+            $w->{'ltext'}->configure( -width => $neededwidth );
+        }
+
+        # Finally insert the linenumbers..
+        $w->{'ltext'}->delete( '1.0', 'end' );
+        my $i = 1;
+        my $highlightline;
+        foreach my $ln (@LineNum) {
+            $w->{'ltext'}->insert( 'end', $ln );
+            if ( $ln =~ /\d+/ and $ln == $insertLine ) {
+                $highlightline = $i;
+            }
+            $i++;
+        }
+        if ( $highlightline and $w->cget( -curlinehighlight ) ) {
+            $w->{'ltext'}->tagAdd( 'CURLINE', "$highlightline\.0", "$highlightline\.end" );
+        }
+        $w->{'ltext'}->tagAdd( 'RIGHT', '1.0', 'end' );
     }
 
-    #Finally insert the linenumbers..
-    my $i = 1;
-    my $highlightline;
-    foreach my $ln (@LineNum) {
-        $w->{'ltext'}->insert( 'end', $ln );
-        if ( $ln =~ /\d+/ and $ln == $insertLine ) {
-            $highlightline = $i;
+    # Now insert the column numbers
+    if ( $w->{'ctext'}->ismapped ) {
+
+        # Note that on Mac, ROText widget appears to have a width limit of 192.
+        # If the string below is more than that, its first characters don't get displayed
+        my $ruler = substr(
+            "....,....1....,....2....,....3....,....4....,....5....,....6....,....7....,....8....,....9....,...10"
+              . "....,....1....,....2....,....3....,....4....,....5....,....6....,....7....,....8....,....9",
+            $leftcol
+        );
+        $w->{'ctext'}->delete( '1.0', 'end' );
+        $w->{'ctext'}->insert( 'end', $ruler );
+
+        # Use tag to highlight in the ruler to the left of where the insert cursor is, i.e. current column
+        if ( $insertCol >= $leftcol ) {
+            my $highlightcol = $insertCol - $leftcol - 1;
+            $w->{'ctext'}->tagAdd( 'CURCOL', "1.$highlightcol" ) if $highlightcol >= 0;
         }
-        $i++;
     }
-    if ( $highlightline and $w->cget( -curlinehighlight ) ) {
-        $w->{'ltext'}->tagAdd( 'CURLINE', "$highlightline\.0", "$highlightline\.end" );
-    }
-    $w->{'ltext'}->tagAdd( 'RIGHT', '1.0', 'end' );
     $w->{'rtext'}->xviewMoveto( $xsave[0] );
     return;
 }
+
 1;

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -907,6 +907,13 @@ sub menu_preferences_appearance {
             -command    => sub { ::displaylinenumbers($::vislnnm) },
         ],
         [
+            Checkbutton => 'Display Column Numbers',
+            -variable   => \$::viscolnm,
+            -onvalue    => 1,
+            -offvalue   => 0,
+            -command    => sub { ::displaycolnumbers($::viscolnm) },
+        ],
+        [
             Checkbutton => 'Auto Show Page Images',
             -variable   => \$::auto_show_images,
             -onvalue    => 1,

--- a/src/lib/Guiguts/StatusBar.pm
+++ b/src/lib/Guiguts/StatusBar.pm
@@ -140,7 +140,6 @@ sub _updatesel {
     $::lglobal{selmaxlength} = $msgln if ( $msgln > $::lglobal{selmaxlength} );
     $::lglobal{selectionlabel}->configure( -text => $msg, -width => $::lglobal{selmaxlength} );
     ::update_indicators();
-    $textwindow->_lineupdate;
 }
 
 ## Status Bar
@@ -183,6 +182,14 @@ AAAAACH5BAAAAAAALAAAAAAMAAwAAwQfMMg5BaDYXiw178AlcJ6VhYFXoSoosm7KvrR8zfXHRQA7
         '<3>',
         sub {
             ::displaylinenumbers( !$::vislnnm );
+        }
+    );
+
+    # Shift-Mouse-3 to toggle column number display
+    $::lglobal{current_line_label}->bind(
+        '<Shift-3>',
+        sub {
+            ::displaycolnumbers( !$::viscolnm );
         }
     );
 

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -19,7 +19,7 @@ BEGIN {
       &sidenotes &poetrynumbers &get_page_number &externalpopup &add_entry_history &entry_history
       &xtops &toolbar_toggle &killpopup &expandselection
       &getprojectid &setprojectid &viewprojectcomments &viewprojectdiscussion &viewprojectpage
-      &scrolldismiss &updatedrecently &hidelinenumbers &restorelinenumbers &displaylinenumbers
+      &scrolldismiss &updatedrecently &hidelinenumbers &restorelinenumbers &displaylinenumbers &displaycolnumbers
       &enable_interrupt &disable_interrupt &set_interrupt &query_interrupt &soundbell &busy &unbusy
       &dieerror &warnerror &infoerror &poperror &BindMouseWheel &display_manual
       &path_settings &path_htmlheader &path_defaulthtmlheader &path_labels &path_defaultlabels &path_userdict &path_defaultdict
@@ -1053,7 +1053,6 @@ sub initialize {
 
     # The actual text widget
     $::textwindow = $::text_frame->LineNumberText(
-        -widget          => 'TextUnicode',
         -exportselection => 'true',           # 'sel' tag is associated with selections
         -background      => $::bkgcolor,
         -relief          => 'sunken',
@@ -1282,6 +1281,7 @@ sub initialize {
     );
     $textwindow->tagBind( 'pagenum', '<ButtonRelease-1>', \&::pnumadjust );
     ::displaylinenumbers($::vislnnm);
+    ::displaycolnumbers($::viscolnm);
 
     %{ $::lglobal{utfblocks} } = (
         'Alphabetic Presentation Forms' => [ 'FB00', 'FB4F' ],
@@ -2959,15 +2959,24 @@ sub displaylinenumbers {
     ::savesettings();
 }
 
-# Temporarily hide line numbers to speed up some operations
-# Note that the global flag is not changed
-sub hidelinenumbers {
-    $::textwindow->hidelinenum if $::vislnnm;
+# Show/hide column numbers based on input argument
+sub displaycolnumbers {
+    $::viscolnm = shift;
+    $::viscolnm ? $::textwindow->showcolnum : $::textwindow->hidecolnum;
+    ::savesettings();
 }
 
-# Restore the line numbers after they have been temporarily hidden
+# Temporarily hide line & column numbers to speed up some operations
+# Note that the global flags are not changed
+sub hidelinenumbers {
+    $::textwindow->hidelinenum if $::vislnnm;
+    $::textwindow->hidecolnum  if $::viscolnm;
+}
+
+# Restore the line & column numbers after they have been temporarily hidden
 sub restorelinenumbers {
     $::textwindow->showlinenum if $::vislnnm;
+    $::textwindow->showcolnum  if $::viscolnm;
 }
 
 # Allow for long operations to be interrupted by the user


### PR DESCRIPTION
Similar to the row numbers which can be displayed on the left of the text window, this implements a column numbers "ruler" widget across the top.

Similar configuration to the row numbers widget is available, but not exposed to the user.

Turn on/off via Preferences menu or by Shift-right-clicking the row/column display in the status bar.

Ruler is one-based rather than zero-based (as used internally), and existing Highlight Alignment Column has been adjusted to match the highlighted column number in the ruler.

Internal LineNumberText code has been simplified a little, removing historical attempt to support plain Text widget rather than the GG TextUnicode widget. Some comments also added.

Fixes #1057 