### PR TITLE
Fix false positive in Word Frequency Emdash check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   be separated by spaces, commas, or plus signs, e.g. `en, fr`
 - `Apply Poetry Markup to Selection` could delete some characters when the 
   poem text had not been indented
+- Word Frequency could report false Emdash suspects if there was an emdash
+  before a hyphenated word.
 
 
 ## Version 1.5.1

--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -33,7 +33,7 @@ sub wordfrequencybuildwordlist {
 
         # build a list of "word--word""
         for my $word (@words) {
-            next unless ( $word =~ /--/ );
+            next unless ( $word =~ /[^-]--[^-]/ );
             next if ( $word =~ /---/ );
             $word =~ s/[\.,']$//;
             $word =~ s/^[\.'-]+//;


### PR DESCRIPTION
Code was attempting to build a list of "word--word", but was inadvertently including "--word" and "word--" which then led to false positives in the "suspects" check.

Fixes #1063