### PR TITLE
Change use of `px` to `em` in autotable padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@
 - `Apply Poetry Markup to Selection` could delete some characters when the 
   poem text had not been indented
 - Word Frequency could report false Emdash suspects if there was an emdash
-  before a hyphenated word.
+  before a hyphenated word
+- The `autotable` class defaulted to padding of `4px`. Values ending in `px`
+  are stripped by ebookmaker resulting in loss of padding. CSS header now
+  defaults to `0.25em`
 
 
 ## Version 1.5.1

--- a/src/headerdefault.txt
+++ b/src/headerdefault.txt
@@ -82,7 +82,7 @@ table {
 }
 table.autotable    { border-collapse: collapse; }
 table.autotable td,
-table.autotable th { padding: 4px; }
+table.autotable th { padding: 0.25em; }
 
 .tdl      {text-align: left;}
 .tdr      {text-align: right;}


### PR DESCRIPTION
The `autotable` class defaulted to padding of `4px`. Values ending in `px` are stripped by ebookmaker resulting in loss of padding.
CSS header now defaults to `0.25em`