### PR TITLE
Implement new PG HTML `<title>` field format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   the Row/Col display in the Status Bar. Highlight Alignment Column now
   highlights the column before the cursor rather than after the cursor to
   match the new ruler.
+- New HTML title format: book title followed by ` | Project Gutenberg`
 
 ### Bug Fixes
 

--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -119,6 +119,7 @@ our $blockrmargin     = 72;
 our $poetrylmargin    = 4;
 our $blockwrap;
 our $booklang             = 'en';
+our $bookauthor           = '';
 our $charsuitewfhighlight = 0;                  # Don't do charsuite availability highlighting in WF dialog
 our $composepopbinding    = 'Alt_R';            # Default key to pop the Compose dialog (Right hand Alt key, also labelled AltGr)
 $composepopbinding = 'Control-m' if $OS_MAC;    # Default to Ctrl+m on a Mac - Alt+RightArrow does the same indent operation

--- a/src/headerdefault.txt
+++ b/src/headerdefault.txt
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>
-      TITLE, by AUTHOR—A Project Gutenberg eBook
+      TITLE | Project Gutenberg
     </title>
     <link rel="icon" href="images/cover.jpg" type="image/x-cover">
     <style>

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -318,6 +318,7 @@ sub _bin_save {
         print $fh "\$::spellindexbkmrk = '$::spellindexbkmrk';\n\n";
         print $fh "\$::projectid = '$::projectid';\n\n";
         print $fh "\$::booklang = '$::booklang';\n\n";
+        print $fh "\$::bookauthor = '$::bookauthor';\n\n";
         print $fh
           "\$scannoslistpath = '@{[::escape_problems(::os_normal($::scannoslistpath))]}';\n\n";
         foreach ( sort keys %::charsuiteenabled ) {

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -360,6 +360,7 @@ sub clearvars {
     @{ $::lglobal{fnarray} } = ();
     $::lglobal{fntotal} = 0;
     undef $::lglobal{prepfile};
+    $::bookauthor = '';
     return;
 }
 

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1342,7 +1342,7 @@ sub html_convert_pageanchors {
 }
 
 sub html_parse_header {
-    my ( $textwindow, $headertext, $title, $author ) = @_;
+    my ( $textwindow, $headertext, $title ) = @_;
     my $selection;
     my $step;
     my $closure = voidclosure();
@@ -1397,9 +1397,7 @@ sub html_parse_header {
         close $infile;
     }
 
-    $author     =~ s/&/&amp;/g       if $author;
-    $headertext =~ s/TITLE/$title/   if $title;
-    $headertext =~ s/AUTHOR/$author/ if $author;
+    $headertext =~ s/TITLE/$title/ if $title;
     my $mainlang = ::main_lang();
     $headertext =~ s/BOOKLANG/$mainlang/g;
 
@@ -2070,7 +2068,7 @@ sub htmlimages {
 }
 
 sub htmlautoconvert {
-    my ( $textwindow, $top, $title, $author ) = @_;
+    my ( $textwindow, $top, $title ) = @_;
     ::hidepagenums();
     my $headertext;
     if ( $::lglobal{global_filename} =~ /No File Loaded/ ) {
@@ -2094,7 +2092,7 @@ sub htmlautoconvert {
     $::lglobal{global_filename} = $savefn;
     $textwindow->FileName($savefn);
     html_convert_ampersands($textwindow);
-    $headertext               = html_parse_header( $textwindow, $headertext, $title, $author );
+    $headertext               = html_parse_header( $textwindow, $headertext, $title );
     $::lglobal{fnsecondpass}  = 0;
     $::lglobal{fnsearchlimit} = 1;
     html_convert_footnotes( $textwindow, $::lglobal{fnarray} );
@@ -2201,8 +2199,9 @@ sub htmlgenpopup {
         )->grid( -row => 1, -column => 3, -padx => 1, -pady => 1 );
 
         my $ishtml = $textwindow->search( '-nocase', '--', '<html', '1.0' );
-        my ( $htmltitle, $htmlauthor ) = ( '', '' );
-        ( $htmltitle, $htmlauthor ) = get_title_author() unless $ishtml;
+        my ( $htmltitle, $author ) = ( '', '' );
+        ( $htmltitle, $author ) = get_title_author() unless $ishtml;
+        $::bookauthor = $author unless $::bookauthor;
         my $f0a = $::lglobal{htmlgenpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $f0a->Label( -text => 'Title:', )
           ->grid( -row => 0, -column => 0, -padx => 2, -pady => 2, -sticky => 'w' );
@@ -2215,7 +2214,7 @@ sub htmlgenpopup {
         $f0a->Label( -text => 'Author:', )
           ->grid( -row => 1, -column => 0, -padx => 2, -pady => 2, -sticky => 'w' );
         $f0a->Entry(
-            -textvariable => \$htmlauthor,
+            -textvariable => \$::bookauthor,
             -width        => 45,
             -background   => $::bkgcolor,
             -relief       => 'sunken',
@@ -2437,9 +2436,9 @@ sub htmlgenpopup {
         my $f2 = $::lglobal{htmlgenpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $f2->Button(
             -activebackground => $::activecolor,
-            -command => sub { htmlautoconvert( $textwindow, $top, $htmltitle, $htmlauthor ) },
-            -text    => 'Autogenerate HTML',
-            -width   => 16
+            -command          => sub { htmlautoconvert( $textwindow, $top, $htmltitle ) },
+            -text             => 'Autogenerate HTML',
+            -width            => 16
         )->grid( -row => 1, -column => 1, -padx => 5, -pady => 1 );
 
         ::initialize_popup_with_deletebinding('htmlgenpop');

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -2346,31 +2346,20 @@ sub ebookmaker {
 
     ::busy();    # Change cursor to show user something is happening
 
-    # Get title and author information
-    my $ttitle  = $fname;      # Title defaults to base filename
-    my $tauthor = 'Unknown';
-    my $tbeg    = $textwindow->search( '-exact', '--', '<title>',  '1.0', '20.0' );
-    my $tend    = $textwindow->search( '-exact', '--', '</title>', '1.0', '20.0' );
+    # Get title information
+    my $ttitle = $fname;    # Title defaults to base filename
+    my $tbeg   = $textwindow->search( '-exact', '--', '<title>',  '1.0', '20.0' );
+    my $tend   = $textwindow->search( '-exact', '--', '</title>', '1.0', '20.0' );
     if ( $tbeg and $tend ) {
-        my $tstring = $textwindow->get( $tbeg . '+7c', $tend );    # Get whole title/author string
-        $tstring =~ s/\s+/ /g;                                     # Join into one line, single spaced
-        if (
-            $tstring =~ s/The Project Gutenberg EBook of//i              # Strip PG part - 2 formats
-            or $tstring =~ s/(--|\x{2014})A Project Gutenberg eBook//i
-        ) {
-            HTML::Entities::decode_entities($tstring);                   # HTML entities need converting to characters
-            $tstring = deaccentdisplay($tstring);                        # Remove accents since passing as argument in shell
-            $tstring =~ s/[^[:ascii:]]/_/g;                              # Substitute "_" for any remaining non-ASCII characters
-
-            # Split into title/author - use last "by" in case "by" is in the book title
-            my $byidx = rindex( $tstring, ", by " );
-            if ( $byidx > -1 ) {
-                $ttitle = substr( $tstring, 0, $byidx );
-                $ttitle =~ s/^\s+|\s+$//g;
-                $tauthor = substr( $tstring, $byidx + 5 );
-                $tauthor =~ s/^\s+|\s+$//g;
-            }
-        }
+        $ttitle = $textwindow->get( $tbeg . '+7c', $tend );       # Get whole title string
+        $ttitle =~ s/\s+/ /g;                                     # Join into one line, single spaced
+        $ttitle =~ s/The Project Gutenberg EBook of//i;           # Strip PG part - 3 formats
+        $ttitle =~ s/(--|\x{2014})A Project Gutenberg eBook//i;
+        $ttitle =~ s/\| Project Gutenberg//i;
+        HTML::Entities::decode_entities($ttitle);                 # HTML entities need converting to characters
+        $ttitle = deaccentdisplay($ttitle);                       # Remove accents since passing as argument in shell
+        $ttitle =~ s/[^[:ascii:]]/_/g;                            # Substitute "_" for any remaining non-ASCII characters
+        $ttitle =~ s/^\s+|\s+$//g;
     }
 
     my $filepath  = $::lglobal{global_filename};
@@ -2414,7 +2403,7 @@ sub ebookmaker {
         $kindleoption,             $kf8option,
         "--output-dir=$outputdir", "--output-file=$fname",
         "--config-dir=$configdir", "--title=$ttitle",
-        "--author=$tauthor",       "$filepath"
+        "--author=$::bookauthor",  "$filepath"
     );
 
     # Check for errors or warnings in ebookmaker output

--- a/src/lib/ppvchecks/pphtml.pl
+++ b/src/lib/ppvchecks/pphtml.pl
@@ -66,26 +66,30 @@ sub runProgram {
       localtime(time);
 
     sub header_check {
-
-        #print LOGFILE "Please confirm title is: 'The Project Gutenberg eBook of TITLE, by AUTHOR.\n";
         my $printing = 0;
         my $count    = 0;
 
+        my $guttitle  = 0;                        # No <title> at all
+        my $gutstring = " | Project Gutenberg";
         foreach my $line (@book) {
             $count++;
             if ( $line =~ /<title>/ ) {
                 $printing = 1;
                 printf LOGFILE ( "%d:0 Confirm title:\n", $count );
-
-                #next;
+                $guttitle = 1;    # <title>, but gutstring not found yet
             }
             if ($printing) {
                 printf LOGFILE ( "%d:0 %s\n", $count, trim($line) );
+                $guttitle = 2 if $line =~ /\Q$gutstring\E/;    # gutstring found
             }
             if ( $line =~ /<\/title>/ ) {
                 $printing = 0;
+                last;
             }
         }
+        printf LOGFILE ( "%d:0 No <title> field found\n", $count ) if $guttitle == 0;
+        printf LOGFILE ( "%d:0 <title> field must end with '%s'\n", $count, $gutstring )
+          if $guttitle == 1;
     }
 
     sub specials {


### PR DESCRIPTION
New format is `Book title | Project Gutenberg`
Author's name is not included.

1. Change default header file to new format
2. Store author in global variable, saved in bin file
3. Continue to show author in Autogen dialog
4. Use author variable when creating epub via ebookmaker
5. Update pphtml's check of `<title>` field
6. Update changelog

Fixes #1067