### PR TITLE
Fix undefined bookauthor variable

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1435,7 +1435,8 @@ sub html_parse_header {
 sub get_title_author {
     my $textwindow = $::textwindow;
     my $step       = 0;
-    my ( $selection, $title, $author );
+    my ( $selection, $title );
+    my $author        = '';
     my $completetitle = '';
     my $intitle       = 0;
     while (1) {    # find title


### PR DESCRIPTION
Introduced in #1069, new global `bookauthor` variable could end up undefined if code couldn't find an author in the text. It never used to matter because the author wasn't stored in the bin file.