### PR TITLE
Avoid `uninitialized` error exporting prep text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - The `autotable` class defaulted to padding of `4px`. Values ending in `px`
   are stripped by ebookmaker resulting in loss of padding. CSS header now
   defaults to `0.25em`
+- Corrupt page markers in the bin file could cause errors when exporting
+  prep text files
 
 
 ## Version 1.5.1

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -203,6 +203,12 @@ sub file_export_preptext {
             $next = 'end';
         }
         my $file = $textwindow->get( $page, $next );
+        if ( not defined $file ) {
+            ::warnerror(
+                "Corrupt page markers detected: quit; delete bin file; delete any prep text files written; restart"
+            );
+            last;
+        }
         if ( $midwordpagebreak and ( $exporttype eq 'onefile' ) ) {
 
             # put the rest of the word after the separator with a *


### PR DESCRIPTION
If page markers have been corrupted, e.g. by editing outside GG, code could fail to grab a page full of text to write to prep text file. It's not practical to try to undo the corruption, so just warn the user. It's no problem to a PM to delete the bin file, since at this point the page separators are still in the file, so when they restart, the page markers will be recalculated.

Fixes #1074 