### PR TITLE
Allow user to prioritize display of footnote error types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
   match the new ruler.
 - New HTML title format: book title followed by ` | Project Gutenberg`
 - Ebookmaker version 0.12.24 included - minimum chunk size = 256KB
+- Colored labels at top of Footnote Check dialog can be clicked to make
+  that error type high priority in the list displayed below, to help with
+  the situation where footnote has more than one error
 
 ### Bug Fixes
 


### PR DESCRIPTION
If a footnote has two errors, e.g. it's a duplicate and a long footnote, then only one of the errors can be shown by coloring the footnote in the Footnote Check dialog list.

This commit allows the user to click a colored label at the top to make that error type the highest priority, so all footnotes with that error will be highlighted in the appropriate color.

Also a bit of code tidying to reduce duplication and put the link between error types and colors in just one place.

Fixes #1072