### PR TITLE
Avoid error when centering over-long line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
 - Consecutive closing block markup or a footnote anchor at the end of a
   footnote could cause syntax errors in the generated HTML
 - Nested blockquote markup was not wrapped correctly
+- Trying to center a line that was longer than the available space between
+  the left and right margin during rewrap caused an error message.
 
 
 ## Version 1.5.1

--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -126,6 +126,7 @@ sub centerblockwrapper {
             $line =~ s/^\s*//;                                                        # Remove any existing indentation
             my $len = length($line);
             $len = ( $rightmargin - $leftmargin - $len ) / 2 + $leftmargin;           # Indentation required for centering
+            $len = 0 if $len < 0;
             $rewrapped .= ' ' x $len . $line . "\n";
         }
     }


### PR DESCRIPTION
If the line length was greater than the gap between the left and right margins, it was trying to insert a negative number of spaces to center it.

Behavior was correct (leave the line alone) but error message about negative repeat count is not wanted.

Fixes #1080