### PR TITLE
Allow SQ results to be sorted alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Colored labels at top of Footnote Check dialog can be clicked to make
   that error type high priority in the list displayed below, to help with
   the situation where footnote has more than one error
+- Spell Query results can now be sorted alphabetically or by line number
 
 ### Bug Fixes
 


### PR DESCRIPTION
When checking spellings, it can be useful to have the queries sorted alphabetically (case sensitive or insensitive) or sorted by location in the file (default)

When the sort order is changed, the list is refreshed without re-running SQ (or previously skipped spellings would re-appear)

The sort order is stored for this run of GG only, not permanently.

Fixes #1071