### PR TITLE
Accept single quote in index pagenum conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
 - Nested blockquote markup was not wrapped correctly
 - Trying to center a line that was longer than the available space between
   the left and right margin during rewrap caused an error message.
+- When the quote following an index entry was a single quote, the first
+  page number was not hyperlinked as it would be for a double quote
 
 
 ## Version 1.5.1

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -4268,10 +4268,10 @@ sub fracconv {
 sub addpagelinks {
     my $selection = shift;
     my $ndash     = "\x{2013}";
-    my $rdblq     = "\x{201d}";
+    my $rquot     = q(["'\x{201d}\x{2019}]);
     $selection =~
-      s/(,["$rdblq]?) +(\d{1,3})([-$ndash])\b(\d{1,3})\b/$1 <a href="#$::htmllabels{pglabel}$2">$2$3$4<\/a>/g;
-    $selection =~ s/(,["$rdblq]?) +\b(\d{1,3})\b/$1 <a href="#$::htmllabels{pglabel}$2">$2<\/a>/g;
+      s/(,$rquot?) +(\d{1,3})([-$ndash])\b(\d{1,3})\b/$1 <a href="#$::htmllabels{pglabel}$2">$2$3$4<\/a>/g;
+    $selection =~ s/(,$rquot?) +\b(\d{1,3})\b/$1 <a href="#$::htmllabels{pglabel}$2">$2<\/a>/g;
     return $selection;
 }
 1;


### PR DESCRIPTION
When hyperlinking page numbers in the index, the code looks for 1 to 3 digit numbers following a comma, with optionally a closing quote. This commit means it accepts a single quote just like it would have accepted a double quote.