### PR TITLE
Fix minor rewrap bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@
   the left and right margin during rewrap caused an error message.
 - When the quote following an index entry was a single quote, the first
   page number was not hyperlinked as it would be for a double quote
+- Page markers immediately following closing block markup could cause an
+  extra blank line to be inserted
+- Closing illo caption markup that immediately followed `C/` or `R/` was
+  centered or right-aligned instead of remaining at left margin
 
 
 ## Version 1.5.1


### PR DESCRIPTION
1. Page markers on the blank line following `C/` or `R/` markup caused extra blank line to be inserted.
2. Test for markup ending wasn't anchoring it to start of line, so something like `i/` in the body of the text was being treated as closure
3. Normally a blank line should follow `R/` or `C/`, but it is permitted to omit, e.g. at end of illo caption, so next line is just a `]`. This was then being right or center justified instead remaining at left margin.
4. Bad markup, e.g. closing when not open, could cause global variable to retain it's non-zero value when wrapping was complete. This then affected the next attempt to wrap, even if the bad markup was corrected.

Fixes #1085