### PR TITLE
Add block search options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
   that error type high priority in the list displayed below, to help with
   the situation where footnote has more than one error
 - Spell Query results can now be sorted alphabetically or by line number
+- Find Block Markup submenu added to Search menu
+- Search/Replace dialog can be kept on top, like Word Frequency, in
+  Preferences->Appearance menu
 
 ### Bug Fixes
 

--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -207,6 +207,7 @@ our $verboseerrorchecks    = 0;
 our $viscolnm              = 0;
 our $vislnnm               = 0;
 our $wfstayontop           = 0;
+our $srstayontop           = 0;
 
 # These are set to the default values in initialize()
 our $gutcommand         = '';

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -904,7 +904,7 @@ EOM
             intelligentWF ignoreversions italic_char jeebiesmode lastversioncheck lastversionrun lmargin markupthreshold
             multisearchsize multiterm nobell nohighlights pagesepauto projectfileslocation notoolbar poetrylmargin projectfileslocation
             recentfile_size rmargin rmargindiff rwhyphenspace sc_char scannos_highlighted
-            searchstickyoptions spellcheckwithenchant spellquerythreshold stayontop toolside
+            searchstickyoptions spellcheckwithenchant spellquerythreshold srstayontop stayontop toolside
             trackoperations txt_conv_bold txt_conv_font txt_conv_gesperrt txt_conv_italic txt_conv_sc txt_conv_tb
             txtfontname txtfontsize txtfontweight txtfontsystemuse
             twowordsinhyphencheck utfcharentrybase utffontname utffontsize utffontweight

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -347,6 +347,12 @@ sub menu_search {
 sub menu_search_block {
     [
         [
+            'command', 'Find Next Block', -command => [ \&::nextblock, 'all' ]
+        ],
+        [
+            'command', 'Find Previous Block', -command => [ \&::nextblock, 'all', 'reverse' ]
+        ],
+        [
             'command', 'Find Next Indented Block', -command => [ \&::nextblock, 'indent' ]
         ],
         [

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -297,6 +297,7 @@ sub menu_search {
         [ 'separator', '' ],
         [ 'command',   'Find ~Orphaned DP Markup...', -command => \&::orphanedmarkup ],
         [ 'command',   'Find ~Asterisks w/o Slash',   -command => \&::find_asterisks ],
+        menu_cascade( '~Find Block Markup', &menu_search_block ),
         [ 'separator', '' ],
         [
             'command', 'Highlight ~Double Quotes in Selection',
@@ -339,6 +340,61 @@ sub menu_search {
             'command', 'Re~move Highlights',
             -accelerator => 'Ctrl+0',
             -command     => \&::hiliteremove,
+        ],
+    ];
+}
+
+sub menu_search_block {
+    [
+        [
+            'command', 'Find Next Indented Block', -command => [ \&::nextblock, 'indent' ]
+        ],
+        [
+            'command',
+            'Find Previous Indented Block',
+            -command => [ \&::nextblock, 'indent', 'reverse' ]
+        ],
+        [
+            'command', 'Find Next /* Block', -command => [ \&::nextblock, '/*' ]
+        ],
+        [
+            'command', 'Find Previous /* Block', -command => [ \&::nextblock, '/*', 'reverse' ]
+        ],
+        [ 'command', 'Find Next /# Block', -command => [ \&::nextblock, '/#' ] ],
+        [
+            'command', 'Find Previous /# Block', -command => [ \&::nextblock, '/#', 'reverse' ]
+        ],
+        [ 'command', 'Find Next /$ Block', -command => [ \&::nextblock, '/$' ] ],
+        [
+            'command', 'Find Previous /$ Block', -command => [ \&::nextblock, '/$', 'reverse' ]
+        ],
+        [ 'command', 'Find Next /P Block', -command => [ \&::nextblock, '/P' ] ],
+        [
+            'command', 'Find Previous /P Block', -command => [ \&::nextblock, '/P', 'reverse' ]
+        ],
+        [ 'command', 'Find Next /C Block', -command => [ \&::nextblock, '/C' ] ],
+        [
+            'command', 'Find Previous /C Block', -command => [ \&::nextblock, '/C', 'reverse' ]
+        ],
+        [ 'command', 'Find Next /R Block', -command => [ \&::nextblock, '/R' ] ],
+        [
+            'command', 'Find Previous /R Block', -command => [ \&::nextblock, '/R', 'reverse' ]
+        ],
+        [ 'command', 'Find Next /F Block', -command => [ \&::nextblock, '/F' ] ],
+        [
+            'command', 'Find Previous /F Block', -command => [ \&::nextblock, '/F', 'reverse' ]
+        ],
+        [ 'command', 'Find Next /L Block', -command => [ \&::nextblock, '/L' ] ],
+        [
+            'command', 'Find Previous /L Block', -command => [ \&::nextblock, '/L', 'reverse' ]
+        ],
+        [ 'command', 'Find Next /X Block', -command => [ \&::nextblock, '/X' ] ],
+        [
+            'command', 'Find Previous /X Block', -command => [ \&::nextblock, '/X', 'reverse' ]
+        ],
+        [ 'command', 'Find Next /I Block', -command => [ \&::nextblock, '/I' ] ],
+        [
+            'command', 'Find Previous /I Block', -command => [ \&::nextblock, '/I', 'reverse' ]
         ],
     ];
 }
@@ -889,6 +945,12 @@ sub menu_preferences_appearance {
         [
             Checkbutton => 'Keep Word Frequency Pop-up On Top',
             -variable   => \$::wfstayontop,
+            -onvalue    => 1,
+            -offvalue   => 0
+        ],
+        [
+            Checkbutton => 'Keep Search/Replace Pop-up On Top',
+            -variable   => \$::srstayontop,
             -onvalue    => 1,
             -offvalue   => 0
         ],

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1683,6 +1683,7 @@ sub find_transliterations {
 #
 # Find next block of given type
 # First argument can be 'indent' to search for next indented block
+# or 'all' to search for any block type that uses '/'
 # or can be open markup for block, e.g. '/#', '/P', etc.
 # Optional second argument means search backwards
 sub nextblock {
@@ -1708,6 +1709,9 @@ sub nextblock {
               $textwindow->search( '-regexp', $dirstr, '--', '^\s', $begstr, $endstr );
 
         }
+    } elsif ( $mark eq 'all' ) {
+        $::searchstartindex =
+          $textwindow->search( '-regexp', $dirstr, '--', '^/', $begstr, $endstr );
     } else {
         $::searchstartindex =
           $textwindow->search( $dirstr, '-nocase', '--', $mark, $begstr, $endstr );

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -9,7 +9,7 @@ BEGIN {
     @EXPORT = qw(&update_sr_histories &searchtext &reg_check &getnextscanno &updatesearchlabels
       &isvalid &swapterms &findascanno &reghint &replace &replaceall
       &searchfromstartifnew &searchoptset &searchpopup &stealthscanno &find_proofer_comment
-      &find_asterisks &find_transliterations &orphanedbrackets &orphanedmarkup &searchsize
+      &find_asterisks &find_transliterations &nextblock &orphanedbrackets &orphanedmarkup &searchsize
       &loadscannos &replace_incr_counter &countmatches &setsearchpopgeometry &quickcount);
 }
 
@@ -1678,6 +1678,49 @@ sub find_transliterations {
     #} else {
     #	::operationadd('Found no more transliterations (\\[[^FIS\\d])');
     #}
+}
+
+#
+# Find next block of given type
+# First argument can be 'indent' to search for next indented block
+# or can be open markup for block, e.g. '/#', '/P', etc.
+# Optional second argument means search backwards
+sub nextblock {
+    my ( $mark, $reverse ) = @_;
+    my $textwindow = $::textwindow;
+
+    $::searchstartindex = $reverse ? 'end' : '1.0' unless $::searchstartindex;
+
+    my $dirstr = '-forwards';
+    my $begstr = $::searchstartindex . '+1l';
+    my $endstr = 'end';
+    my $incr   = 1;
+    if ($reverse) {
+        $dirstr = '-backwards';
+        $begstr = $::searchstartindex . '-1l';
+        $endstr = '1.0';
+        $incr   = -1;
+    }
+
+    if ( $mark eq 'indent' ) {    # Find non-indented line first in case currently in a block, then next indented line
+        if ( $begstr = $textwindow->search( '-regexp', $dirstr, '--', '^\S', $begstr, $endstr ) ) {
+            $::searchstartindex =
+              $textwindow->search( '-regexp', $dirstr, '--', '^\s', $begstr, $endstr );
+
+        }
+    } else {
+        $::searchstartindex =
+          $textwindow->search( $dirstr, '-nocase', '--', $mark, $begstr, $endstr );
+    }
+    if ($::searchstartindex) {
+        $textwindow->markSet( 'insert', $::searchstartindex );
+        $textwindow->see('end');
+        $textwindow->see($::searchstartindex);
+    } else {
+        ::soundbell();
+    }
+    $textwindow->update;
+    $textwindow->focus;
 }
 
 sub orphanedbrackets {

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1831,9 +1831,11 @@ sub initialize_popup_without_deletebinding {
     }
     $::lglobal{$popupname}->Icon( -image => $::icon );
 
-    # wfpop has its own "stay on top" flag
-    $::lglobal{$popupname}->transient($top)
-      if ( $popupname eq "wfpop" ? $::wfstayontop : $::stayontop );
+    # sfpop and searchpop dialogs have their own "stay on top" flag
+    my $ontop = $::stayontop;
+    $ontop = $::wfstayontop if $popupname eq "wfpop";
+    $ontop = $::srstayontop if $popupname eq "searchpop";
+    $::lglobal{$popupname}->transient($top) if $ontop;
 
     $::lglobal{$popupname}->Tk::bind( '<F1>' => sub { display_manual( $popupname, $context ); } );
 


### PR DESCRIPTION
Two features to improve ability to search for blocks and then do S&R operations within the block

1. Previously removed by #928 because only some block types were implemented, and it took a lot of space in the Search menu. No-one seemed to notice or care for a long time. Request for its return has been implemented - as a submenu so as not to clog Search menu - also improved to avoid code duplication, to make it cope better when it doesn't find any more blocks, and to cope better when switching from searching forwards to backwards and vice versa. All block types now implemented, ordered so that if menu is torn off, user can shrink it to just show the most important ones.

2. There is a general "stay on top" flag already, and a specific flag for the WF dialog. This implements a similar specific flag for the S/R dialog.