### PR TITLE
Fix wrap bug from #1086

### DIFF
--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -438,10 +438,10 @@ sub selectrewrap {
             $blockcenter  = 0;
             $blockright   = 0;
         }
-        if ( $selection =~ /(^|\n)$TEMPPAGEMARK*[$blockwraptypes]\/$TEMPPAGEMARK*(\n|$)/ ) {
+        if ( $selection =~ /^$TEMPPAGEMARK*[$blockwraptypes]\/$TEMPPAGEMARK*$/m ) {
 
             # blockquote
-            if ( $selection =~ /(^|\n)$TEMPPAGEMARK*\#\/$TEMPPAGEMARK*(\n|$)/ ) {
+            if ( $selection =~ /^$TEMPPAGEMARK*\#\/$TEMPPAGEMARK*$/m ) {
 
                 # In order to support poetry, etc., within blockquotes,
                 # if [pP\*Ll] markup is closed immediately preceding close of blockquote,

--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -438,10 +438,10 @@ sub selectrewrap {
             $blockcenter  = 0;
             $blockright   = 0;
         }
-        if ( $selection =~ /\n$TEMPPAGEMARK*[$blockwraptypes]\/$TEMPPAGEMARK*(\n|$)/ ) {
+        if ( $selection =~ /(^|\n)$TEMPPAGEMARK*[$blockwraptypes]\/$TEMPPAGEMARK*(\n|$)/ ) {
 
             # blockquote
-            if ( $selection =~ /\n$TEMPPAGEMARK*\#\/$TEMPPAGEMARK*(\n|$)/ ) {
+            if ( $selection =~ /(^|\n)$TEMPPAGEMARK*\#\/$TEMPPAGEMARK*(\n|$)/ ) {
 
                 # In order to support poetry, etc., within blockquotes,
                 # if [pP\*Ll] markup is closed immediately preceding close of blockquote,


### PR DESCRIPTION
Regex to allow page markers around closing markup insisted on a newline before the closing markup, but the markup can also be right at the start of the `$selection` string being wrapped.