### PR TITLE
Fix SQ sorting bug

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -644,7 +644,7 @@ sub errorcheckpop_up {
 sub errsortfunc {
 
     # Keep first line first, and last line last
-    return -1 if $a =~ /^$BEGMSG/ or $b =~ /^ENDMSG/;
+    return -1 if $a =~ /^$BEGMSG/ or $b =~ /^$ENDMSG/;
     return 1  if $b =~ /^$BEGMSG/ or $a =~ /^$ENDMSG/;
 
     # Extract row:col numbers from message

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -669,7 +669,13 @@ sub errsortfunc {
 sub errsortrefresh {
     my $errorchecktype = shift;
 
-    @errorchecklines = sort errsortfunc @errorchecklines if $errorchecktype eq 'Spell Query';
+    if ( $errorchecktype eq 'Spell Query' ) {
+        my @errorchecktemp;
+        for my $line (@errorchecklines) {
+            push @errorchecktemp, $line if defined $errors{$line};
+        }
+        @errorchecklines = sort errsortfunc @errorchecktemp;
+    }
 
     # Get currently active error, so we can reselect it after refreshing the list
     my $actidx = -1;


### PR DESCRIPTION
If Spell Query errors were right clicked (to skip/remove from list) then using the new sorting options made them reappear. Also you could then get error messages if you clicked on one of those errors.