### PR TITLE
Show matching tags, and detect unclosed tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   button, or typing Return/Shift-Return, searches forwards or backwards.
 
 
+- `Find Match` in the Search menu (or `Ctrl-[`) finds the matching bracket,
+  quote or HTML tag to the one currently selected or indicated by the cursor.
+- `Unclosed Tag Check` in the HTML menu reports unclosed HTML tags.
+
+
 ## Version 1.5.2
 
 - Spell query no longer queries year/decade/shillings/pence abbreviations,

--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -26,6 +26,8 @@ sub keybindings {
             ::highlight_quotbrac();
         }
     );
+    keybind( '<Control-bracketleft>',  sub { ::hilitematch(); } );
+    keybind( '<Control-bracketright>', sub { ::hilitematch(); } );
 
     # File
     keybind( '<Control-o>',       sub { ::file_open($textwindow); } );

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -819,6 +819,13 @@ sub menu_html {
         ],
         [
             'command',
+            'Unclo~sed Tag Check',
+            -command => sub {
+                ::errorcheckpop_up( $textwindow, $top, 'HTML Tags' );
+            }
+        ],
+        [
+            'command',
             '~PPhtml',
             -command => sub {
                 ::errorcheckpop_up( $textwindow, $top, 'pphtml' );

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -303,6 +303,7 @@ sub menu_search {
         [ 'command',   'Find ~Orphaned DP Markup...', -command => \&::orphanedmarkup ],
         [ 'command',   'Find ~Asterisks w/o Slash',   -command => \&::find_asterisks ],
         menu_cascade( '~Find Block Markup', &menu_search_block ),
+        [ 'command',   'Find ~Match', -command => \&::hilitematch ],
         [ 'separator', '' ],
         [
             'command', 'Highlight ~Double Quotes in Selection',


### PR DESCRIPTION
1. User can select quote/bracket/start of tag, or place cursor
adjacent (code prefers before) to or inside tag
2. Menu option or Control+square-bracket finds matching one,
or warns if not found

Also

3. New check, like Tidy, Jeebies, etc., accessible in the HTML menu
4. Lists any HTML opening tags that don't have a matching close
and vice versa
5. Ignores self-closing (void) tags.