### PR TITLE
Fix two ruler bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   basic search options and a history button. Clicking or Shift-clicking Search
   button, or typing Return/Shift-Return, searches forwards or backwards.
 
+### Bug Fixes
+- The column display (ruler) numbers could sometimes display wrongly
 
 ## Version 1.5.2
 

--- a/src/lib/Guiguts/LineNumberText.pm
+++ b/src/lib/Guiguts/LineNumberText.pm
@@ -254,13 +254,10 @@ sub _lincolupdate {
     my $leftcol   = 0;                                                  # Max value of leftmost column number
 
     # Find row,column index of leftmost visible column character for each row
-    # If no character there (line too short) column 0 is returned, so need to
-    # check every row to find if there's a non-zero left-column number
     # Use y coordinate to get line number of visible rows
     while (1) {
         my $idx = $w->{'rtext'}->index( '@0,' . "$ypix" );
         my ( $realline, $realcol ) = split( /\./, $idx );
-        $leftcol = $realcol if $realcol > 0;
         my ( $x, $y, $wi, $he ) = $w->{'rtext'}->dlineinfo($idx);
         last unless defined $he;
         last if ( $oldy == $y );    #line is the same as the last one
@@ -268,6 +265,9 @@ sub _lincolupdate {
         $ypix += $he;
         last
           if $ypix >= ( $theight - 1 );    #we have reached the end of the display
+
+        # if last line of file is onscreen, we tried above to get index of first character of
+        # line beyond end, which index returns as row/col of last character of last line of file
         last if ( $y == $ypix );
         $ltextline++;
 
@@ -277,6 +277,11 @@ sub _lincolupdate {
             push( @LineNum, "$realline\n" );
         }
         $lastline = $realline;
+
+        # If line too short and scrolled off left side of screen, index returns column number
+        # of last character of line, so need to get maximum column number, not just the first.
+        # That will give us the column number of the first visible column of the screen
+        $leftcol = $realcol if $realcol > $leftcol;
     }
 
     if ( $w->{'ltext'}->ismapped ) {


### PR DESCRIPTION
1. If the last line of the file had no newline on the end, then if it was
visible on screen, the ruler numbering was offset by the length of
that line

Fixed by moving column check code below "last" test in loop

2. If the last visible line on screen was shorter than some other lines,
and the screen was scrolled so that last line vanished completely
off to the left, the ruler was displayed as though the the last
character of that line was visible.

Fixed by storing maximum column number of left-most visible
column, not last non-zero column