### PR TITLE
Remove superfluous calls to `update_indicators`

### DIFF
--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -667,7 +667,6 @@ sub cp1252toUni {
             $textwindow->replacewith( $thisblockstart, "$thisblockstart+1c", $cp{$term} );
         }
     }
-    ::update_indicators();
 }
 
 # Pop up compose window to allow entering characters via keystroke shortcuts

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -753,7 +753,6 @@ sub errorcheckrun {    # Runs error checks
         $::lglobal{errorchecklistbox}->delete( '0', 'end' );
     }
     $textwindow->focus;
-    ::update_indicators();
     unless ( $errorchecktype eq 'EPUBCheck' ) {    # Checks an epub, not the currently loaded file
         return 1 if ::nofileloadedwarning();
     }
@@ -1053,7 +1052,6 @@ sub errorcheckview {
             }
         }
         $textwindow->tagAdd( 'highlight', $start, $end );
-        ::update_indicators();
     } else {    # some tools output error without line number
         if ( $line =~ /^\+(.*):/ ) {    # search on text between + and :
             my @savesets = @::sopt;

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -48,7 +48,6 @@ sub file_include {    # FIXME: Should include even if no file loaded.
     $textwindow->IncludeFile($name)
       if defined($name)
       and length($name);
-    ::update_indicators();
     return;
 }
 
@@ -97,7 +96,6 @@ sub file_saveas {
         }
 
         $textwindow->FileName( $::lglobal{global_filename} );
-        ::update_indicators();
         $::top->Unbusy( -recurse => 1 );
     }
 
@@ -110,7 +108,6 @@ sub file_close {
     my $textwindow = shift;
     return if ( ::confirmempty() =~ m{cancel}i );
     clearvars($textwindow);
-    ::update_indicators();
     return;
 }
 
@@ -419,7 +416,6 @@ sub savefile {
             ::_bin_save();
             $textwindow->ResetUndo;                    # Necessary to reset edited flag
             ::setedited(0);
-            ::update_indicators();
             $::top->Unbusy( -recurse => 1 );
         }
     }
@@ -766,7 +762,6 @@ sub openfile {    # and open it
     }
     ::highlight_scannos();
     ::highlight_quotbrac();
-    ::update_indicators();
     file_mark_pages() if $::auto_page_marks;
     ::readlabels();
 

--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -397,7 +397,6 @@ sub footnoteshow {
       if ( ( $anchor ne $start ) && $anchorend );
     $::lglobal{footnotetotal}->configure( -text => "# $::lglobal{fnindex}/$::lglobal{fntotal}" )
       if $::lglobal{footpop};
-    ::update_indicators();
 }
 
 sub fninsertmarkers {
@@ -853,7 +852,6 @@ sub footnotefixup {
             $::lglobal{fnarray}->[ $::lglobal{fnindex} ][2] );
         $textwindow->markSet( "fnb$::lglobal{fnindex}",
             $::lglobal{fnarray}->[ $::lglobal{fnindex} ][3] );
-        ::update_indicators();
         $textwindow->focus;
         $::lglobal{footpop}->raise if $::lglobal{footpop};
 

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -2070,7 +2070,6 @@ sub htmlimages {
     return unless $end;
     $textwindow->tagAdd( 'highlight', $start, $end );
     $textwindow->markSet( 'insert', $start );
-    ::update_indicators();
     $::lglobal{imarkupstart} = $start;
     $::lglobal{imarkupend}   = $end;
     htmlimage();
@@ -3527,7 +3526,6 @@ sub orphans {
                 $textwindow->see( $op[0] )               if $op[0];
                 $textwindow->tagAdd( 'highlight', $op[0], $op[0] . '+' . $lengthc . 'c' );
             }
-            ::update_indicators();
             return 0;
         }
     }

--- a/src/lib/Guiguts/Highlight.pm
+++ b/src/lib/Guiguts/Highlight.pm
@@ -305,7 +305,6 @@ sub highlight_scannos {    # Enable / disable word highlighting in the text
         undef $::lglobal{scannos_highlightedid};
         $textwindow->tagRemove( 'scannos', '1.0', 'end' );
     }
-    ::update_indicators();
     ::savesettings();
 }
 
@@ -322,7 +321,6 @@ sub highlight_quotbrac {
         undef $::lglobal{quotbrac_highlightedid};
         highlight_quotbrac_remove();
     }
-    ::update_indicators();
     ::savesettings();
 }
 

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -270,7 +270,6 @@ sub menu_search {
             -accelerator => 'Ctrl+p',
             -command     => sub {
                 ::gotopage();
-                ::update_indicators();
             }
         ],
         [
@@ -279,7 +278,6 @@ sub menu_search {
             -accelerator => 'Ctrl+Shift+p',
             -command     => sub {
                 ::gotolabel();
-                ::update_indicators();
             }
         ],
         [
@@ -288,7 +286,6 @@ sub menu_search {
             -accelerator => 'Ctrl+j',
             -command     => sub {
                 ::gotoline();
-                ::update_indicators();
             }
         ],
         [ 'command',   '~Which Line?', -command => sub { $textwindow->WhatLineNumberPopUp } ],

--- a/src/lib/Guiguts/PageNumbers.pm
+++ b/src/lib/Guiguts/PageNumbers.pm
@@ -395,7 +395,6 @@ sub pgfocus {
     }
     $textwindow->markSet( 'insert', $mark );
     ::seeindex( $mark, $::donotcenterpagemarkers );
-    ::update_indicators();
 }
 
 #

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -281,7 +281,6 @@ sub searchtext {
     }
     unless ($silentmode) {
         ::updatesearchlabels();
-        ::update_indicators();
     }
     return $foundone;    # return index of where found text started
 }

--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -510,7 +510,6 @@ sub selectrewrap {
         $textwindow->update;
         $textwindow->see($start);
         $textwindow->Unbusy;
-        ::update_indicators();
         ::restorelinenumbers();
     }
     $::blockwrap = 0;    # In case of markup error, don't want to leave blockwrap variable set

--- a/src/lib/Guiguts/SpellCheck.pm
+++ b/src/lib/Guiguts/SpellCheck.pm
@@ -113,7 +113,6 @@ sub spellchecknext {
       if $::lglobal{matchindex};                                                #get the index of the end of the match
     spellguesses( $::lglobal{misspelledlist}[ $::lglobal{nextmiss} ] );         # get a list of guesses for the misspelling
     spellshow_guesses();                                                        # and put them in the guess list
-    ::update_indicators();                                                      # update the status bar
     $::lglobal{spellpopup}->configure( -title => 'Current Dictionary - '
           . ( $::globalspelldictopt || 'No dictionary!' )
           . " | $#{$::lglobal{misspelledlist}} words to check." );

--- a/src/lib/Guiguts/StatusBar.pm
+++ b/src/lib/Guiguts/StatusBar.pm
@@ -6,7 +6,7 @@ BEGIN {
     use Exporter();
     our ( @ISA, @EXPORT );
     @ISA    = qw(Exporter);
-    @EXPORT = qw(&update_indicators &_updatesel &buildstatusbar &togglelongordlabel &seecurrentimage
+    @EXPORT = qw(&_updatesel &buildstatusbar &togglelongordlabel &seecurrentimage
       &setlang &selection &gotoline &gotopage &gotolabel &set_auto_img);
 }
 
@@ -139,7 +139,7 @@ sub _updatesel {
 
     $::lglobal{selmaxlength} = $msgln if ( $msgln > $::lglobal{selmaxlength} );
     $::lglobal{selectionlabel}->configure( -text => $msg, -width => $::lglobal{selmaxlength} );
-    ::update_indicators();
+    update_indicators();
 }
 
 ## Status Bar
@@ -173,7 +173,6 @@ AAAAACH5BAAAAAAALAAAAAAMAAwAAwQfMMg5BaDYXiw178AlcJ6VhYFXoSoosm7KvrR8zfXHRQA7
         sub {
             $::lglobal{current_line_label}->configure( -relief => 'sunken' );
             gotoline();
-            ::update_indicators();
         }
     );
 
@@ -358,7 +357,6 @@ sub update_img_button {
             sub {
                 $::lglobal{img_num_label}->configure( -relief => 'sunken' );
                 gotopage();
-                ::update_indicators();
             }
         );
         $::lglobal{img_num_label}->bind(
@@ -366,7 +364,6 @@ sub update_img_button {
             sub {
                 $::lglobal{img_num_label}->configure( -relief => 'sunken' );
                 ::togglepagenums();
-                ::update_indicators();
             }
         );
         _butbind( $::lglobal{img_num_label} );
@@ -431,7 +428,6 @@ sub update_ordinal_button {
 
 sub togglelongordlabel {
     $::lglobal{longordlabel} = 1 - $::lglobal{longordlabel};
-    ::update_indicators();
 }
 
 sub update_prev_img_button {
@@ -737,7 +733,6 @@ sub gotolineok {
     }
     $textwindow->markSet( 'insert', "$::lglobal{line_number}.0" );
     $textwindow->see('insert');
-    update_indicators();
 }
 
 #
@@ -776,7 +771,6 @@ sub gotopageok {
     $textwindow->markSet( 'insert', "$index +1l linestart" );
     ::seeindex( 'insert -2l', 1 );
     $textwindow->focus;
-    update_indicators();
 }
 
 #
@@ -814,7 +808,6 @@ sub gotolabelok {
     $textwindow->markSet( 'insert', "$index +1l linestart" );
     ::seeindex( 'insert -2l', 1 );
     $textwindow->focus;
-    ::update_indicators();
 }
 
 1;

--- a/src/lib/Guiguts/TextProcessingMenu.pm
+++ b/src/lib/Guiguts/TextProcessingMenu.pm
@@ -457,7 +457,6 @@ sub fixup {
             $textwindow->see($index);
             $textwindow->markSet( 'insert', $index );
             $textwindow->update;
-            ::update_indicators();
         }
         $lastindex = $index;
         $index++;
@@ -471,7 +470,6 @@ sub fixup {
     ::disable_interrupt();
     $textwindow->markSet( 'insert', 'end' );
     $textwindow->see('end');
-    ::update_indicators();
     ::restorelinenumbers();
 }
 
@@ -533,7 +531,6 @@ sub endofline {
         $end   = $ranges[-1];
     }
     $textwindow->FindAndReplaceAll( '-regex', '-nocase', '\s+$', '' );
-    ::update_indicators();
 }
 
 ## Clean Up Rewrap

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1071,7 +1071,7 @@ sub initialize {
     $top->configure( -menu => $::menubar = $top->Menu );
 
     # routines to call every time the text is edited
-    $::textwindow->SetGUICallbacks( [ \&::update_indicators, ] );
+    $::textwindow->SetGUICallbacks( [] );
 
     # Ignore any watchdog timer alarms. Subroutines that take a long time to
     # complete can trip it
@@ -2311,7 +2311,6 @@ sub gotobookmark {
     } else {
         ::soundbell();
     }
-    ::update_indicators();
 }
 
 sub seeindex {
@@ -2537,7 +2536,6 @@ sub poetrynumbers {
         last unless $::searchstartindex;
         $textwindow->see($::searchstartindex);
         $textwindow->update;
-        ::update_indicators();
         ( $row, $col ) = split /\./, $::searchstartindex;
         $line = $textwindow->get( "$row.0", "$row.end" );
         $line =~ s/(?<=\S)\s\s+(\d+)$//;
@@ -2729,7 +2727,6 @@ sub toolbar_toggle {
             -command => sub {
                 return if ( ::confirmempty() =~ /cancel/i );
                 ::clearvars($textwindow);
-                ::update_indicators();
             },
             -tip => 'Discard Edits'
         );

--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -426,7 +426,6 @@ sub wordfrequency {
     $wc = wordfrequencybuildwordlist($textwindow);
     allwords($wc);
     $top->Unbusy( -recurse => 1 );
-    ::update_indicators();
 }
 
 sub allwords {


### PR DESCRIPTION
Since `update_indicators` is called from `_updatesel` which is called on a 0.2 second timer, it's not necessary to call `update_indicators` via `SetGUICallbacks`, nor in various other places through the code.