### PR TITLE
Improve handling of default widget settings

### DIFF
--- a/src/lib/Guiguts/ASCIITables.pm
+++ b/src/lib/Guiguts/ASCIITables.pm
@@ -116,7 +116,6 @@ sub tablefx {
         $::lglobal{tblindent} = 0 unless $::lglobal{tblindent};
         my $ientry = $f1ah->Entry(
             -width        => 4,
-            -background   => $::bkgcolor,
             -textvariable => \$::lglobal{tblindent},
             -validate     => 'all',
             -vcmd         => sub { return $_[0] =~ /^\d*$/; }
@@ -167,7 +166,6 @@ sub tablefx {
           unless defined $::lglobal{tablefillchar} and length( $::lglobal{tablefillchar} ) == 1;
         $f2f->Entry(
             -width        => 2,
-            -background   => $::bkgcolor,
             -textvariable => \$::lglobal{tablefillchar},
             -validate     => 'all',
             -vcmd         => sub { return length( $_[0] ) <= 1; }
@@ -188,7 +186,6 @@ sub tablefx {
           ->grid( -row => 1, -column => 0, -padx => 1, -pady => 2 );
         $f3->Entry(
             -width        => 4,
-            -background   => $::bkgcolor,
             -textvariable => \$::lglobal{stepmaxwidth},
             -validate     => 'all',
             -vcmd         => sub { return $_[0] =~ /^\d*$/; }

--- a/src/lib/Guiguts/ASCIITables.pm
+++ b/src/lib/Guiguts/ASCIITables.pm
@@ -97,22 +97,19 @@ sub tablefx {
         my $f1aj = $f1a->Frame->pack( -side => 'left', -anchor => 'w', -padx => 20 );
         $f1aj->Label( -text => 'Justify', )->pack( -side => 'left', -anchor => 'w' );
         my $rb1 = $f1aj->Radiobutton(
-            -text        => 'L',
-            -variable    => \$::lglobal{tblcoljustify},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'l',
+            -text     => 'L',
+            -variable => \$::lglobal{tblcoljustify},
+            -value    => 'l',
         )->pack( -side => 'left', -anchor => 'w' );
         my $rb2 = $f1aj->Radiobutton(
-            -text        => 'C',
-            -variable    => \$::lglobal{tblcoljustify},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'c',
+            -text     => 'C',
+            -variable => \$::lglobal{tblcoljustify},
+            -value    => 'c',
         )->pack( -side => 'left', -anchor => 'w' );
         my $rb3 = $f1aj->Radiobutton(
-            -text        => 'R',
-            -variable    => \$::lglobal{tblcoljustify},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'r',
+            -text     => 'R',
+            -variable => \$::lglobal{tblcoljustify},
+            -value    => 'r',
         )->pack( -side => 'left', -anchor => 'w' );
         my $f1ah = $f1a->Frame->pack( -side => 'left', -anchor => 'w', -padx => 20 );
         $f1ah->Label( -text => 'Indent', )->pack( -side => 'left', -anchor => 'w' );
@@ -125,16 +122,14 @@ sub tablefx {
             -vcmd         => sub { return $_[0] =~ /^\d*$/; }
         )->pack( -side => 'left', -anchor => 'w', -pady => 2 );
         my $hitog = $f1ah->Checkbutton(
-            -variable    => \$::lglobal{tblhanging},
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Hanging',
+            -variable => \$::lglobal{tblhanging},
+            -text     => 'Hanging',
         )->pack( -side => 'left', -anchor => 'w', -pady => 5 );
         my $f1b = $f1->Frame->pack( -side => 'top', -anchor => 'n' );
         $f1b->Checkbutton(
-            -variable    => \$::lglobal{tblrwcol},
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Rewrap Cols',
-            -command     => sub {
+            -variable => \$::lglobal{tblrwcol},
+            -text     => 'Rewrap Cols',
+            -command  => sub {
                 if ( $::lglobal{tblrwcol} ) {
                     $rb1->configure( -state => 'active' );
                     $rb2->configure( -state => 'active' );

--- a/src/lib/Guiguts/ASCIITables.pm
+++ b/src/lib/Guiguts/ASCIITables.pm
@@ -80,10 +80,9 @@ sub tablefx {
             $row = int( $inc / 4 );
             $col = $inc % 4;
             $f0->Button(
-                -activebackground => $::activecolor,
-                -command          => $tb_buttons[$inc][1],
-                -text             => $tb_buttons[$inc][0],
-                -width            => 16
+                -command => $tb_buttons[$inc][1],
+                -text    => $tb_buttons[$inc][0],
+                -width   => 16
             )->grid(
                 -row    => $row,
                 -column => $col,
@@ -152,16 +151,14 @@ sub tablefx {
             },
         )->pack( -side => 'left', -anchor => 'n', -padx => 1 );
         $f1b->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { coladjust(-1) },
-            -text             => 'Move Left',
-            -width            => 10
+            -command => sub { coladjust(-1) },
+            -text    => 'Move Left',
+            -width   => 10
         )->pack( -side => 'left', -anchor => 'n', -padx => 1 );
         $f1b->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { coladjust(1) },
-            -text             => 'Move Right',
-            -width            => 10
+            -command => sub { coladjust(1) },
+            -text    => 'Move Right',
+            -width   => 10
         )->pack( -side => 'left', -anchor => 'n', -padx => 1 );
         $::lglobal{colwidthlbl} = $f1b->Label(
             -text  => "Width $::lglobal{columnspaces}",
@@ -181,16 +178,14 @@ sub tablefx {
             -vcmd         => sub { return length( $_[0] ) <= 1; }
         )->grid( -row => 1, -column => 1, -padx => 1, -pady => 2 );
         $f2f->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { leadtrailspaces('fill'); },
-            -text             => 'Fill',
-            -width            => 10
+            -command => sub { leadtrailspaces('fill'); },
+            -text    => 'Fill',
+            -width   => 10
         )->grid( -row => 1, -column => 3, -padx => 5, -pady => 2 );
         $f2f->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { leadtrailspaces('restore'); },
-            -text             => 'Restore',
-            -width            => 10
+            -command => sub { leadtrailspaces('restore'); },
+            -text    => 'Restore',
+            -width   => 10
         )->grid( -row => 1, -column => 4, -padx => 5, -pady => 2 );
         my $f3 = $::lglobal{tblfxpop}->LabFrame( -label => 'Grid <=> Step' )
           ->pack( -side => 'top', -anchor => 'n', -expand => 'yes', -fill => 'x' );
@@ -204,37 +199,32 @@ sub tablefx {
             -vcmd         => sub { return $_[0] =~ /^\d*$/; }
         )->grid( -row => 1, -column => 1, -padx => 1, -pady => 2 );
         $f3->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { grid2step() },
-            -text             => 'Convert Grid to Step',
-            -width            => 16
+            -command => sub { grid2step() },
+            -text    => 'Convert Grid to Step',
+            -width   => 16
         )->grid( -row => 1, -column => 3, -padx => 5, -pady => 2 );
         $f3->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { step2grid() },
-            -text             => 'Convert Step to Grid',
-            -width            => 16
+            -command => sub { step2grid() },
+            -text    => 'Convert Step to Grid',
+            -width   => 16
         )->grid( -row => 1, -column => 4, -padx => 5, -pady => 2 );
         my $f3a = $::lglobal{tblfxpop}->LabFrame( -label => 'Restructure' )
           ->pack( -side => 'top', -anchor => 'n', -expand => 'yes', -fill => 'x' );
         $f3a->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { rejoinrows() },
-            -text             => 'Rejoin Rows',
-            -width            => 16
+            -command => sub { rejoinrows() },
+            -text    => 'Rejoin Rows',
+            -width   => 16
         )->grid( -row => 1, -column => 0, -padx => 5, -pady => 2 );
         my $f4   = $::lglobal{tblfxpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         my $ubtn = $f4->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { undoredo('undo'); },
-            -text             => 'Undo',
-            -width            => 10
+            -command => sub { undoredo('undo'); },
+            -text    => 'Undo',
+            -width   => 10
         )->grid( -row => 1, -column => 1, -padx => 1, -pady => 2 );
         my $rbtn = $f4->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { undoredo('redo'); },
-            -text             => 'Redo',
-            -width            => 10
+            -command => sub { undoredo('redo'); },
+            -text    => 'Redo',
+            -width   => 10
         )->grid( -row => 1, -column => 2, -padx => 1, -pady => 2 );
         ::initialize_popup_without_deletebinding('tblfxpop');
 

--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -32,16 +32,14 @@ sub commoncharspopup {
         my $blln      = $::lglobal{comcharspop}->Balloon( -initwait => 750 );
         my $tframe    = $::lglobal{comcharspop}->Frame->pack;
         my $charradio = $tframe->Radiobutton(
-            -variable    => \$::lglobal{comcharoutp},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'c',
-            -text        => 'Character',
+            -variable => \$::lglobal{comcharoutp},
+            -value    => 'c',
+            -text     => 'Character',
         )->grid( -row => 1, -column => 1 );
         $tframe->Radiobutton(
-            -variable    => \$::lglobal{comcharoutp},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'h',
-            -text        => 'HTML Entity',
+            -variable => \$::lglobal{comcharoutp},
+            -value    => 'h',
+            -text     => 'HTML Entity',
         )->grid( -row => 1, -column => 2 );
         $charradio->select;
         my $frame = $::lglobal{comcharspop}->Frame( -background => $::bkgcolor )
@@ -288,16 +286,14 @@ sub utfpopup {
     # Choose Unicode/HTML code and select block
     my $cframe = $::lglobal{utfpop}->Frame->pack;
     my $usel   = $cframe->Radiobutton(
-        -variable    => \$::lglobal{uoutp},
-        -selectcolor => $::lglobal{checkcolor},
-        -value       => 'u',
-        -text        => 'Unicode',
+        -variable => \$::lglobal{uoutp},
+        -value    => 'u',
+        -text     => 'Unicode',
     )->grid( -row => 1, -column => 5, -padx => 5 );
     $cframe->Radiobutton(
-        -variable    => \$::lglobal{uoutp},
-        -selectcolor => $::lglobal{checkcolor},
-        -value       => 'h',
-        -text        => 'HTML code',
+        -variable => \$::lglobal{uoutp},
+        -value    => 'h',
+        -text     => 'HTML code',
     )->grid( -row => 1, -column => 6 );
     my $unicodelist = $cframe->BrowseEntry(
         -label     => 'Block',

--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -96,13 +96,12 @@ sub commoncharspopup {
 
                 # Define simple flat button to save space
                 my $w = $frame->Button(
-                    -activebackground => $::activecolor,
-                    -text             => $text,
-                    -font             => 'unicode',
-                    -relief           => 'flat',
-                    -borderwidth      => 0,
-                    -background       => $::bkgcolor,
-                    -command          =>
+                    -text        => $text,
+                    -font        => 'unicode',
+                    -relief      => 'flat',
+                    -borderwidth => 0,
+                    -background  => $::bkgcolor,
+                    -command     =>
                       sub { insertit( $::lglobal{comcharoutp} eq 'h' ? ::entity($ord) : $text ); },
                     -highlightthickness => 0,
                     -width              => 1,
@@ -254,13 +253,12 @@ sub doutfbuttons {
             my $text = chr($ord);
 
             my $w = $::lglobal{utfframe}->Button(
-                -activebackground => $::activecolor,
-                -text             => $text,
-                -font             => 'unicode',
-                -relief           => 'flat',
-                -borderwidth      => 0,
-                -background       => $::bkgcolor,
-                -command => sub { insertit( $::lglobal{uoutp} eq 'h' ? "&#$ord;" : $text ); },
+                -text        => $text,
+                -font        => 'unicode',
+                -relief      => 'flat',
+                -borderwidth => 0,
+                -background  => $::bkgcolor,
+                -command     => sub { insertit( $::lglobal{uoutp} eq 'h' ? "&#$ord;" : $text ); },
                 -highlightthickness => 0,
                 -width              => 1,
             )->grid( -row => $y, -column => $x );
@@ -1114,9 +1112,8 @@ sub composeref {
             -font       => 'proofing',
         )->pack( -anchor => 'n', -expand => 'y', -fill => 'both' );
         my $button_ok = $::lglobal{composerefpop}->Button(
-            -activebackground => $::activecolor,
-            -text             => 'Close',
-            -command          => sub { ::killpopup('composerefpop'); }
+            -text    => 'Close',
+            -command => sub { ::killpopup('composerefpop'); }
         )->pack;
         ::initialize_popup_with_deletebinding('composerefpop');
         ::drag($comtext);

--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -549,11 +549,9 @@ sub utfcharentrypopup {
 
         # Define output entry field first so it can be populated by input entry validation routine
         $outentry = $frame->ROText(
-            -background => $::bkgcolor,
-            -relief     => 'sunken',
-            -font       => 'unicode',
-            -width      => 6,
-            -height     => 1,
+            -font   => 'unicode',
+            -width  => 6,
+            -height => 1,
         )->grid( -row => 2, -column => 2 );
 
         # Input entry field

--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -382,10 +382,7 @@ sub utfcharsearchpopup {
             $cframe, 1 );
 
         $frame0->Label( -text => 'Search Characteristics ', )->grid( -row => 1, -column => 1 );
-        my $characteristics = $frame0->Entry(
-            -width      => 40,
-            -background => $::bkgcolor
-        )->grid( -row => 1, -column => 2 );
+        my $characteristics = $frame0->Entry( -width => 40, )->grid( -row => 1, -column => 2 );
         $characteristics->focus;
         my $doit = $frame0->Button(
             -text    => 'Search',
@@ -561,7 +558,6 @@ sub utfcharentrypopup {
 
         # Input entry field
         $inentry = $frame->Entry(
-            -background   => $::bkgcolor,
             -width        => 6,
             -textvariable => \$::lglobal{utfcharentryord},
             -validate     => 'key',

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -58,8 +58,7 @@ sub errorcheckpop_up {
     my $buttonlabel = 'Run Checks';
     $buttonlabel = 'Load Checkfile' if $errorchecktype eq 'Load Checkfile';
     my $opsbutton = $ptopframeb->Button(
-        -activebackground => $::activecolor,
-        -command          => sub {
+        -command => sub {
             errorcheckpop_up( $textwindow, $top, $errorchecktype );
         },
         -text  => $buttonlabel,
@@ -67,8 +66,7 @@ sub errorcheckpop_up {
     )->grid( -padx => 10, -row => 0, -column => $gcol++ );
 
     $ptopframeb->Button(
-        -activebackground => $::activecolor,
-        -command          => sub {
+        -command => sub {
             errorcheckcopy();
         },
         -text  => "Copy errors",
@@ -89,10 +87,9 @@ sub errorcheckpop_up {
         # Bookloupe has button to change View Options
     } elsif ( $errorchecktype eq 'Bookloupe' ) {
         $ptopframeb->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { gcviewopts(); },
-            -text             => 'View Options',
-            -width            => 16
+            -command => sub { gcviewopts(); },
+            -text    => 'View Options',
+            -width   => 16
         )->grid( -padx => 10, -row => 0, -column => $gcol++ );
 
         # Jeebies has paranoia level radio buttons
@@ -113,8 +110,7 @@ sub errorcheckpop_up {
     } elsif ( $errorchecktype eq 'Spell Query' ) {
         $::lglobal{spellqueryballoon} = $top->Balloon() unless $::lglobal{spellqueryballoon};
         $ptopframeb->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 ::spelladdgoodwords();                                     # Add good words to project dictionary
                 spellquerycleardict();                                     # Clear cache, so project dictionary will be reloaded below
                 errorcheckpop_up( $textwindow, $top, $errorchecktype );    # Rerun Spell Query
@@ -123,8 +119,7 @@ sub errorcheckpop_up {
             -width => 16
         )->grid( -row => 1, -column => $gcol - 1 );
         my $btnskip = $ptopframeb->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 errorcheckremove($errorchecktype);
                 errorcheckview($errorchecktype);
             },
@@ -134,8 +129,7 @@ sub errorcheckpop_up {
         $::lglobal{spellqueryballoon}
           ->attach( $btnskip, -msg => "Right-click\non queried spelling to Skip" );
         my $btnskipall = $ptopframeb->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 errorcheckremovesimilar($errorchecktype);
                 errorcheckview($errorchecktype);
             },
@@ -145,8 +139,7 @@ sub errorcheckpop_up {
         $::lglobal{spellqueryballoon}->attach( $btnskipall,
             -msg => "Ctrl+Shift+Right-click\non queried spelling to Skip All" );
         my $btnproj = $ptopframeb->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 errorcheckprocessspell('project');
                 errorcheckremovesimilar($errorchecktype);
                 errorcheckview($errorchecktype);
@@ -157,8 +150,7 @@ sub errorcheckpop_up {
         $::lglobal{spellqueryballoon}->attach( $btnproj,
             -msg => "Ctrl+Left-click\non queried spelling to\nAdd to Project Dictionary" );
         my $btnglob = $ptopframeb->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 errorcheckprocessspell('global');
                 errorcheckremovesimilar($errorchecktype);
                 errorcheckview($errorchecktype);
@@ -1276,8 +1268,7 @@ sub gcviewopts {
         }
         my $pframe2 = $::lglobal{gcviewoptspop}->Frame->pack;
         $pframe2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 for ( 0 .. $#gsoptions ) {
                     $gsoptions[$_]->select;
                 }
@@ -1292,8 +1283,7 @@ sub gcviewopts {
             -anchor => 'n'
         );
         $pframe2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 for ( 0 .. $#gsoptions ) {
                     $gsoptions[$_]->deselect;
                 }
@@ -1310,8 +1300,7 @@ sub gcviewopts {
         my $mainlang = ::main_lang();
         if ( $mainlang !~ /^en/ && @::gcviewlang ) {
             $pframe2->Button(
-                -activebackground => $::activecolor,
-                -command          => sub {
+                -command => sub {
                     for ( 0 .. $#::gcviewlang ) {
                         if ( $::gcviewlang[$_] ) {
                             $gsoptions[$_]->select;
@@ -1331,8 +1320,7 @@ sub gcviewopts {
             );
         } else {
             $pframe2->Button(
-                -activebackground => $::activecolor,
-                -command          => sub {
+                -command => sub {
                     for ( 0 .. $#gsoptions ) {
                         $gsoptions[$_]->toggle;
                     }
@@ -1348,8 +1336,7 @@ sub gcviewopts {
             );
         }
         $pframe2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 for ( 0 .. $#::mygcview ) {
                     if ( $::mygcview[$_] ) {
                         $gsoptions[$_]->select;
@@ -1368,8 +1355,7 @@ sub gcviewopts {
             -anchor => 'n'
         );
         $pframe2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 for ( 0 .. $#::gsopt ) {
                     $::mygcview[$_] = $::gsopt[$_];
                 }

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -79,9 +79,8 @@ sub errorcheckpop_up {
         or $errorchecktype eq 'ppvimage'
         or $errorchecktype eq 'pphtml' ) {
         $ptopframeb->Checkbutton(
-            -variable    => \$::verboseerrorchecks,
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Verbose'
+            -variable => \$::verboseerrorchecks,
+            -text     => 'Verbose'
         )->grid( -padx => 10, -row => 0, -column => $gcol++ );
 
         # Bookloupe has button to change View Options
@@ -1260,10 +1259,9 @@ sub gcviewopts {
             $gcrow         = $_ % $gcrows;
             $::gsopt[$_]   = 0 unless defined $::gsopt[$_];
             $gsoptions[$_] = $pframe1->Checkbutton(
-                -variable    => \$::gsopt[$_],
-                -command     => sub { gcwindowpopulate(); },
-                -selectcolor => $::lglobal{checkcolor},
-                -text        => $::lglobal{gcarray}->[$_],
+                -variable => \$::gsopt[$_],
+                -command  => sub { gcwindowpopulate(); },
+                -text     => $::lglobal{gcarray}->[$_],
             )->grid( -row => $gcrow, -column => $gccol, -sticky => 'nw' );
         }
         my $pframe2 = $::lglobal{gcviewoptspop}->Frame->pack;

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -1269,11 +1269,10 @@ sub charsuitespopup {
         for my $suite ( sort keys %{ $::lglobal{dpcharsuite} } ) {
             $::charsuiteenabled{$suite} = 0 unless defined $::charsuiteenabled{$suite};
             $f0->Checkbutton(
-                -variable    => \$::charsuiteenabled{$suite},
-                -selectcolor => $::lglobal{checkcolor},
-                -text        => $suite,
-                -state       => ( $suite eq 'Basic Latin' ? 'disabled' : 'normal' ),    # User can't turn off Basic Latin
-                -command     => sub { ::sortanddisplayhighlight(); },
+                -variable => \$::charsuiteenabled{$suite},
+                -text     => $suite,
+                -state    => ( $suite eq 'Basic Latin' ? 'disabled' : 'normal' ),    # User can't turn off Basic Latin
+                -command  => sub { ::sortanddisplayhighlight(); },
             )->grid(
                 -row    => $row++,
                 -column => 1,

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -500,30 +500,22 @@ sub file_guess_page_marks {
         my $f1 = $::lglobal{guesspgmarkerpop}->Frame->pack;
         $f1->Label( -text => 'How many pages are there total?', )
           ->grid( -row => 1, -column => 1, -padx => 1, -pady => 2 );
-        my $tpages = $f1->Entry(
-            -background => $::bkgcolor,
-            -width      => 8,
-        )->grid( -row => 1, -column => 2, -padx => 1, -pady => 2 );
+        my $tpages =
+          $f1->Entry( -width => 8, )->grid( -row => 1, -column => 2, -padx => 1, -pady => 2 );
         $f1->Label( -text => 'What line # does page 25 start with?', )
           ->grid( -row => 2, -column => 1, -padx => 1, -pady => 2 );
-        my $page25 = $f1->Entry(
-            -background => $::bkgcolor,
-            -width      => 8,
-        )->grid( -row => 2, -column => 2, -padx => 1, -pady => 2 );
+        my $page25 =
+          $f1->Entry( -width => 8, )->grid( -row => 2, -column => 2, -padx => 1, -pady => 2 );
         my $f3 = $::lglobal{guesspgmarkerpop}->Frame->pack;
         $f3->Label( -text => 'Select a page near the back, before the index starts.', )
           ->grid( -row => 2, -column => 1, -padx => 1, -pady => 2 );
         my $f4 = $::lglobal{guesspgmarkerpop}->Frame->pack;
         $f4->Label( -text => 'Page #?.', )->grid( -row => 1, -column => 1, -padx => 1, -pady => 2 );
         $f4->Label( -text => 'Line #?.', )->grid( -row => 1, -column => 2, -padx => 1, -pady => 2 );
-        my $pagexe = $f4->Entry(
-            -background => $::bkgcolor,
-            -width      => 8,
-        )->grid( -row => 2, -column => 1, -padx => 1, -pady => 2 );
-        my $linexe = $f4->Entry(
-            -background => $::bkgcolor,
-            -width      => 8,
-        )->grid( -row => 2, -column => 2, -padx => 1, -pady => 2 );
+        my $pagexe =
+          $f4->Entry( -width => 8, )->grid( -row => 2, -column => 1, -padx => 1, -pady => 2 );
+        my $linexe =
+          $f4->Entry( -width => 8, )->grid( -row => 2, -column => 2, -padx => 1, -pady => 2 );
         my $f2         = $::lglobal{guesspgmarkerpop}->Frame->pack;
         my $calcbutton = $f2->Button(
             -command => sub {

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -526,8 +526,7 @@ sub file_guess_page_marks {
         )->grid( -row => 2, -column => 2, -padx => 1, -pady => 2 );
         my $f2         = $::lglobal{guesspgmarkerpop}->Frame->pack;
         my $calcbutton = $f2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 my ( $pnum, $lnum, $pagex, $linex, $number );
                 $totpages = $tpages->get;
                 $line25   = $page25->get;

--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -113,21 +113,18 @@ sub footnotepop {
             -background => $::bkgcolor,
             -relief     => 'sunken',
             -justify    => 'center',
-            -font       => '{Times} 10',
             -width      => 10,
         )->grid( -row => 3, -column => 1, -padx => 2, -pady => 4 );
         $::lglobal{footnoteletter} = $frame3->Label(
             -background => $::bkgcolor,
             -relief     => 'sunken',
             -justify    => 'center',
-            -font       => '{Times} 10',
             -width      => 10,
         )->grid( -row => 3, -column => 2, -padx => 2, -pady => 4 );
         $::lglobal{footnoteroman} = $frame3->Label(
             -background => $::bkgcolor,
             -relief     => 'sunken',
             -justify    => 'center',
-            -font       => '{Times} 10',
             -width      => 10,
         )->grid( -row => 3, -column => 3, -padx => 2, -pady => 4 );
         $checkn = $frame3->Checkbutton(

--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -189,11 +189,10 @@ sub footnotepop {
         )->grid( -row => 4, -column => 3, -padx => 2, -pady => 4 );
         my $frame4 = $::lglobal{footpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         my $fnrb1  = $frame4->Radiobutton(
-            -text        => 'Inline',
-            -variable    => \$::lglobal{footstyle},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'inline',
-            -command     => sub {
+            -text     => 'Inline',
+            -variable => \$::lglobal{footstyle},
+            -value    => 'inline',
+            -command  => sub {
                 $::lglobal{fnindex} = 1;
                 footnoteshow();
                 $::lglobal{fnmvbutton}->configure( -state => 'disabled' );
@@ -206,11 +205,10 @@ sub footnotepop {
             -width   => 14
         )->grid( -row => 8, -column => 3, -padx => 2, -pady => 4 );
         my $fnrb2 = $frame4->Radiobutton(
-            -text        => 'Out-of-Line',
-            -variable    => \$::lglobal{footstyle},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'end',
-            -command     => sub {
+            -text     => 'Out-of-Line',
+            -variable => \$::lglobal{footstyle},
+            -value    => 'end',
+            -command  => sub {
                 $::lglobal{fnindex} = 1;
                 footnoteshow();
                 $::lglobal{fnmvbutton}->configure( -state => 'normal' )

--- a/src/lib/Guiguts/Footnotes.pm
+++ b/src/lib/Guiguts/Footnotes.pm
@@ -30,35 +30,30 @@ sub footnotepop {
         $::lglobal{footpop}->title('Footnote Fixup');
         my $frame1 = $::lglobal{footpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $frame1->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { fnfirstpass() },
-            -text             => 'First Pass',
-            -underline        => 0,
-            -width            => 14
+            -command   => sub { fnfirstpass() },
+            -text      => 'First Pass',
+            -underline => 0,
+            -width     => 14
         )->grid( -row => 1, -column => 1, -padx => 2, -pady => 4 );
         $frame1->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { footnoteadjust() },
-            -text             => 'Rescan this FN',
-            -width            => 14
+            -command => sub { footnoteadjust() },
+            -text    => 'Rescan this FN',
+            -width   => 14
         )->grid( -row => 1, -column => 2, -padx => 2, -pady => 2 );
         $frame1->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { fnview() },
-            -text             => 'Check Footnotes',
-            -width            => 14
+            -command => sub { fnview() },
+            -text    => 'Check Footnotes',
+            -width   => 14
         )->grid( -row => 1, -column => 3, -padx => 6, -pady => 2 );
         $frame1->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { fnjoin() },
-            -text             => 'Join With Previous',
-            -width            => 14
+            -command => sub { fnjoin() },
+            -text    => 'Join With Previous',
+            -width   => 14
         )->grid( -row => 2, -column => 2, -padx => 2, -pady => 2 );
         $frame1->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { setanchor() },
-            -text             => 'Set Anchor',
-            -width            => 14
+            -command => sub { setanchor() },
+            -text    => 'Set Anchor',
+            -width   => 14
         )->grid( -row => 2, -column => 3, -padx => 2, -pady => 2 );
         my $frame1b = $::lglobal{footpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $::lglobal{unlimitedsearchbutton} = $frame1b->Checkbutton(
@@ -71,8 +66,7 @@ sub footnotepop {
         )->grid( -row => 1, -column => 2, -padx => 3, -pady => 4 );
         my $frame2 = $::lglobal{footpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $frame2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 $textwindow->yview('end');
                 $textwindow->see( $::lglobal{fnarray}->[ $::lglobal{fnindex} ][2] )
                   if $::lglobal{fnarray}->[ $::lglobal{fnindex} ][2];
@@ -82,16 +76,14 @@ sub footnotepop {
         )->grid( -row => 1, -column => 1, -padx => 2, -pady => 4 );
         $::lglobal{footnotetotal} = $frame2->Label->grid( -row => 1, -column => 2 );
         $frame2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 footnoteshow();
             },
             -text  => 'See Footnote',
             -width => 14
         )->grid( -row => 1, -column => 3, -padx => 2, -pady => 4 );
         $frame2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 $::lglobal{fnindex}--;
                 footnoteshow();
             },
@@ -109,8 +101,7 @@ sub footnotepop {
             }
         )->grid( -row => 2, -column => 2 );
         $frame2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 $::lglobal{fnindex}++;
                 footnoteshow();
             },
@@ -170,8 +161,7 @@ sub footnotepop {
             -width => 14
         )->grid( -row => 5, -column => 3, -padx => 2, -pady => 4 );
         $frame3->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 return if ( $::lglobal{footstyle} eq 'inline' );
                 fninsertmarkers('n');
                 footnoteshow();
@@ -180,8 +170,7 @@ sub footnotepop {
             -width => 14
         )->grid( -row => 4, -column => 1, -padx => 2, -pady => 4 );
         $frame3->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 return if ( $::lglobal{footstyle} eq 'inline' );
                 fninsertmarkers('a');
                 footnoteshow();
@@ -190,8 +179,7 @@ sub footnotepop {
             -width => 14
         )->grid( -row => 4, -column => 2, -padx => 2, -pady => 4 );
         $frame3->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 return if ( $::lglobal{footstyle} eq 'inline' );
                 fninsertmarkers('r');
                 footnoteshow();
@@ -212,11 +200,10 @@ sub footnotepop {
             },
         )->grid( -row => 8, -column => 1 );
         $::lglobal{fnfpbutton} = $frame4->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { &footnotefixup() },
-            -text             => 'Reindex',
-            -state            => 'disabled',
-            -width            => 14
+            -command => sub { &footnotefixup() },
+            -text    => 'Reindex',
+            -state   => 'disabled',
+            -width   => 14
         )->grid( -row => 8, -column => 3, -padx => 2, -pady => 4 );
         my $fnrb2 = $frame4->Radiobutton(
             -text        => 'Out-of-Line',
@@ -233,26 +220,22 @@ sub footnotepop {
         )->grid( -row => 8, -column => 2 );
         my $frame6 = $::lglobal{footpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $frame6->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { setlz('insert') },
-            -text             => 'Set LZ @ cursor',
-            -width            => 14
+            -command => sub { setlz('insert') },
+            -text    => 'Set LZ @ cursor',
+            -width   => 14
         )->grid( -row => 1, -column => 1, -padx => 2, -pady => 4 );
         $frame6->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { autochaptlz() },
-            -text             => 'Autoset Chap. LZ',
-            -width            => 14
+            -command => sub { autochaptlz() },
+            -text    => 'Autoset Chap. LZ',
+            -width   => 14
         )->grid( -row => 1, -column => 2, -padx => 2, -pady => 4 );
         $frame6->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { autoendlz() },
-            -text             => 'Autoset End LZ',
-            -width            => 14
+            -command => sub { autoendlz() },
+            -text    => 'Autoset End LZ',
+            -width   => 14
         )->grid( -row => 1, -column => 3, -padx => 2, -pady => 4 );
         $frame6->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 getlz();
                 return                  unless $::lglobal{fnlzs} and @{ $::lglobal{fnlzs} };
                 $::lglobal{zoneindex}-- unless $::lglobal{zoneindex} < 1;
@@ -270,8 +253,7 @@ sub footnotepop {
             -width => 12
         )->grid( -row => 2, -column => 1, -padx => 2, -pady => 4 );
         $frame6->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 getlz();
                 return unless $::lglobal{fnlzs} and @{ $::lglobal{fnlzs} };
                 $::lglobal{zoneindex}++
@@ -291,23 +273,20 @@ sub footnotepop {
         )->grid( -row => 2, -column => 3, -padx => 6, -pady => 4 );
         my $frame7 = $::lglobal{footpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $::lglobal{fnmvbutton} = $frame7->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { footnotemove() },
-            -text             => 'Move FNs to Landing Zone(s)',
-            -state            => 'disabled',
-            -width            => 30
+            -command => sub { footnotemove() },
+            -text    => 'Move FNs to Landing Zone(s)',
+            -state   => 'disabled',
+            -width   => 30
         )->grid( -row => 1, -column => 2, -padx => 3, -pady => 4 );
         $::lglobal{fnmvinlinebutton} = $frame7->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { footnotemoveinline() },
-            -text             => 'Move FNs to Para',
-            -state            => 'disabled',
-            -width            => 30
+            -command => sub { footnotemoveinline() },
+            -text    => 'Move FNs to Para',
+            -state   => 'disabled',
+            -width   => 30
         )->grid( -row => 2, -column => 2, -padx => 3, -pady => 4 );
         my $frame8 = $::lglobal{footpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $frame8->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 if ( $::lglobal{footstyle} eq 'inline' ) {
                     $::top->Dialog(
                         -text    => 'Inline footnotes cannot be tidied.',

--- a/src/lib/Guiguts/Greek.pm
+++ b/src/lib/Guiguts/Greek.pm
@@ -310,7 +310,6 @@ sub greekpopup {
     $::lglobal{buildentry} = $bframe2->Entry(
         -width    => 5,
         -font     => 'unicode',
-        -relief   => 'ridge',
         -validate => 'all',
         -vcmd     => \&buildvalidator,
     )->pack( -side => 'left', -padx => 2 );

--- a/src/lib/Guiguts/Greek.pm
+++ b/src/lib/Guiguts/Greek.pm
@@ -259,28 +259,24 @@ sub greekpopup {
     # Radio buttons determine type of input obtained by pressing letter buttons
     my $tframe = $::lglobal{grpop}->Frame->pack( -expand => 'no', -fill => 'none', -anchor => 'n' );
     $tframe->Radiobutton(
-        -variable    => \$::lglobal{groutp},
-        -selectcolor => $::lglobal{checkcolor},
-        -value       => 'l',
-        -text        => 'Latin-1',
+        -variable => \$::lglobal{groutp},
+        -value    => 'l',
+        -text     => 'Latin-1',
     )->grid( -row => 1, -column => 1 );
     $tframe->Radiobutton(
-        -variable    => \$::lglobal{groutp},
-        -selectcolor => $::lglobal{checkcolor},
-        -value       => 'n',
-        -text        => 'Greek Name',
+        -variable => \$::lglobal{groutp},
+        -value    => 'n',
+        -text     => 'Greek Name',
     )->grid( -row => 1, -column => 2 );
     $tframe->Radiobutton(
-        -variable    => \$::lglobal{groutp},
-        -selectcolor => $::lglobal{checkcolor},
-        -value       => 'h',
-        -text        => 'HTML code',
+        -variable => \$::lglobal{groutp},
+        -value    => 'h',
+        -text     => 'HTML code',
     )->grid( -row => 1, -column => 3 );
     $tframe->Radiobutton(
-        -variable    => \$::lglobal{groutp},
-        -selectcolor => $::lglobal{checkcolor},
-        -value       => 'u',
-        -text        => 'UTF-8',
+        -variable => \$::lglobal{groutp},
+        -value    => 'u',
+        -text     => 'UTF-8',
     )->grid( -row => 1, -column => 4 );
 
     # Fill frame with Greek letter buttons - first row consists of labels

--- a/src/lib/Guiguts/Greek.pm
+++ b/src/lib/Guiguts/Greek.pm
@@ -308,12 +308,11 @@ sub greekpopup {
         -relief     => 'ridge'
     )->pack( -side => 'left', -padx => 2 );
     $::lglobal{buildentry} = $bframe2->Entry(
-        -width      => 5,
-        -font       => 'unicode',
-        -background => $::bkgcolor,
-        -relief     => 'ridge',
-        -validate   => 'all',
-        -vcmd       => \&buildvalidator,
+        -width    => 5,
+        -font     => 'unicode',
+        -relief   => 'ridge',
+        -validate => 'all',
+        -vcmd     => \&buildvalidator,
     )->pack( -side => 'left', -padx => 2 );
     $::lglobal{buildentry}->bind(
         '<FocusIn>',

--- a/src/lib/Guiguts/Greek.pm
+++ b/src/lib/Guiguts/Greek.pm
@@ -378,16 +378,14 @@ sub greekpopup {
     );
     for (qw!( ) / \ | ~ + = _!) {
         $bframe2->Button(
-            -activebackground => $::activecolor,
-            -text             => $_,
-            -font             => 'unicode',
-            -borderwidth      => 0,
-            -command          => \&placechar,
+            -text        => $_,
+            -font        => 'unicode',
+            -borderwidth => 0,
+            -command     => \&placechar,
         )->pack( -side => 'left' );
     }
     $bframe2->Button(
-        -activebackground => $::activecolor,
-        -command          => sub {
+        -command => sub {
             my $spot = $::lglobal{grtext}->index('insert');
             $::lglobal{grtext}->insert( 'insert', ' ' );
             $::lglobal{grtext}->markSet( 'insert', "$spot+1c" );
@@ -432,43 +430,36 @@ sub greekpopup {
         -pady   => 3
     );
     $tframe2->Button(
-        -activebackground => $::activecolor,
-        -command          => sub { greekpopuptranslate( \&togreektr ); },
-        -text             => 'ASCII->Greek',
+        -command => sub { greekpopuptranslate( \&togreektr ); },
+        -text    => 'ASCII->Greek',
     )->pack( -side => 'left', -padx => 5 );
     $tframe2->Button(
-        -activebackground => $::activecolor,
-        -command          => sub { greekpopuptranslate( \&fromgreektr ); },
-        -text             => 'Greek->ASCII',
+        -command => sub { greekpopuptranslate( \&fromgreektr ); },
+        -text    => 'Greek->ASCII',
     )->pack( -side => 'left', -padx => 5 );
     $tframe2->Button(
-        -activebackground => $::activecolor,
-        -command          => sub { greekpopuptranslate( \&bettergreek ); },
-        -text             => 'Beta code->Unicode',
+        -command => sub { greekpopuptranslate( \&bettergreek ); },
+        -text    => 'Beta code->Unicode',
     )->pack( -side => 'left', -padx => 5 );
     $tframe2->Button(
-        -activebackground => $::activecolor,
-        -command          => sub { greekpopuptranslate( \&greekbetter ); },
-        -text             => 'Unicode->Beta code',
+        -command => sub { greekpopuptranslate( \&greekbetter ); },
+        -text    => 'Unicode->Beta code',
     )->pack( -side => 'left', -padx => 5 );
 
     my $oframe = $::lglobal{grpop}
       ->Frame->pack( -expand => 'no', -fill => 'none', -anchor => 's', -pady => 3 );
 
     $oframe->Button(
-        -activebackground => $::activecolor,
-        -command          => \&movegreek,
-        -text             => 'Transfer',
+        -command => \&movegreek,
+        -text    => 'Transfer',
     )->pack( -side => 'left', -padx => 5 );
     $oframe->Button(
-        -activebackground => $::activecolor,
-        -command          => sub { movegreek(); findandextractgreek(); },
-        -text             => 'Transfer & Get Next',
+        -command => sub { movegreek(); findandextractgreek(); },
+        -text    => 'Transfer & Get Next',
     )->pack( -side => 'left', -padx => 5 );
 
     $oframe->Button(
-        -activebackground => $::activecolor,
-        -command          => sub {
+        -command => sub {
             $textwindow->tagRemove( 'highlight', '1.0', 'end' );
             movegreek();
             %attributes = ();
@@ -477,8 +468,7 @@ sub greekpopup {
         -text => 'OK',
     )->pack( -side => 'left', -padx => 10 );
     my $cancel = $oframe->Button(
-        -activebackground => $::activecolor,
-        -command          => sub {
+        -command => sub {
             $textwindow->tagRemove( 'highlight', '1.0', 'end' );
             %attributes = ();
             ::killpopup('grpop');
@@ -509,7 +499,6 @@ sub greekpopupbutton {
     my $attrib = shift;
     return unless $attrib;
     my $w = $frame->Label(
-        -activebackground   => $::activecolor,
         -text               => $attrib->[3],
         -font               => 'unicode',
         -relief             => 'flat',

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -2208,21 +2208,18 @@ sub htmlgenpopup {
         $f0a->Entry(
             -textvariable => \$htmltitle,
             -width        => 45,
-            -relief       => 'sunken',
         )->grid( -row => 0, -column => 1, -pady => 2, -sticky => 'w' );
         $f0a->Label( -text => 'Author:', )
           ->grid( -row => 1, -column => 0, -padx => 2, -pady => 2, -sticky => 'w' );
         $f0a->Entry(
             -textvariable => \$::bookauthor,
             -width        => 45,
-            -relief       => 'sunken',
         )->grid( -row => 1, -column => 1, -pady => 2, -sticky => 'w' );
         $f0a->Label( -text => 'Language:', )
           ->grid( -row => 2, -column => 0, -padx => 2, -pady => 2, -sticky => 'w' );
         $f0a->Entry(
             -textvariable => \$::booklang,
             -width        => 5,
-            -relief       => 'sunken',
         )->grid( -row => 2, -column => 1, -pady => 2, -sticky => 'w' );
 
         my $f0 = $::lglobal{htmlgenpop}->Frame->pack( -side => 'top', -anchor => 'n' );
@@ -2473,10 +2470,8 @@ sub htmlmarkpopup {
         # Create rows with entry field and buttons for configurable div, span & i
         for my $row ( 1 .. @::htmlentry ) {
             my $col   = 1;
-            my $entry = $f5->Entry(
-                -width  => 23,
-                -relief => 'sunken',
-            )->grid( -row => $row, -column => $col++, -padx => 1, -pady => 2 );
+            my $entry = $f5->Entry( -width => 23, )
+              ->grid( -row => $row, -column => $col++, -padx => 1, -pady => 2 );
             $f5->Button(
                 -command => sub {
                     ::entry_history( $entry, \@::htmlentryhistory );
@@ -2566,7 +2561,7 @@ sub htmlmarkpopup {
           $lf4->Frame->pack( -side => 'top', -anchor => 'n', -expand => 'yes', -fill => 'x' );
         $f4a->Label( -text => 'Column Format:', )
           ->pack( -side => 'left', -anchor => 'n', -padx => 4, -pady => 2 );
-        $tableformat = $f4a->Entry( -relief => 'sunken', )->pack(
+        $tableformat = $f4a->Entry()->pack(
             -side   => 'left',
             -anchor => 'n',
             -padx   => 4,

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -1668,25 +1668,22 @@ sub htmlimage {
         $::htmlimagewidthtype = '%'
           if $::htmlimagewidthtype eq 'px' and not $::htmlimageallowpixels;
         my $percentsel = $f51->Radiobutton(
-            -variable    => \$::htmlimagewidthtype,
-            -text        => '%',
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => '%',
-            -command     => sub { htmlimagewidthsetdefault(); }
+            -variable => \$::htmlimagewidthtype,
+            -text     => '%',
+            -value    => '%',
+            -command  => sub { htmlimagewidthsetdefault(); }
         )->pack( -side => 'left' );
         my $emsel = $f51->Radiobutton(
-            -variable    => \$::htmlimagewidthtype,
-            -text        => 'em',
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'em',
-            -command     => sub { htmlimagewidthsetdefault(); }
+            -variable => \$::htmlimagewidthtype,
+            -text     => 'em',
+            -value    => 'em',
+            -command  => sub { htmlimagewidthsetdefault(); }
         )->pack( -side => 'left' );
         my $pxsel = $f51->Radiobutton(
-            -variable    => \$::htmlimagewidthtype,
-            -text        => 'px',
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'px',
-            -command     => sub { htmlimagewidthsetdefault(); }
+            -variable => \$::htmlimagewidthtype,
+            -text     => 'px',
+            -value    => 'px',
+            -command  => sub { htmlimagewidthsetdefault(); }
         )->pack( -side => 'left' )
           if $::htmlimageallowpixels;
         my $f52 = $f5->Frame->pack( -side => 'top', -anchor => 'n' );
@@ -1695,31 +1692,27 @@ sub htmlimage {
         $::lglobal{htmlimgmaxwidth} =
           $f52->Label( -text => '' )->pack();
         $f52->Checkbutton(
-            -variable    => \$::epubpercentoverride,
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Override % with 100% in epub',
-            -anchor      => 'w',
+            -variable => \$::epubpercentoverride,
+            -text     => 'Override % with 100% in epub',
+            -anchor   => 'w',
         )->pack();
         my $f2 =
           $::lglobal{htmlimpop}->LabFrame( -label => 'Alignment' )
           ->pack( -side => 'top', -anchor => 'n' );
         $f2->Radiobutton(
-            -variable    => \$::lglobal{htmlimgalignment},
-            -text        => 'Left',
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'left',
+            -variable => \$::lglobal{htmlimgalignment},
+            -text     => 'Left',
+            -value    => 'left',
         )->grid( -row => 1, -column => 1 );
         my $censel = $f2->Radiobutton(
-            -variable    => \$::lglobal{htmlimgalignment},
-            -text        => 'Center',
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'center',
+            -variable => \$::lglobal{htmlimgalignment},
+            -text     => 'Center',
+            -value    => 'center',
         )->grid( -row => 1, -column => 2 );
         $f2->Radiobutton(
-            -variable    => \$::lglobal{htmlimgalignment},
-            -text        => 'Right',
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'right',
+            -variable => \$::lglobal{htmlimgalignment},
+            -text     => 'Right',
+            -value    => 'right',
         )->grid( -row => 1, -column => 3 );
         $censel->select;
         my $f8 = $::lglobal{htmlimpop}->Frame->pack( -side => 'top', -anchor => 'n' );
@@ -2239,10 +2232,9 @@ sub htmlgenpopup {
 
         # Page numbers retained as comments rather than spans in HTML
         $f0->Checkbutton(
-            -variable    => \$::lglobal{pagecmt},
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Pg #s as Comments',
-            -anchor      => 'w',
+            -variable => \$::lglobal{pagecmt},
+            -text     => 'Pg #s as Comments',
+            -anchor   => 'w',
         )->grid(
             -row    => 1,
             -column => 1,
@@ -2253,10 +2245,9 @@ sub htmlgenpopup {
 
         # Add anchor at each page boundary
         $f0->Checkbutton(
-            -variable    => \$::lglobal{pageanch},
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Insert Anchors at Pg #s',
-            -anchor      => 'w',
+            -variable => \$::lglobal{pageanch},
+            -text     => 'Insert Anchors at Pg #s',
+            -anchor   => 'w',
         )->grid(
             -row    => 1,
             -column => 2,
@@ -2267,10 +2258,9 @@ sub htmlgenpopup {
 
         # Only output last of coincident page numbers (due to blank pages)
         $f0->Checkbutton(
-            -variable    => \$::lglobal{pageskipco},
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Skip coincident Pg #s',
-            -anchor      => 'w',
+            -variable => \$::lglobal{pageskipco},
+            -text     => 'Skip coincident Pg #s',
+            -anchor   => 'w',
         )->grid(
             -row    => 1,
             -column => 3,
@@ -2281,10 +2271,9 @@ sub htmlgenpopup {
 
         # Use <div> with CSS class rather than HTML <blockquote> element
         $f0->Checkbutton(
-            -variable    => \$::lglobal{cssblockmarkup},
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'CSS blockquote',
-            -anchor      => 'w',
+            -variable => \$::lglobal{cssblockmarkup},
+            -text     => 'CSS blockquote',
+            -anchor   => 'w',
         )->grid(
             -row    => 2,
             -column => 1,
@@ -2295,10 +2284,9 @@ sub htmlgenpopup {
 
         # Anchor will be of the form Footnote_3 rather than Footnote_3_3
         $f0->Checkbutton(
-            -variable    => \$::lglobal{shorthtmlfootnotes},
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Short FN Anchors',
-            -anchor      => 'w',
+            -variable => \$::lglobal{shorthtmlfootnotes},
+            -text     => 'Short FN Anchors',
+            -anchor   => 'w',
         )->grid(
             -row    => 2,
             -column => 2,
@@ -2309,10 +2297,9 @@ sub htmlgenpopup {
 
         # Automatically convert 1/2, 1/4, 3/4 to entities
         $f0->Checkbutton(
-            -variable    => \$::lglobal{autofraction},
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Convert Fractions',
-            -anchor      => 'w',
+            -variable => \$::lglobal{autofraction},
+            -text     => 'Convert Fractions',
+            -anchor   => 'w',
         )->grid(
             -row    => 2,
             -column => 3,
@@ -2325,9 +2312,8 @@ sub htmlgenpopup {
 
         # Find & format poetry line numbers consisting of digits spaced beyond end of line
         $f7->Checkbutton(
-            -variable    => \$::lglobal{poetrynumbers},
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Find and Format Poetry Line Numbers'
+            -variable => \$::lglobal{poetrynumbers},
+            -text     => 'Find and Format Poetry Line Numbers'
         )->grid( -row => 1, -column => 1, -pady => 2 );
 
         my $f4 = $::lglobal{htmlgenpop}->Frame->pack( -side => 'top', -anchor => 'n' );
@@ -2335,109 +2321,93 @@ sub htmlgenpopup {
         # HTML to use when converting <i> markup
         $f4->Label( -text => '<i>:', )->grid( -row => 1, -column => 0, -padx => 2, -pady => 2 );
         $f4->Radiobutton(
-            -text        => '<i>',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{html_i},
-            -value       => '<i>',
+            -text     => '<i>',
+            -variable => \$::lglobal{html_i},
+            -value    => '<i>',
         )->grid( -row => 1, -column => 1 );
         $f4->Radiobutton(
-            -text        => '<em>',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{html_i},
-            -value       => '<em>',
+            -text     => '<em>',
+            -variable => \$::lglobal{html_i},
+            -value    => '<em>',
         )->grid( -row => 1, -column => 2 );
         $f4->Radiobutton(
-            -text        => '<em class>',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{html_i},
-            -value       => '<em class="italic">',
+            -text     => '<em class>',
+            -variable => \$::lglobal{html_i},
+            -value    => '<em class="italic">',
         )->grid( -row => 1, -column => 3 );
         $f4->Radiobutton(
-            -text        => '<span class>',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{html_i},
-            -value       => '<span class="italic">',
+            -text     => '<span class>',
+            -variable => \$::lglobal{html_i},
+            -value    => '<span class="italic">',
         )->grid( -row => 1, -column => 4 );
 
         # HTML to use when converting <b> markup
         $f4->Label( -text => '<b>:', )->grid( -row => 2, -column => 0, -padx => 2, -pady => 2 );
         $f4->Radiobutton(
-            -text        => '<b>',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{html_b},
-            -value       => '<b>',
+            -text     => '<b>',
+            -variable => \$::lglobal{html_b},
+            -value    => '<b>',
         )->grid( -row => 2, -column => 1 );
         $f4->Radiobutton(
-            -text        => '<em>',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{html_b},
-            -value       => '<em>',
+            -text     => '<em>',
+            -variable => \$::lglobal{html_b},
+            -value    => '<em>',
         )->grid( -row => 2, -column => 2 );
         $f4->Radiobutton(
-            -text        => '<em class>',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{html_b},
-            -value       => '<em class="bold">',
+            -text     => '<em class>',
+            -variable => \$::lglobal{html_b},
+            -value    => '<em class="bold">',
         )->grid( -row => 2, -column => 3 );
         $f4->Radiobutton(
-            -text        => '<span class>',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{html_b},
-            -value       => '<span class="bold">',
+            -text     => '<span class>',
+            -variable => \$::lglobal{html_b},
+            -value    => '<span class="bold">',
         )->grid( -row => 2, -column => 4 );
 
         # HTML to use when converting <g> markup
         $f4->Label( -text => '<g>:', )->grid( -row => 3, -column => 0, -padx => 2, -pady => 2 );
         $f4->Radiobutton(
-            -text        => 'ign.',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{html_g},
-            -value       => '<g>',
+            -text     => 'ign.',
+            -variable => \$::lglobal{html_g},
+            -value    => '<g>',
         )->grid( -row => 3, -column => 1 );
         $f4->Radiobutton(
-            -text        => '<em>',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{html_g},
-            -value       => '<em>',
+            -text     => '<em>',
+            -variable => \$::lglobal{html_g},
+            -value    => '<em>',
         )->grid( -row => 3, -column => 2 );
         $f4->Radiobutton(
-            -text        => '<em class>',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{html_g},
-            -value       => '<em class="gesperrt">',
+            -text     => '<em class>',
+            -variable => \$::lglobal{html_g},
+            -value    => '<em class="gesperrt">',
         )->grid( -row => 3, -column => 3 );
         $f4->Radiobutton(
-            -text        => '<span class>',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{html_g},
-            -value       => '<span class="gesperrt">',
+            -text     => '<span class>',
+            -variable => \$::lglobal{html_g},
+            -value    => '<span class="gesperrt">',
         )->grid( -row => 3, -column => 4 );
 
         # HTML to use when converting <f> markup
         $f4->Label( -text => '<f>:', )->grid( -row => 4, -column => 0, -padx => 2, -pady => 2 );
         $f4->Radiobutton(
-            -text        => 'ign.',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{html_f},
-            -value       => '<f>',
+            -text     => 'ign.',
+            -variable => \$::lglobal{html_f},
+            -value    => '<f>',
         )->grid( -row => 4, -column => 1 );
         $f4->Radiobutton(
-            -text        => '<em>',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{html_f},
-            -value       => '<em>',
+            -text     => '<em>',
+            -variable => \$::lglobal{html_f},
+            -value    => '<em>',
         )->grid( -row => 4, -column => 2 );
         $f4->Radiobutton(
-            -text        => '<em class>',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{html_f},
-            -value       => '<em class="antiqua">',
+            -text     => '<em class>',
+            -variable => \$::lglobal{html_f},
+            -value    => '<em class="antiqua">',
         )->grid( -row => 4, -column => 3 );
         $f4->Radiobutton(
-            -text        => '<span class>',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{html_f},
-            -value       => '<span class="antiqua">',
+            -text     => '<span class>',
+            -variable => \$::lglobal{html_f},
+            -value    => '<span class="antiqua">',
         )->grid( -row => 4, -column => 4 );
 
         my $f2 = $::lglobal{htmlgenpop}->Frame->pack( -side => 'top', -anchor => 'n' );
@@ -2572,16 +2542,14 @@ sub htmlmarkpopup {
         my $lf3 = $::lglobal{markpop}->LabFrame( -label => 'Lists' )
           ->pack( -side => 'top', -anchor => 'n', -expand => 'yes', -fill => 'x' );
         my $unorderselect = $lf3->Radiobutton(
-            -text        => 'unordered',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{liststyle},
-            -value       => 'ul',
+            -text     => 'unordered',
+            -variable => \$::lglobal{liststyle},
+            -value    => 'ul',
         )->pack( -side => 'left', -anchor => 'w', -padx => 4, -pady => 2 );
         my $orderselect = $lf3->Radiobutton(
-            -text        => 'ordered',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{liststyle},
-            -value       => 'ol',
+            -text     => 'ordered',
+            -variable => \$::lglobal{liststyle},
+            -value    => 'ol',
         )->pack( -side => 'left', -anchor => 'w', -padx => 4, -pady => 2 );
         $unorderselect->select;
         $lf3->Checkbutton(
@@ -2616,22 +2584,19 @@ sub htmlmarkpopup {
         my $f4b =
           $lf4->Frame->pack( -side => 'top', -anchor => 'n', -expand => 'yes', -fill => 'x' );
         my $leftselect = $f4b->Radiobutton(
-            -text        => 'left',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{tablecellalign},
-            -value       => ' class="tdl"',
+            -text     => 'left',
+            -variable => \$::lglobal{tablecellalign},
+            -value    => ' class="tdl"',
         )->pack( -side => 'left', -anchor => 'n', -padx => 4, -pady => 2 );
         my $censelect = $f4b->Radiobutton(
-            -text        => 'center',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{tablecellalign},
-            -value       => ' class="tdc"',
+            -text     => 'center',
+            -variable => \$::lglobal{tablecellalign},
+            -value    => ' class="tdc"',
         )->pack( -side => 'left', -anchor => 'n', -padx => 4, -pady => 2 );
         my $rghtselect = $f4b->Radiobutton(
-            -text        => 'right',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{tablecellalign},
-            -value       => ' class="tdr"',
+            -text     => 'right',
+            -variable => \$::lglobal{tablecellalign},
+            -value    => ' class="tdr"',
         )->pack( -side => 'left', -anchor => 'n', -padx => 4, -pady => 2 );
         $leftselect->select;
         $f4b->Checkbutton(
@@ -2940,10 +2905,9 @@ sub markup {
             $::lglobal{fnlinks} = 1;
             my $tframe = $::lglobal{linkpop}->Frame->pack;
             $tframe->Checkbutton(
-                -variable    => \$::lglobal{ilinksrt},
-                -selectcolor => $::lglobal{checkcolor},
-                -text        => 'Sort Alphabetically',
-                -command     => sub {
+                -variable => \$::lglobal{ilinksrt},
+                -text     => 'Sort Alphabetically',
+                -command  => sub {
                     $linklistbox->delete( '0', 'end' );
                     linkpopulate( $linklistbox, \@intanchors );
                 },
@@ -2954,10 +2918,9 @@ sub markup {
                 -anchor => 'n'
             );
             $tframe->Checkbutton(
-                -variable    => \$::lglobal{fnlinks},
-                -selectcolor => $::lglobal{checkcolor},
-                -text        => 'Hide Footnote Links',
-                -command     => sub {
+                -variable => \$::lglobal{fnlinks},
+                -text     => 'Hide Footnote Links',
+                -command  => sub {
                     $linklistbox->delete( '0', 'end' );
                     linkpopulate( $linklistbox, \@intanchors );
                 },
@@ -2968,10 +2931,9 @@ sub markup {
                 -anchor => 'n'
             );
             $tframe->Checkbutton(
-                -variable    => \$::lglobal{pglinks},
-                -selectcolor => $::lglobal{checkcolor},
-                -text        => 'Hide Page Links',
-                -command     => sub {
+                -variable => \$::lglobal{pglinks},
+                -text     => 'Hide Page Links',
+                -command  => sub {
                     $linklistbox->delete( '0', 'end' );
                     linkpopulate( $linklistbox, \@intanchors );
                 },
@@ -3846,11 +3808,10 @@ sub fracconv {
         $::lglobal{pagelabelballoon}
           ->attach( $fimg, -msg => 'Double-click on page list to show image' );
         $::lglobal{pagelabelautoimgbtn} = $fimg->Checkbutton(
-            -variable    => \$::lglobal{pagelabelautoimg},
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Auto Img',
-            -anchor      => 'w',
-            -command     => sub {
+            -variable => \$::lglobal{pagelabelautoimg},
+            -text     => 'Auto Img',
+            -anchor   => 'w',
+            -command  => sub {
                 $::lglobal{pagelabelimgbtn}->invoke if $::lglobal{pagelabelautoimg};
             },
         )->pack( -side => 'top', -anchor => 'nw' );
@@ -3871,25 +3832,22 @@ sub fracconv {
         $::lglobal{pagelabelballoon}
           ->attach( $fstyle, -msg => 'Shift-click on page list to cycle style' );
         my $fstylea = $fstyle->Radiobutton(
-            -text        => 'Arabic',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{pagelabelstyle},
-            -value       => 'Arabic',
-            -command     => sub { pagelabelsetstyle(); },
+            -text     => 'Arabic',
+            -variable => \$::lglobal{pagelabelstyle},
+            -value    => 'Arabic',
+            -command  => sub { pagelabelsetstyle(); },
         )->grid( -row => 1, -column => 1, -sticky => 'w' );
         my $fstyler = $fstyle->Radiobutton(
-            -text        => 'Roman',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{pagelabelstyle},
-            -value       => 'Roman',
-            -command     => sub { pagelabelsetstyle(); },
+            -text     => 'Roman',
+            -variable => \$::lglobal{pagelabelstyle},
+            -value    => 'Roman',
+            -command  => sub { pagelabelsetstyle(); },
         )->grid( -row => 2, -column => 1, -sticky => 'w' );
         my $fstyled = $fstyle->Radiobutton(
-            -text        => '"',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{pagelabelstyle},
-            -value       => '"',
-            -command     => sub { pagelabelsetstyle(); },
+            -text     => '"',
+            -variable => \$::lglobal{pagelabelstyle},
+            -value    => '"',
+            -command  => sub { pagelabelsetstyle(); },
         )->grid( -row => 3, -column => 1, -sticky => 'w' );
 
         # Label action - Start @/+1/No Count
@@ -3898,25 +3856,22 @@ sub fracconv {
         $::lglobal{pagelabelballoon}
           ->attach( $faction, -msg => 'Control-click on page list to cycle action' );
         my $factions = $faction->Radiobutton(
-            -text        => 'Start @',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{pagelabelaction},
-            -value       => 'Start @',
-            -command     => sub { pagelabelsetaction(); },
+            -text     => 'Start @',
+            -variable => \$::lglobal{pagelabelaction},
+            -value    => 'Start @',
+            -command  => sub { pagelabelsetaction(); },
         )->grid( -row => 1, -column => 1, -sticky => 'w' );
         my $factionp = $faction->Radiobutton(
-            -text        => '+1',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{pagelabelaction},
-            -value       => '+1',
-            -command     => sub { pagelabelsetaction(); },
+            -text     => '+1',
+            -variable => \$::lglobal{pagelabelaction},
+            -value    => '+1',
+            -command  => sub { pagelabelsetaction(); },
         )->grid( -row => 2, -column => 1, -sticky => 'w' );
         my $factionn = $faction->Radiobutton(
-            -text        => 'No Count',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{pagelabelaction},
-            -value       => 'No Count',
-            -command     => sub { pagelabelsetaction(); },
+            -text     => 'No Count',
+            -variable => \$::lglobal{pagelabelaction},
+            -value    => 'No Count',
+            -command  => sub { pagelabelsetaction(); },
         )->grid( -row => 3, -column => 1, -sticky => 'w' );
 
         # Label base - only used with 'Start @' action

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -2200,10 +2200,9 @@ sub htmlgenpopup {
             -command => sub { ::pageadjust() },
         )->grid( -row => 1, -column => 2, -padx => 1, -pady => 1 );
         $f1->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { htmlimages( $textwindow, $top ); },
-            -text             => 'Auto Illus Search',
-            -width            => 16,
+            -command => sub { htmlimages( $textwindow, $top ); },
+            -text    => 'Auto Illus Search',
+            -width   => 16,
         )->grid( -row => 1, -column => 3, -padx => 1, -pady => 1 );
 
         my $ishtml = $textwindow->search( '-nocase', '--', '<html', '1.0' );
@@ -2443,10 +2442,9 @@ sub htmlgenpopup {
 
         my $f2 = $::lglobal{htmlgenpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $f2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { htmlautoconvert( $textwindow, $top, $htmltitle ) },
-            -text             => 'Autogenerate HTML',
-            -width            => 16
+            -command => sub { htmlautoconvert( $textwindow, $top, $htmltitle ) },
+            -text    => 'Autogenerate HTML',
+            -width   => 16
         )->grid( -row => 1, -column => 1, -padx => 5, -pady => 1 );
 
         ::initialize_popup_with_deletebinding('htmlgenpop');
@@ -2486,8 +2484,7 @@ sub htmlmarkpopup {
             $col = $inc % 6;
             $row = int $inc / 6;
             my $mbtn = $f1->Button(
-                -activebackground => $::activecolor,
-                -command          => [
+                -command => [
                     sub {
                         markup( $textwindow, $top, $_[0], $::htmlentryattribhash{ $_[0] } );
                     },
@@ -2515,8 +2512,7 @@ sub htmlmarkpopup {
                 -relief     => 'sunken',
             )->grid( -row => $row, -column => $col++, -padx => 1, -pady => 2 );
             $f5->Button(
-                -activebackground => $::activecolor,
-                -command          => sub {
+                -command => sub {
                     ::entry_history( $entry, \@::htmlentryhistory );
                 },
                 -image  => $::lglobal{hist_img},
@@ -2527,8 +2523,7 @@ sub htmlmarkpopup {
             $entry->insert( 'end', $::htmlentry[$ent] );
             for (qw / div span i /) {
                 $f5->Button(
-                    -activebackground => $::activecolor,
-                    -command          => [
+                    -command => [
                         sub {
                             $::htmlentry[$ent] = $entry->get;
                             ::add_entry_history( $::htmlentry[$ent], \@::htmlentryhistory );
@@ -2557,8 +2552,7 @@ sub htmlmarkpopup {
         for (@hbuttons) {
             my $marktype = $hbuttons[$col][1];
             my $mbtn     = $f2->Button(
-                -activebackground => $::activecolor,
-                -command          => [
+                -command => [
                     sub {
                         markup( $textwindow, $top, $marktype, $::htmlentryattribhash{$marktype} );
                     }
@@ -2597,10 +2591,9 @@ sub htmlmarkpopup {
             -offvalue => 0
         )->pack( -side => 'right', -anchor => 'e', -padx => 4, -pady => 2 );
         my $autolbutton = $lf3->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { autolist($textwindow); $textwindow->focus },
-            -text             => 'Auto List',
-            -width            => 12
+            -command => sub { autolist($textwindow); $textwindow->focus },
+            -text    => 'Auto List',
+            -width   => 12
         )->pack( -side => 'right', -anchor => 'e', -padx => 4, -pady => 2 );
 
         my $lf4 = $::lglobal{markpop}->LabFrame( -label => 'Tables' )
@@ -2648,8 +2641,7 @@ sub htmlmarkpopup {
             -offvalue => 0
         )->pack( -side => 'right', -anchor => 'n', -padx => 4, -pady => 2 );
         $f4b->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 autotable( $textwindow, $tableformat->get );
                 $textwindow->focus;
             },
@@ -2659,28 +2651,24 @@ sub htmlmarkpopup {
 
         my $f7 = $::lglobal{markpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $f7->Button(
-            -activebackground => $::activecolor,
-            -command          => \&poetryhtml,
-            -text             => 'Apply Poetry Markup to Sel.',
-            -width            => 24
+            -command => \&poetryhtml,
+            -text    => 'Apply Poetry Markup to Sel.',
+            -width   => 24
         )->grid( -row => 1, -column => 1, -padx => 1, -pady => 2 );
         $f7->Button(
-            -activebackground => $::activecolor,
-            -command          => \&hyperlinkpagenums,
-            -text             => 'Hyperlink Page Nums',
-            -width            => 24
+            -command => \&hyperlinkpagenums,
+            -text    => 'Hyperlink Page Nums',
+            -width   => 24
         )->grid( -row => 1, -column => 2, -padx => 1, -pady => 2 );
 
         my $f3 = $::lglobal{markpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $f3->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { clearmarkupinselection() },
-            -text             => 'Remove Markup from Selection',
-            -width            => 24
+            -command => sub { clearmarkupinselection() },
+            -text    => 'Remove Markup from Selection',
+            -width   => 24
         )->grid( -row => 1, -column => 1, -padx => 1, -pady => 2 );
         $f3->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 for my $orphan (
                     'i',          'b',    'u',      'center', 'sub',   'sup',
                     'h1',         'h2',   'h3',     'h4',     'h5',    'h6',
@@ -2869,10 +2857,9 @@ sub markup {
               $linkf1->Entry( -background => $::bkgcolor )->pack( -expand => 'yes', -fill => 'x' );
             my $linkf2    = $::lglobal{elinkpop}->Frame->pack( -side => 'top', -anchor => 'n' );
             my $extbrowse = $linkf2->Button(
-                -activebackground => $::activecolor,
-                -text             => 'Browse',
-                -width            => 16,
-                -command          => sub {
+                -text    => 'Browse',
+                -width   => 16,
+                -command => sub {
                     $name = $::lglobal{elinkpop}->getOpenFile( -title => 'File Name?' );
                     if ($name) {
                         $::lglobal{linkentry}->delete( 0, 'end' );
@@ -2882,10 +2869,9 @@ sub markup {
             )->pack( -side => 'left', -pady => 4 );
             my $linkf3 = $::lglobal{elinkpop}->Frame->pack( -side => 'top', -anchor => 'n' );
             my $okbut  = $linkf3->Button(
-                -activebackground => $::activecolor,
-                -text             => 'OK',
-                -width            => 16,
-                -command          => sub {
+                -text    => 'OK',
+                -width   => 16,
+                -command => sub {
                     $name = $::lglobal{linkentry}->get;
                     if ($name) {
                         $name =~ s/[\/\\]/;/g;

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -2208,7 +2208,6 @@ sub htmlgenpopup {
         $f0a->Entry(
             -textvariable => \$htmltitle,
             -width        => 45,
-            -background   => $::bkgcolor,
             -relief       => 'sunken',
         )->grid( -row => 0, -column => 1, -pady => 2, -sticky => 'w' );
         $f0a->Label( -text => 'Author:', )
@@ -2216,7 +2215,6 @@ sub htmlgenpopup {
         $f0a->Entry(
             -textvariable => \$::bookauthor,
             -width        => 45,
-            -background   => $::bkgcolor,
             -relief       => 'sunken',
         )->grid( -row => 1, -column => 1, -pady => 2, -sticky => 'w' );
         $f0a->Label( -text => 'Language:', )
@@ -2224,7 +2222,6 @@ sub htmlgenpopup {
         $f0a->Entry(
             -textvariable => \$::booklang,
             -width        => 5,
-            -background   => $::bkgcolor,
             -relief       => 'sunken',
         )->grid( -row => 2, -column => 1, -pady => 2, -sticky => 'w' );
 
@@ -2477,9 +2474,8 @@ sub htmlmarkpopup {
         for my $row ( 1 .. @::htmlentry ) {
             my $col   = 1;
             my $entry = $f5->Entry(
-                -width      => 23,
-                -background => $::bkgcolor,
-                -relief     => 'sunken',
+                -width  => 23,
+                -relief => 'sunken',
             )->grid( -row => $row, -column => $col++, -padx => 1, -pady => 2 );
             $f5->Button(
                 -command => sub {
@@ -2570,10 +2566,7 @@ sub htmlmarkpopup {
           $lf4->Frame->pack( -side => 'top', -anchor => 'n', -expand => 'yes', -fill => 'x' );
         $f4a->Label( -text => 'Column Format:', )
           ->pack( -side => 'left', -anchor => 'n', -padx => 4, -pady => 2 );
-        $tableformat = $f4a->Entry(
-            -background => $::bkgcolor,
-            -relief     => 'sunken',
-        )->pack(
+        $tableformat = $f4a->Entry( -relief => 'sunken', )->pack(
             -side   => 'left',
             -anchor => 'n',
             -padx   => 4,
@@ -2819,7 +2812,7 @@ sub markup {
             );
             my $linklabel = $linkf1->Label( -text => 'Link name' )->pack;
             $::lglobal{linkentry} =
-              $linkf1->Entry( -background => $::bkgcolor )->pack( -expand => 'yes', -fill => 'x' );
+              $linkf1->Entry()->pack( -expand => 'yes', -fill => 'x' );
             my $linkf2    = $::lglobal{elinkpop}->Frame->pack( -side => 'top', -anchor => 'n' );
             my $extbrowse = $linkf2->Button(
                 -text    => 'Browse',

--- a/src/lib/Guiguts/HelpMenu.pm
+++ b/src/lib/Guiguts/HelpMenu.pm
@@ -51,9 +51,8 @@ EOM
             -text    => $about_text
         )->pack;
         my $button_ok = $::lglobal{aboutpop}->Button(
-            -activebackground => $::activecolor,
-            -text             => 'OK',
-            -command          => sub { ::killpopup('aboutpop'); }
+            -text    => 'OK',
+            -command => sub { ::killpopup('aboutpop'); }
         )->pack( -pady => 6 );
         $::lglobal{aboutpop}->resizable( 'yes', 'yes' );
         $::lglobal{aboutpop}->raise;

--- a/src/lib/Guiguts/Highlight.pm
+++ b/src/lib/Guiguts/Highlight.pm
@@ -236,9 +236,8 @@ sub hilitepopup {
         $f->Label( -text => 'Highlight Character(s) or Regex', )
           ->pack( -side => 'top', -pady => 2, -padx => 2, -anchor => 'n' );
         my $entry = $f->Entry(
-            -width      => 40,
-            -background => $::bkgcolor,
-            -relief     => 'sunken',
+            -width  => 40,
+            -relief => 'sunken',
         )->pack(
             -expand => 1,
             -fill   => 'x',

--- a/src/lib/Guiguts/Highlight.pm
+++ b/src/lib/Guiguts/Highlight.pm
@@ -248,16 +248,14 @@ sub hilitepopup {
         );
         my $f2 = $::lglobal{hilitepop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $f2->Radiobutton(
-            -variable    => \$hilitemode,
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'exact',
-            -text        => 'Exact',
+            -variable => \$hilitemode,
+            -value    => 'exact',
+            -text     => 'Exact',
         )->grid( -row => 0, -column => 1 );
         $f2->Radiobutton(
-            -variable    => \$hilitemode,
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'regex',
-            -text        => 'Regex',
+            -variable => \$hilitemode,
+            -value    => 'regex',
+            -text     => 'Regex',
         )->grid( -row => 0, -column => 2 );
         my $f3 = $::lglobal{hilitepop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $f3->Button(

--- a/src/lib/Guiguts/Highlight.pm
+++ b/src/lib/Guiguts/Highlight.pm
@@ -235,10 +235,7 @@ sub hilitepopup {
         my $f          = $::lglobal{hilitepop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $f->Label( -text => 'Highlight Character(s) or Regex', )
           ->pack( -side => 'top', -pady => 2, -padx => 2, -anchor => 'n' );
-        my $entry = $f->Entry(
-            -width  => 40,
-            -relief => 'sunken',
-        )->pack(
+        my $entry = $f->Entry( -width => 40, )->pack(
             -expand => 1,
             -fill   => 'x',
             -padx   => 3,

--- a/src/lib/Guiguts/Highlight.pm
+++ b/src/lib/Guiguts/Highlight.pm
@@ -261,8 +261,7 @@ sub hilitepopup {
         )->grid( -row => 0, -column => 2 );
         my $f3 = $::lglobal{hilitepop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $f3->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
 
                 if ( $textwindow->markExists('selstart') ) {
                     $textwindow->tagAdd( 'sel', 'selstart', 'selend' );
@@ -272,22 +271,19 @@ sub hilitepopup {
             -width => 16,
         )->grid( -row => 1, -column => 1, -padx => 2, -pady => 2 );
         $f3->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { $textwindow->tagAdd( 'sel', '1.0', 'end' ) },
-            -text             => 'Select Whole File',
-            -width            => 16,
+            -command => sub { $textwindow->tagAdd( 'sel', '1.0', 'end' ) },
+            -text    => 'Select Whole File',
+            -width   => 16,
         )->grid( -row => 1, -column => 2, -padx => 2, -pady => 2 );
         $f3->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { hilite( $entry->get, $hilitemode ) },
-            -text             => 'Apply Highlights',
-            -width            => 16,
+            -command => sub { hilite( $entry->get, $hilitemode ) },
+            -text    => 'Apply Highlights',
+            -width   => 16,
         )->grid( -row => 2, -column => 1, -padx => 2, -pady => 2 );
         $f3->Button(
-            -activebackground => $::activecolor,
-            -command          => \&::hiliteremove,
-            -text             => 'Remove Highlight',
-            -width            => 16,
+            -command => \&::hiliteremove,
+            -text    => 'Remove Highlight',
+            -width   => 16,
         )->grid( -row => 2, -column => 2, -padx => 2, -pady => 2 );
     }
 }

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -1020,7 +1020,7 @@ sub menu_preferences_appearance {
             -command => sub {
                 my $thiscolor = ::setcolor($::activecolor);
                 $::activecolor = $thiscolor if $thiscolor;
-                $::lglobal{checkcolor} = $::OS_WIN ? 'white' : $::activecolor;
+                ::setwidgetdefaultoptions();    # Update database with new defaults
                 ::savesettings();
             }
         ],

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -1011,6 +1011,7 @@ sub menu_preferences_appearance {
             -command => sub {
                 my $thiscolor = ::setcolor($::bkgcolor);
                 $::bkgcolor = $thiscolor if $thiscolor;
+                ::setwidgetdefaultoptions();    # Update database with new defaults
                 ::savesettings();
             }
         ],

--- a/src/lib/Guiguts/MultiLingual.pm
+++ b/src/lib/Guiguts/MultiLingual.pm
@@ -465,7 +465,6 @@ sub setmultiplelanguages {
     )->pack( -side => 'left' );
     my $minfreqcell = $freqframe->Entry(
         -width        => 6,
-        -relief       => 'sunken',
         -textvariable => \$minfreq,
     )->pack( -side => 'left' );
     $spellop->Show;

--- a/src/lib/Guiguts/MultiLingual.pm
+++ b/src/lib/Guiguts/MultiLingual.pm
@@ -63,10 +63,8 @@ sub multilangpopup {
         my $labelone =
           $f2->Label( -text => 'Dictionaries selected:' )
           ->grid( -row => 1, -column => 1, -padx => 1, -pady => 1 );
-        $multidictentry = $f2->Entry(
-            -background => $::bkgcolor,
-            -width      => 40,
-        )->grid( -row => 1, -column => 2, -padx => 1, -pady => 1 );
+        $multidictentry =
+          $f2->Entry( -width => 40, )->grid( -row => 1, -column => 2, -padx => 1, -pady => 1 );
         my $f0 = $::lglobal{multispellpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $f0->Button(
             -command => sub {
@@ -467,7 +465,6 @@ sub setmultiplelanguages {
     )->pack( -side => 'left' );
     my $minfreqcell = $freqframe->Entry(
         -width        => 6,
-        -background   => $::bkgcolor,
         -relief       => 'sunken',
         -textvariable => \$minfreq,
     )->pack( -side => 'left' );

--- a/src/lib/Guiguts/MultiLingual.pm
+++ b/src/lib/Guiguts/MultiLingual.pm
@@ -69,8 +69,7 @@ sub multilangpopup {
         )->grid( -row => 1, -column => 2, -padx => 1, -pady => 1 );
         my $f0 = $::lglobal{multispellpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $f0->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 setmultiplelanguages( $textwindow, $top );
                 updateMultiDictEntry();
             },
@@ -78,8 +77,7 @@ sub multilangpopup {
             -width => 20
         )->grid( -row => 1, -column => 2, -padx => 1, -pady => 1 );
         $f0->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 ::spelloptions();
                 clearmultilanguages();
                 updateMultiDictEntry();
@@ -88,65 +86,55 @@ sub multilangpopup {
             -width => 20
         )->grid( -row => 1, -column => 1, -padx => 1, -pady => 1 );
         $f0->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { createseenwordslang( $textwindow, $top ) },
-            -text             => '(Re)create Wordlist',
-            -width            => 20
+            -command => sub { createseenwordslang( $textwindow, $top ) },
+            -text    => '(Re)create Wordlist',
+            -width   => 20
         )->grid( -row => 2, -column => 1, -padx => 1, -pady => 1 );
         $f0->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { multilingualgetmisspelled( $textwindow, $top ) },
-            -text             => 'Check spelling',
-            -width            => 20
+            -command => sub { multilingualgetmisspelled( $textwindow, $top ) },
+            -text    => 'Check spelling',
+            -width   => 20
         )->grid( -row => 2, -column => 2, -padx => 1, -pady => 1 );
         $f0->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { includeprojectdict( $textwindow, $top ) },
-            -text             => 'Include project words',
-            -width            => 20
+            -command => sub { includeprojectdict( $textwindow, $top ) },
+            -text    => 'Include project words',
+            -width   => 20
         )->grid( -row => 2, -column => 3, -padx => 1, -pady => 1 );
         $f0->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { showAllWords() },
-            -text             => 'Show all words',
-            -width            => 20
+            -command => sub { showAllWords() },
+            -text    => 'Show all words',
+            -width   => 20
         )->grid( -row => 3, -column => 1, -padx => 1, -pady => 1 );
         $f0->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { showUnspeltWords() },
-            -text             => 'Show unspelt words',
-            -width            => 20
+            -command => sub { showUnspeltWords() },
+            -text    => 'Show unspelt words',
+            -width   => 20
         )->grid( -row => 3, -column => 2, -padx => 1, -pady => 1 );
         $f0->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { showspeltforeignwords() },
-            -text             => 'Show spelt foreign words',
-            -width            => 20
+            -command => sub { showspeltforeignwords() },
+            -text    => 'Show spelt foreign words',
+            -width   => 20
         )->grid( -row => 3, -column => 3, -padx => 1, -pady => 1 );
         $f0->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { showprojectdict() },
-            -text             => 'Show project dictionary',
-            -width            => 20
+            -command => sub { showprojectdict() },
+            -text    => 'Show project dictionary',
+            -width   => 20
         )->grid( -row => 4, -column => 1, -padx => 1, -pady => 1 );
         $f0->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { addspeltforeignproject() },
-            -text             => 'Add foreign to project',
-            -width            => 20
+            -command => sub { addspeltforeignproject() },
+            -text    => 'Add foreign to project',
+            -width   => 20
         )->grid( -row => 4, -column => 2, -padx => 1, -pady => 1 );
         $f0->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { addminfreqproject() },
-            -text             => 'Add frequent to project',
-            -width            => 20
+            -command => sub { addminfreqproject() },
+            -text    => 'Add frequent to project',
+            -width   => 20
         )->grid( -row => 4, -column => 3, -padx => 1, -pady => 1 );
 
         $f0->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { multi_help_popup($top) },
-            -text             => 'Help',
-            -width            => 20
+            -command => sub { multi_help_popup($top) },
+            -text    => 'Help',
+            -width   => 20
         )->grid( -row => 1, -column => 3, -padx => 1, -pady => 1 );
         my $f1 = $::lglobal{multispellpop}->Frame->pack( -fill => 'both', -expand => 'both', );
         $multiwclistbox = $f1->Scrolled(
@@ -897,9 +885,8 @@ EOM
             -text    => $text
         )->pack;
         $::lglobal{multihelppop}->Button(
-            -activebackground => $::activecolor,
-            -text             => 'OK',
-            -command          => sub {
+            -text    => 'OK',
+            -command => sub {
                 $::lglobal{multihelppop}->destroy;
                 undef $::lglobal{multihelppop};
             }

--- a/src/lib/Guiguts/MultiLingual.pm
+++ b/src/lib/Guiguts/MultiLingual.pm
@@ -152,22 +152,19 @@ sub multilangpopup {
         );
         my $f3 = $::lglobal{multispellpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $f3->Radiobutton(
-            -variable    => \$sortorder,
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'a',
-            -text        => 'Alph',
+            -variable => \$sortorder,
+            -value    => 'a',
+            -text     => 'Alph',
         )->pack( -side => 'left', -anchor => 'nw', -pady => 1 );
         $f3->Radiobutton(
-            -variable    => \$sortorder,
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'f',
-            -text        => 'Frq',
+            -variable => \$sortorder,
+            -value    => 'f',
+            -text     => 'Frq',
         )->pack( -side => 'left', -anchor => 'nw', -pady => 1 );
         $f3->Radiobutton(
-            -variable    => \$sortorder,
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'l',
-            -text        => 'Len',
+            -variable => \$sortorder,
+            -value    => 'l',
+            -text     => 'Len',
         )->pack( -side => 'left', -anchor => 'nw', -pady => 1 );
         $multiwclistbox->bind(
             '<Control-f>' => sub {

--- a/src/lib/Guiguts/PageNumbers.pm
+++ b/src/lib/Guiguts/PageNumbers.pm
@@ -99,7 +99,6 @@ sub pnumadjust {
         )->grid( -row => 2, -column => 1 );
         $::lglobal{pagenumentry} = $frame2->Entry(
             -background => 'yellow',
-            -relief     => 'sunken',
             -text       => $mark,
             -width      => 10,
             -justify    => 'center',

--- a/src/lib/Guiguts/PageNumbers.pm
+++ b/src/lib/Guiguts/PageNumbers.pm
@@ -88,16 +88,14 @@ sub pnumadjust {
         $::lglobal{pagemarkerpop}->title('Adjust Page Markers');
         my $frame2   = $::lglobal{pagemarkerpop}->Frame->pack( -pady => 5 );
         my $upbutton = $frame2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { pmove('up'); },
-            -text             => 'Move Up',
-            -width            => 10
+            -command => sub { pmove('up'); },
+            -text    => 'Move Up',
+            -width   => 10
         )->grid( -row => 1, -column => 2 );
         my $leftbutton = $frame2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { pmove('left'); },
-            -text             => 'Move Left',
-            -width            => 10
+            -command => sub { pmove('left'); },
+            -text    => 'Move Left',
+            -width   => 10
         )->grid( -row => 2, -column => 1 );
         $::lglobal{pagenumentry} = $frame2->Entry(
             -background => 'yellow',
@@ -107,29 +105,25 @@ sub pnumadjust {
             -justify    => 'center',
         )->grid( -row => 2, -column => 2 );
         my $rightbutton = $frame2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { pmove('right'); },
-            -text             => 'Move Right',
-            -width            => 10
+            -command => sub { pmove('right'); },
+            -text    => 'Move Right',
+            -width   => 10
         )->grid( -row => 2, -column => 3 );
         my $downbutton = $frame2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { pmove('down'); },
-            -text             => 'Move Down',
-            -width            => 10
+            -command => sub { pmove('down'); },
+            -text    => 'Move Down',
+            -width   => 10
         )->grid( -row => 3, -column => 2 );
         my $frame3     = $::lglobal{pagemarkerpop}->Frame->pack( -pady => 4 );
         my $prevbutton = $frame3->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { pgfocus(-1); },
-            -text             => 'Previous Marker',
-            -width            => 14
+            -command => sub { pgfocus(-1); },
+            -text    => 'Previous Marker',
+            -width   => 14
         )->grid( -row => 1, -column => 1 );
         my $nextbutton = $frame3->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { pgfocus(+1); },
-            -text             => 'Next Marker',
-            -width            => 14
+            -command => sub { pgfocus(+1); },
+            -text    => 'Next Marker',
+            -width   => 14
         )->grid( -row => 1, -column => 2 );
         my $frame4 = $::lglobal{pagemarkerpop}->Frame->pack( -pady => 5 );
         $frame4->Label( -text => 'Adjust Page Offset', )->grid( -row => 1, -column => 1 );
@@ -141,21 +135,18 @@ sub pnumadjust {
             -width        => 6,
         )->grid( -row => 2, -column => 1 );
         $frame4->Button(
-            -activebackground => $::activecolor,
-            -command          => \&::pgrenum,
-            -text             => 'Renumber',
-            -width            => 12
+            -command => \&::pgrenum,
+            -text    => 'Renumber',
+            -width   => 12
         )->grid( -row => 3, -column => 1, -pady => 3 );
         my $frame5 = $::lglobal{pagemarkerpop}->Frame->pack( -pady => 5 );
         $frame5->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { ::soundbell() unless ::pageadd() },
-            -text             => 'Add',
-            -width            => 8
+            -command => sub { ::soundbell() unless ::pageadd() },
+            -text    => 'Add',
+            -width   => 8
         )->grid( -row => 1, -column => 1 );
         $frame5->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 my $insert = $textwindow->index('insert');
                 unless ( ::pageadd() ) {
                     $::lglobal{pagerenumoffset}->configure( -textvariable => '1' );
@@ -170,23 +161,20 @@ sub pnumadjust {
             -width => 8
         )->grid( -row => 1, -column => 2 );
         my $removebutton = $frame5->Button(
-            -activebackground => $::activecolor,
-            -command          => \&::pageremove,
-            -text             => 'Remove',
-            -width            => 8
+            -command => \&::pageremove,
+            -text    => 'Remove',
+            -width   => 8
         )->grid( -row => 1, -column => 3 );
         my $frame6 = $::lglobal{pagemarkerpop}->Frame->pack( -pady => 5 );
         $frame6->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { pagetextinsert('markers'); },
-            -text             => 'Insert Page Markers',
-            -width            => 16,
+            -command => sub { pagetextinsert('markers'); },
+            -text    => 'Insert Page Markers',
+            -width   => 16,
         )->grid( -row => 1, -column => 1 );
         $frame6->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { pagetextinsert('labels'); },
-            -text             => 'Insert Page Labels',
-            -width            => 16,
+            -command => sub { pagetextinsert('labels'); },
+            -text    => 'Insert Page Labels',
+            -width   => 16,
         )->grid( -row => 1, -column => 2 );
         $::lglobal{pagemarkerpop}->bind( '<Up>'     => sub { $upbutton->invoke; } );
         $::lglobal{pagemarkerpop}->bind( '<Left>'   => sub { $leftbutton->invoke; } );

--- a/src/lib/Guiguts/PageSeparators.pm
+++ b/src/lib/Guiguts/PageSeparators.pm
@@ -45,9 +45,8 @@ EOM
             -text    => $help_text
         )->pack;
         my $button_ok = $::lglobal{pagesephelppop}->Button(
-            -activebackground => $::activecolor,
-            -text             => 'Close',
-            -command          => sub { ::killpopup('pagesephelppop'); }
+            -text    => 'Close',
+            -command => sub { ::killpopup('pagesephelppop'); }
         )->pack;
         $::lglobal{pagesephelppop}->resizable( 'yes', 'yes' );
     }
@@ -524,45 +523,39 @@ sub separatorpopup {
         $::lglobal{pageseppop}->title('Fixup Page Separators');
         my $sf1        = $::lglobal{pageseppop}->Frame->pack( -side => 'top', -anchor => 'n' );
         my $joinbutton = $sf1->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { processpageseparatorrefresh('j') },
-            -text             => 'Join Lines',
-            -underline        => 0,
-            -width            => 19
+            -command   => sub { processpageseparatorrefresh('j') },
+            -text      => 'Join Lines',
+            -underline => 0,
+            -width     => 19
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         my $joinhybutton = $sf1->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { processpageseparatorrefresh('k') },
-            -text             => 'Join, Keep Hyphen',
-            -underline        => 6,
-            -width            => 19
+            -command   => sub { processpageseparatorrefresh('k') },
+            -text      => 'Join, Keep Hyphen',
+            -underline => 6,
+            -width     => 19
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         my $phelpbutton = $sf1->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { pageseparatorhelppopup() },
-            -text             => 'Help',
+            -command => sub { pageseparatorhelppopup() },
+            -text    => 'Help',
         )->pack( -side => 'left', -pady => 2, -padx => 10, -anchor => 'w' );
         my $sf2 = $::lglobal{pageseppop}->Frame->pack( -side => 'top', -anchor => 'n', -padx => 5 );
         my $blankbutton = $sf2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { processpageseparatorrefresh('l') },
-            -text             => 'Blank Line',
-            -underline        => 6,
-            -width            => 12
+            -command   => sub { processpageseparatorrefresh('l') },
+            -text      => 'Blank Line',
+            -underline => 6,
+            -width     => 12
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         my $sectjoinbutton = $sf2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { processpageseparatorrefresh('t') },
-            -text             => 'New Section',
-            -underline        => 7,
-            -width            => 12
+            -command   => sub { processpageseparatorrefresh('t') },
+            -text      => 'New Section',
+            -underline => 7,
+            -width     => 12
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         my $chjoinbutton = $sf2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { processpageseparatorrefresh('h') },
-            -text             => 'New Chapter',
-            -underline        => 5,
-            -width            => 12
+            -command   => sub { processpageseparatorrefresh('h') },
+            -text      => 'New Chapter',
+            -underline => 5,
+            -width     => 12
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         my $sf3 = $::lglobal{pageseppop}->Frame->pack( -side => 'top', -anchor => 'n', -padx => 5 );
         $sf3->Radiobutton(
@@ -591,8 +584,7 @@ sub separatorpopup {
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         my $sf4 = $::lglobal{pageseppop}->Frame->pack( -side => 'top', -anchor => 'n', -padx => 5 );
         my $viewbutton = $sf4->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 ::openpng( $textwindow, ::get_page_number() );
                 $::lglobal{pageseppop}->raise;
             },
@@ -601,33 +593,29 @@ sub separatorpopup {
             -width     => 8
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         my $refreshbutton = $sf4->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { refreshpageseparatorwrapper() },
-            -text             => 'Refresh',
-            -underline        => 0,
-            -width            => 8
+            -command   => sub { refreshpageseparatorwrapper() },
+            -text      => 'Refresh',
+            -underline => 0,
+            -width     => 8
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         my $delbutton = $sf4->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { processpageseparatorrefresh('d') },
-            -text             => 'Delete',
-            -underline        => 0,
-            -width            => 8
+            -command   => sub { processpageseparatorrefresh('d') },
+            -text      => 'Delete',
+            -underline => 0,
+            -width     => 8
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         my $sf5 = $::lglobal{pageseppop}->Frame->pack( -side => 'top', -anchor => 'n', -padx => 5 );
         my $undobutton = $sf5->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { undojoin() },
-            -text             => 'Undo',
-            -underline        => 0,
-            -width            => 8
+            -command   => sub { undojoin() },
+            -text      => 'Undo',
+            -underline => 0,
+            -width     => 8
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         my $redobutton = $sf5->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { redojoin() },
-            -text             => 'Redo',
-            -underline        => 1,
-            -width            => 8
+            -command   => sub { redojoin() },
+            -text      => 'Redo',
+            -underline => 1,
+            -width     => 8
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         ::initialize_popup_without_deletebinding('pageseppop');
         $::lglobal{pageseppop}->protocol(

--- a/src/lib/Guiguts/PageSeparators.pm
+++ b/src/lib/Guiguts/PageSeparators.pm
@@ -559,28 +559,24 @@ sub separatorpopup {
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         my $sf3 = $::lglobal{pageseppop}->Frame->pack( -side => 'top', -anchor => 'n', -padx => 5 );
         $sf3->Radiobutton(
-            -variable    => \$::pagesepauto,
-            -value       => 0,
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'No Auto',
+            -variable => \$::pagesepauto,
+            -value    => 0,
+            -text     => 'No Auto',
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         $sf3->Radiobutton(
-            -variable    => \$::pagesepauto,
-            -value       => 1,
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Auto Advance',
+            -variable => \$::pagesepauto,
+            -value    => 1,
+            -text     => 'Auto Advance',
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         $sf3->Radiobutton(
-            -variable    => \$::pagesepauto,
-            -value       => 2,
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => '80% Auto',
+            -variable => \$::pagesepauto,
+            -value    => 2,
+            -text     => '80% Auto',
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         $sf3->Radiobutton(
-            -variable    => \$::pagesepauto,
-            -value       => 3,
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => '99% Auto',
+            -variable => \$::pagesepauto,
+            -value    => 3,
+            -text     => '99% Auto',
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'w' );
         my $sf4 = $::lglobal{pageseppop}->Frame->pack( -side => 'top', -anchor => 'n', -padx => 5 );
         my $viewbutton = $sf4->Button(

--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -453,7 +453,6 @@ sub saveinterval {
         my $frame = $::lglobal{intervalpop}->Frame->pack( -fill => 'x', -padx => 5, -pady => 5 );
         $frame->Label( -text => 'Minutes between auto save' )->pack( -side => 'left' );
         my $entry = $frame->Entry(
-            -background   => $::bkgcolor,
             -width        => 5,
             -textvariable => \$::autosaveinterval,
             -validate     => 'key',
@@ -655,7 +654,6 @@ sub filePathsPopup {
             -textvariable => \$::globalviewerpath,
             -width        => 60,
             -relief       => 'sunken',
-            -background   => $::bkgcolor,
         )->pack( -expand => 'y', -fill => 'x' );
         my $f2 = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
@@ -675,7 +673,6 @@ sub filePathsPopup {
         $f2->Entry(
             -textvariable => \$::globalspellpath,
             -relief       => 'sunken',
-            -background   => $::bkgcolor,
         )->pack( -expand => 'y', -fill => 'x' );
         my $f3 = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
@@ -695,7 +692,6 @@ sub filePathsPopup {
         $f3->Entry(
             -textvariable => \$::gutcommand,
             -relief       => 'sunken',
-            -background   => $::bkgcolor,
         )->pack( -expand => 'y', -fill => 'x' );
         my $f4 = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
@@ -715,7 +711,6 @@ sub filePathsPopup {
         $f4->Entry(
             -textvariable => \$::jeebiescommand,
             -relief       => 'sunken',
-            -background   => $::bkgcolor,
         )->pack( -expand => 'y', -fill => 'x' );
         my $f5 = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
@@ -735,7 +730,6 @@ sub filePathsPopup {
         $f5->Entry(
             -textvariable => \$::tidycommand,
             -relief       => 'sunken',
-            -background   => $::bkgcolor,
         )->pack( -expand => 'y', -fill => 'x' );
         my $f6 = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
@@ -758,7 +752,6 @@ sub filePathsPopup {
         $f6->Entry(
             -textvariable => \$::validatecommand,
             -relief       => 'sunken',
-            -background   => $::bkgcolor,
         )->pack( -expand => 'y', -fill => 'x' );
         my $f7 = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
@@ -781,7 +774,6 @@ sub filePathsPopup {
         $f7->Entry(
             -textvariable => \$::validatecsscommand,
             -relief       => 'sunken',
-            -background   => $::bkgcolor,
         )->pack( -expand => 'y', -fill => 'x' );
         my $f7a = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
@@ -804,7 +796,6 @@ sub filePathsPopup {
         $f7a->Entry(
             -textvariable => \$::epubcheckcommand,
             -relief       => 'sunken',
-            -background   => $::bkgcolor,
         )->pack( -expand => 'y', -fill => 'x' );
         my $f8 = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
@@ -824,7 +815,6 @@ sub filePathsPopup {
         $f8->Entry(
             -textvariable => \$::ebookmakercommand,
             -relief       => 'sunken',
-            -background   => $::bkgcolor,
         )->pack( -expand => 'y', -fill => 'x' );
         my $f8b = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
@@ -849,7 +839,6 @@ sub filePathsPopup {
         $f9->Entry(
             -textvariable => \$::scannospath,
             -relief       => 'sunken',
-            -background   => $::bkgcolor,
         )->pack( -expand => 'y', -fill => 'x' );
         my $f0 = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
@@ -864,7 +853,6 @@ sub filePathsPopup {
         $f0->Entry(
             -textvariable => \$::extops[0]{command},
             -relief       => 'sunken',
-            -background   => $::bkgcolor,
         )->pack( -expand => 'y', -fill => 'x' );
         $::lglobal{filepathspop}->Button(
             -text    => 'OK',
@@ -894,7 +882,6 @@ sub setDPurls {
             -width        => 70,
             -textvariable => \$::urlprojectpage,
             -relief       => 'sunken',
-            -background   => $::bkgcolor,
         )->grid( -row => 3, -column => 1, -pady => 2 );
         $f0->Label( -text => "View project discussion of projectid:" )
           ->grid( -row => 4, -column => 0, -sticky => 'w' );
@@ -902,7 +889,6 @@ sub setDPurls {
             -width        => 70,
             -textvariable => \$::urlprojectdiscussion,
             -relief       => 'sunken',
-            -background   => $::bkgcolor,
         )->grid( -row => 4, -column => 1, -pady => 2 );
         $f0->Button(
             -text    => 'OK',

--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -93,8 +93,6 @@ sub setmargins {
         )->pack( -side => 'left' );
         my $lmentry = $lmframe->Spinbox(
             -width        => 6,
-            -background   => $::bkgcolor,
-            -relief       => 'sunken',
             -textvariable => \$::lmargin,
             -increment    => 1,
             -from         => 0,
@@ -107,8 +105,6 @@ sub setmargins {
         )->pack( -side => 'left' );
         my $rmentry = $rmframe->Spinbox(
             -width        => 6,
-            -background   => $::bkgcolor,
-            -relief       => 'sunken',
             -textvariable => \$::rmargin,
             -increment    => 1,
             -from         => 0,
@@ -122,8 +118,6 @@ sub setmargins {
         )->pack( -side => 'left' );
         my $blmentry = $blmframe->Spinbox(
             -width        => 6,
-            -background   => $::bkgcolor,
-            -relief       => 'sunken',
             -textvariable => \$::blocklmargin,
             -increment    => 1,
             -from         => 0,
@@ -137,8 +131,6 @@ sub setmargins {
         )->pack( -side => 'left' );
         my $brmentry = $brmframe->Spinbox(
             -width        => 6,
-            -background   => $::bkgcolor,
-            -relief       => 'sunken',
             -textvariable => \$::blockrmargin,
             -increment    => 1,
             -from         => 0,
@@ -152,8 +144,6 @@ sub setmargins {
         )->pack( -side => 'left' );
         my $plmentry = $plmframe->Spinbox(
             -width        => 6,
-            -background   => $::bkgcolor,
-            -relief       => 'sunken',
             -textvariable => \$::poetrylmargin,
             -increment    => 1,
             -from         => 0,
@@ -167,8 +157,6 @@ sub setmargins {
         )->pack( -side => 'left' );
         my $didntmentry = $didntframe->Spinbox(
             -width        => 6,
-            -background   => $::bkgcolor,
-            -relief       => 'sunken',
             -textvariable => \$::defaultindent,
             -increment    => 1,
             -from         => 0,
@@ -183,8 +171,6 @@ sub setmargins {
         )->pack( -side => 'left' );
         my $rmdiffentry = $rmdiffframe->Spinbox(
             -width        => 6,
-            -background   => $::bkgcolor,
-            -relief       => 'sunken',
             -textvariable => \$::rmargindiff,
             -increment    => 1,
             -from         => 0,
@@ -653,7 +639,6 @@ sub filePathsPopup {
         $f1->Entry(
             -textvariable => \$::globalviewerpath,
             -width        => 60,
-            -relief       => 'sunken',
         )->pack( -expand => 'y', -fill => 'x' );
         my $f2 = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
@@ -689,10 +674,7 @@ sub filePathsPopup {
             -command => sub { ::locateExecutable( 'Bookloupe', \$::gutcommand ); },
             -width   => 24,
         )->pack( -side => 'right' );
-        $f3->Entry(
-            -textvariable => \$::gutcommand,
-            -relief       => 'sunken',
-        )->pack( -expand => 'y', -fill => 'x' );
+        $f3->Entry( -textvariable => \$::gutcommand, )->pack( -expand => 'y', -fill => 'x' );
         my $f4 = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
             -anchor => 'n',
@@ -708,10 +690,7 @@ sub filePathsPopup {
             -command => sub { ::locateExecutable( 'Jeebies', \$::jeebiescommand ); },
             -width   => 24,
         )->pack( -side => 'right' );
-        $f4->Entry(
-            -textvariable => \$::jeebiescommand,
-            -relief       => 'sunken',
-        )->pack( -expand => 'y', -fill => 'x' );
+        $f4->Entry( -textvariable => \$::jeebiescommand, )->pack( -expand => 'y', -fill => 'x' );
         my $f5 = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
             -anchor => 'n',
@@ -727,10 +706,7 @@ sub filePathsPopup {
             -command => sub { ::locateExecutable( 'HTML Tidy', \$::tidycommand ); },
             -width   => 24,
         )->pack( -side => 'right' );
-        $f5->Entry(
-            -textvariable => \$::tidycommand,
-            -relief       => 'sunken',
-        )->pack( -expand => 'y', -fill => 'x' );
+        $f5->Entry( -textvariable => \$::tidycommand, )->pack( -expand => 'y', -fill => 'x' );
         my $f6 = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
             -anchor => 'n',
@@ -749,10 +725,7 @@ sub filePathsPopup {
             },
             -width => 24,
         )->pack( -side => 'right' );
-        $f6->Entry(
-            -textvariable => \$::validatecommand,
-            -relief       => 'sunken',
-        )->pack( -expand => 'y', -fill => 'x' );
+        $f6->Entry( -textvariable => \$::validatecommand, )->pack( -expand => 'y', -fill => 'x' );
         my $f7 = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
             -anchor => 'n',
@@ -771,10 +744,8 @@ sub filePathsPopup {
             },
             -width => 24,
         )->pack( -side => 'right' );
-        $f7->Entry(
-            -textvariable => \$::validatecsscommand,
-            -relief       => 'sunken',
-        )->pack( -expand => 'y', -fill => 'x' );
+        $f7->Entry( -textvariable => \$::validatecsscommand, )
+          ->pack( -expand => 'y', -fill => 'x' );
         my $f7a = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
             -anchor => 'n',
@@ -793,10 +764,7 @@ sub filePathsPopup {
             },
             -width => 24,
         )->pack( -side => 'right' );
-        $f7a->Entry(
-            -textvariable => \$::epubcheckcommand,
-            -relief       => 'sunken',
-        )->pack( -expand => 'y', -fill => 'x' );
+        $f7a->Entry( -textvariable => \$::epubcheckcommand, )->pack( -expand => 'y', -fill => 'x' );
         my $f8 = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
             -anchor => 'n',
@@ -812,10 +780,7 @@ sub filePathsPopup {
             -command => sub { ::locateExecutable( 'ebookmaker.exe', \$::ebookmakercommand ); },
             -width   => 24,
         )->pack( -side => 'right' );
-        $f8->Entry(
-            -textvariable => \$::ebookmakercommand,
-            -relief       => 'sunken',
-        )->pack( -expand => 'y', -fill => 'x' );
+        $f8->Entry( -textvariable => \$::ebookmakercommand, )->pack( -expand => 'y', -fill => 'x' );
         my $f8b = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
             -anchor => 'n',
@@ -836,10 +801,7 @@ sub filePathsPopup {
             -command => sub { locateDirectory( 'scannos', \$::scannospath ); },
             -width   => 24,
         )->pack( -side => 'right' );
-        $f9->Entry(
-            -textvariable => \$::scannospath,
-            -relief       => 'sunken',
-        )->pack( -expand => 'y', -fill => 'x' );
+        $f9->Entry( -textvariable => \$::scannospath, )->pack( -expand => 'y', -fill => 'x' );
         my $f0 = $::lglobal{filepathspop}->Frame->pack(
             -side   => 'top',
             -anchor => 'n',
@@ -850,10 +812,8 @@ sub filePathsPopup {
             -width  => 22,
             -anchor => 'w',
         )->pack( -side => 'left' );
-        $f0->Entry(
-            -textvariable => \$::extops[0]{command},
-            -relief       => 'sunken',
-        )->pack( -expand => 'y', -fill => 'x' );
+        $f0->Entry( -textvariable => \$::extops[0]{command}, )
+          ->pack( -expand => 'y', -fill => 'x' );
         $::lglobal{filepathspop}->Button(
             -text    => 'OK',
             -command => sub {
@@ -881,14 +841,12 @@ sub setDPurls {
         $f0->Entry(
             -width        => 70,
             -textvariable => \$::urlprojectpage,
-            -relief       => 'sunken',
         )->grid( -row => 3, -column => 1, -pady => 2 );
         $f0->Label( -text => "View project discussion of projectid:" )
           ->grid( -row => 4, -column => 0, -sticky => 'w' );
         $f0->Entry(
             -width        => 70,
             -textvariable => \$::urlprojectdiscussion,
-            -relief       => 'sunken',
         )->grid( -row => 4, -column => 1, -pady => 2 );
         $f0->Button(
             -text    => 'OK',

--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -193,9 +193,8 @@ sub setmargins {
         my $button_frame =
           $::lglobal{marginspop}->Frame->pack( -side => 'top', -padx => 5, -pady => 3 );
         my $button_ok = $button_frame->Button(
-            -activebackground => $::activecolor,
-            -text             => 'OK',
-            -command          => sub {
+            -text    => 'OK',
+            -command => sub {
                 ::killpopup('marginspop');
                 if ( ( $::blockrmargin < $::blocklmargin ) || ( $::rmargin < $::lmargin ) ) {
                     $top->messageBox(
@@ -267,9 +266,8 @@ sub setfonts {
         )->grid( -row => 6, -column => 1, -columnspan => 3, -padx => 5, -pady => 5 );
 
         my $button_ok = $::lglobal{fontpop}->Button(
-            -activebackground => $::activecolor,
-            -text             => 'OK',
-            -command          => sub {
+            -text    => 'OK',
+            -command => sub {
                 $::top->fontConfigure(
                     'proofing',
                     -family => $::fontname,
@@ -869,9 +867,8 @@ sub filePathsPopup {
             -background   => $::bkgcolor,
         )->pack( -expand => 'y', -fill => 'x' );
         $::lglobal{filepathspop}->Button(
-            -activebackground => $::activecolor,
-            -text             => 'OK',
-            -command          => sub {
+            -text    => 'OK',
+            -command => sub {
                 ::killpopup('filepathspop');
                 ::savesettings();
             }
@@ -908,9 +905,8 @@ sub setDPurls {
             -background   => $::bkgcolor,
         )->grid( -row => 4, -column => 1, -pady => 2 );
         $f0->Button(
-            -activebackground => $::activecolor,
-            -text             => 'OK',
-            -command          => sub {
+            -text    => 'OK',
+            -command => sub {
                 ::killpopup('defurlspop');
                 ::savesettings();
             }

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1039,31 +1039,26 @@ sub searchpopup {
             -pady   => 1
         );
         $::lglobal{searchop1} = $sf2->Checkbutton(
-            -variable    => \$::sopt[1],
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Case Insensitive'
+            -variable => \$::sopt[1],
+            -text     => 'Case Insensitive'
         )->grid( -row => 1, -column => 1, -padx => 1 );
         $::lglobal{searchop0} = $sf2->Checkbutton(
-            -variable    => \$::sopt[0],
-            -command     => [ \&searchoptset, 'x', 'x', 'x', 0 ],
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Whole Word'
+            -variable => \$::sopt[0],
+            -command  => [ \&searchoptset, 'x', 'x', 'x', 0 ],
+            -text     => 'Whole Word'
         )->grid( -row => 1, -column => 2, -padx => 1 );
         $::lglobal{searchop3} = $sf2->Checkbutton(
-            -variable    => \$::sopt[3],
-            -command     => [ \&searchoptset, 0, 'x', 'x', 'x' ],
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Regex'
+            -variable => \$::sopt[3],
+            -command  => [ \&searchoptset, 0, 'x', 'x', 'x' ],
+            -text     => 'Regex'
         )->grid( -row => 1, -column => 3, -padx => 1 );
         $::lglobal{searchop2} = $sf2->Checkbutton(
-            -variable    => \$::sopt[2],
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Reverse'
+            -variable => \$::sopt[2],
+            -text     => 'Reverse'
         )->grid( -row => 1, -column => 4, -padx => 1 );
         $::lglobal{searchop4} = $sf2->Checkbutton(
-            -variable    => \$::sopt[4],
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Start at Beginning'
+            -variable => \$::sopt[4],
+            -text     => 'Start at Beginning'
         )->grid( -row => 1, -column => 5, -padx => 1 );
 
         my $sf5;
@@ -1728,124 +1723,99 @@ sub orphanedbrackets {
 
         # The list of radio buttons below must be the same as the matches in sub brsel
         my $psel = $frame->Radiobutton(
-            -variable    => \$::lglobal{brsel},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => '[\(\)]',
-            -text        => '(  )',
+            -variable => \$::lglobal{brsel},
+            -value    => '[\(\)]',
+            -text     => '(  )',
         )->grid( -row => 1, -column => 1 );
         $psel->select;
         $frame->Radiobutton(
-            -variable    => \$::lglobal{brsel},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => '[\[\]]',
-            -text        => '[  ]',
+            -variable => \$::lglobal{brsel},
+            -value    => '[\[\]]',
+            -text     => '[  ]',
         )->grid( -row => 1, -column => 2 );
         $frame->Radiobutton(
-            -variable    => \$::lglobal{brsel},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => '[\{\}]',
-            -text        => '{  }',
+            -variable => \$::lglobal{brsel},
+            -value    => '[\{\}]',
+            -text     => '{  }',
         )->grid( -row => 1, -column => 3, -pady => 5 );
         $frame->Radiobutton(
-            -variable    => \$::lglobal{brsel},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => '[<>]',
-            -text        => '<  >',
+            -variable => \$::lglobal{brsel},
+            -value    => '[<>]',
+            -text     => '<  >',
         )->grid( -row => 1, -column => 4, -pady => 5 );
         my $frame1 = $::lglobal{brkpop}->Frame->pack;
         $frame1->Radiobutton(
-            -variable    => \$::lglobal{brsel},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => '\/\*|\*\/',
-            -text        => '/* */',
+            -variable => \$::lglobal{brsel},
+            -value    => '\/\*|\*\/',
+            -text     => '/* */',
         )->grid( -row => 1, -column => 1 );
         $frame1->Radiobutton(
-            -variable    => \$::lglobal{brsel},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => '\/#|#\/',
-            -text        => '/# #/',
+            -variable => \$::lglobal{brsel},
+            -value    => '\/#|#\/',
+            -text     => '/# #/',
         )->grid( -row => 1, -column => 2 );
         $frame1->Radiobutton(
-            -variable    => \$::lglobal{brsel},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => '\/\$|\$\/',
-            -text        => '/$ $/',
+            -variable => \$::lglobal{brsel},
+            -value    => '\/\$|\$\/',
+            -text     => '/$ $/',
         )->grid( -row => 1, -column => 3 );
         $frame1->Radiobutton(
-            -variable    => \$::lglobal{brsel},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => '^\/[Pp]|[Pp]\/',
-            -text        => '/P P/',
+            -variable => \$::lglobal{brsel},
+            -value    => '^\/[Pp]|[Pp]\/',
+            -text     => '/P P/',
         )->grid( -row => 1, -column => 4 );
         $frame1->Radiobutton(
-            -variable    => \$::lglobal{brsel},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => '^\/[Xx]|[Xx]\/',
-            -text        => '/X X/',
+            -variable => \$::lglobal{brsel},
+            -value    => '^\/[Xx]|[Xx]\/',
+            -text     => '/X X/',
         )->grid( -row => 1, -column => 5 );
         $frame1->Radiobutton(
-            -variable    => \$::lglobal{brsel},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => '^\/[Ff]|[Ff]\/',
-            -text        => '/F F/',
+            -variable => \$::lglobal{brsel},
+            -value    => '^\/[Ff]|[Ff]\/',
+            -text     => '/F F/',
         )->grid( -row => 2, -column => 1 );
         $frame1->Radiobutton(
-            -variable    => \$::lglobal{brsel},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => '^\/[Ll]|[Ll]\/',
-            -text        => '/L L/',
+            -variable => \$::lglobal{brsel},
+            -value    => '^\/[Ll]|[Ll]\/',
+            -text     => '/L L/',
         )->grid( -row => 2, -column => 2 );
         $frame1->Radiobutton(
-            -variable    => \$::lglobal{brsel},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => '^\/[Ii]|[Ii]\/',
-            -text        => '/I I/',
+            -variable => \$::lglobal{brsel},
+            -value    => '^\/[Ii]|[Ii]\/',
+            -text     => '/I I/',
         )->grid( -row => 2, -column => 3 );
         $frame1->Radiobutton(
-            -variable    => \$::lglobal{brsel},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => '^\/[Cc]|[Cc]\/',
-            -text        => '/C C/',
+            -variable => \$::lglobal{brsel},
+            -value    => '^\/[Cc]|[Cc]\/',
+            -text     => '/C C/',
         )->grid( -row => 2, -column => 4 );
         $frame1->Radiobutton(
-            -variable    => \$::lglobal{brsel},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => '^\/[Rr]|[Rr]\/',
-            -text        => '/R R/',
+            -variable => \$::lglobal{brsel},
+            -value    => '^\/[Rr]|[Rr]\/',
+            -text     => '/R R/',
         )->grid( -row => 2, -column => 5 );
         my $frame3 = $::lglobal{brkpop}->Frame->pack;
         $frame3->Radiobutton(
-            -variable    => \$::lglobal{brsel},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => "«|»",
-            -text        => 'French angle quotes « »',
+            -variable => \$::lglobal{brsel},
+            -value    => "«|»",
+            -text     => 'French angle quotes « »',
         )->grid( -row => 2, -column => 2, -pady => 1, -sticky => 'w' );
         $frame3->Radiobutton(
-            -variable    => \$::lglobal{brsel},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => '»|«',
-            -text        => 'German angle quotes » «',
+            -variable => \$::lglobal{brsel},
+            -value    => '»|«',
+            -text     => 'German angle quotes » «',
         )->grid( -row => 3, -column => 2, -pady => 1, -sticky => 'w' );
         $frame3->Radiobutton(
-            -variable    => \$::lglobal{brsel},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => "\x{201c}|\x{201d}",
-            -text        => "English curly quotes \x{201c} \x{201d}",
+            -variable => \$::lglobal{brsel},
+            -value    => "\x{201c}|\x{201d}",
+            -text     => "English curly quotes \x{201c} \x{201d}",
         )->grid( -row => 4, -column => 2, -pady => 1, -sticky => 'w' );
         $frame3->Radiobutton(
-            -variable    => \$::lglobal{brsel},
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => "\x{201e}|\x{201c}",
-            -text        => "German curly quotes \x{201e} \x{201c}",
+            -variable => \$::lglobal{brsel},
+            -value    => "\x{201e}|\x{201c}",
+            -text     => "German curly quotes \x{201e} \x{201c}",
         )->grid( -row => 5, -column => 2, -pady => 1, -sticky => 'w' );
 
-        #		my $allqsel =
-        #		  $frame3->Radiobutton(
-        #								-variable    => \$::lglobal{brsel},
-        #								-selectcolor => $::lglobal{checkcolor},
-        #								-value       => 'all',
-        #								-text        => 'All brackets ( )',
-        #		  )->grid( -row => 3, -column => 2 );
         my $frame2 = $::lglobal{brkpop}->Frame->pack;
         my ( $brkresult, $brnextbt );
         $brkresult =
@@ -2265,23 +2235,20 @@ sub quicksearchpopup {
       ->bind( '<ButtonRelease-1>', sub { $::lglobal{searchreversetemp} = ''; } );
 
     $frame1->Checkbutton(
-        -variable    => \\$::lglobal{statussearchnocase},
-        -selectcolor => $::lglobal{checkcolor},
-        -text        => 'Nocase',
+        -variable => \\$::lglobal{statussearchnocase},
+        -text     => 'Nocase',
     )->grid( -row => 1, -column => 1, -padx => 1 );
     $frame1->Checkbutton(
-        -variable    => \\$::lglobal{statussearchword},
-        -selectcolor => $::lglobal{checkcolor},
-        -text        => 'Word',
-        -command     => sub {
+        -variable => \\$::lglobal{statussearchword},
+        -text     => 'Word',
+        -command  => sub {
             $::lglobal{statussearchregex} = 0 if $::lglobal{statussearchword};    # Can't have word and regex
         },
     )->grid( -row => 1, -column => 2, -padx => 1 );
     $frame1->Checkbutton(
-        -variable    => \\$::lglobal{statussearchregex},
-        -selectcolor => $::lglobal{checkcolor},
-        -text        => 'Regex',
-        -command     => sub {
+        -variable => \\$::lglobal{statussearchregex},
+        -text     => 'Regex',
+        -command  => sub {
             $::lglobal{statussearchword} = 0 if $::lglobal{statussearchregex};    # Can't have word and regex
         },
     )->grid( -row => 1, -column => 3, -padx => 1 );

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -381,31 +381,27 @@ sub regedit {
     )->pack;
     my $buttonframe = $editor->add('Frame')->pack;
     $buttonframe->Button(
-        -activebackground => $::activecolor,
-        -text             => '<--',
-        -command          => sub {
+        -text    => '<--',
+        -command => sub {
             $::lglobal{scannosindex}-- if $::lglobal{scannosindex};
             regload();
         },
     )->pack( -side => 'left', -pady => 5, -padx => 2, -anchor => 'w' );
     $buttonframe->Button(
-        -activebackground => $::activecolor,
-        -text             => '-->',
-        -command          => sub {
+        -text    => '-->',
+        -command => sub {
             $::lglobal{scannosindex}++
               if $::lglobal{scannosarray}[ $::lglobal{scannosindex} ];
             regload();
         },
     )->pack( -side => 'left', -pady => 5, -padx => 2, -anchor => 'w' );
     $buttonframe->Button(
-        -activebackground => $::activecolor,
-        -text             => 'Add',
-        -command          => \&regadd,
+        -text    => 'Add',
+        -command => \&regadd,
     )->pack( -side => 'left', -pady => 5, -padx => 2, -anchor => 'w' );
     $buttonframe->Button(
-        -activebackground => $::activecolor,
-        -text             => 'Del',
-        -command          => \&regdel,
+        -text    => 'Del',
+        -command => \&regdel,
     )->pack( -side => 'left', -pady => 5, -padx => 2, -anchor => 'w' );
     $::lglobal{regsearch}->insert( 'end', ( $::lglobal{searchentry}->get ) )
       if $::lglobal{searchentry}->get;
@@ -975,8 +971,7 @@ sub searchpopup {
           $sf1->Label( -text => 'Search Text', )
           ->pack( -side => 'left', -anchor => 'w', -padx => 80 );
         $::lglobal{searchpopcountbutton} = $sf1->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 update_sr_histories();
                 countmatches( $::lglobal{searchentry}->get );
             },
@@ -998,8 +993,7 @@ sub searchpopup {
             -fill   => 'x'
         );
         $sf11->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 $textwindow->undo;
                 $textwindow->tagRemove( 'highlight', '1.0', 'end' );
                 $textwindow->see('insert');
@@ -1008,8 +1002,7 @@ sub searchpopup {
             -width => 6
         )->pack( -side => 'right', -anchor => 'w' );
         $::lglobal{searchbutton} = $sf11->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 update_sr_histories();
                 searchtext('');
             },
@@ -1022,8 +1015,7 @@ sub searchpopup {
         );
         search_shiftreverse( $::lglobal{searchbutton} );
         $sf11->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 ::entry_history( $::lglobal{searchentry}, \@::search_history );
             },
             -image  => $::lglobal{hist_img},
@@ -1110,8 +1102,7 @@ sub searchpopup {
         # Button to increment number of multiterms (also switches to multi)
         # Add frame/field/buttons if necessary
         $::lglobal{searchmultiadd} = $sf10->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 if ( $::multisearchsize < 10 ) {    # don't go above 10 in multi-term mode
                     ++$::multisearchsize;
                     searchaddterms( \@multisearch, $::multisearchsize - 2 );
@@ -1136,8 +1127,7 @@ sub searchpopup {
         # Button to decrement number of multiterms (also switches to multi)
         # Don't destroy field/buttons, just hide their frame
         $sf10->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 if ( $::multisearchsize > 2 ) {    # don't go below 2 in multi-term mode
                     --$::multisearchsize;
 
@@ -1165,8 +1155,7 @@ sub searchpopup {
             -pady   => 1
         );
         $sf12->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 update_sr_histories();
                 replaceall( $::lglobal{replaceentry}->get );
             },
@@ -1178,8 +1167,7 @@ sub searchpopup {
             -anchor => 'w'
         );
         my $sf12rs = $sf12->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 update_sr_histories();
                 replace( $::lglobal{replaceentry}->get );
                 searchtext('');
@@ -1193,8 +1181,7 @@ sub searchpopup {
         );
         search_shiftreverse($sf12rs);
         $sf12->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 update_sr_histories();
                 replace( $::lglobal{replaceentry}->get );
             },
@@ -1206,8 +1193,7 @@ sub searchpopup {
             -anchor => 'w'
         );
         $sf12->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 ::entry_history( $::lglobal{replaceentry}, \@::replace_history );
             },
             -image  => $::lglobal{hist_img},
@@ -1238,8 +1224,7 @@ sub searchpopup {
         $sf5 = $::lglobal{searchpop}->Frame->pack( -side => 'top', -anchor => 'n', -pady => 1 );
         if ( $::lglobal{doscannos} ) {
             my $nextbutton = $sf5->Button(
-                -activebackground => $::activecolor,
-                -command          => sub {
+                -command => sub {
                     $::lglobal{scannosindex}++
                       unless $::lglobal{scannosindex} >= $#{ $::lglobal{scannosarray} };
                     getnextscanno();
@@ -1252,8 +1237,7 @@ sub searchpopup {
                 -anchor => 'w'
             );
             $::lglobal{nextoccurrencebutton} = $sf5->Button(
-                -activebackground => $::activecolor,
-                -command          => sub {
+                -command => sub {
                     searchtext('');
                 },
                 -text  => 'Next Occurrence',
@@ -1265,8 +1249,7 @@ sub searchpopup {
             );
             search_shiftreverse( $::lglobal{nextoccurrencebutton} );
             my $lastbutton = $sf5->Button(
-                -activebackground => $::activecolor,
-                -command          => sub {
+                -command => sub {
                     $aacheck->deselect;
                     $::lglobal{scannosindex}--
                       unless ( $::lglobal{scannosindex} == 0 );
@@ -1280,30 +1263,27 @@ sub searchpopup {
                 -anchor => 'w'
             );
             my $switchbutton = $sf5->Button(
-                -activebackground => $::activecolor,
-                -command          => sub { swapterms() },
-                -text             => 'Swap Terms',
-                -width            => 15
+                -command => sub { swapterms() },
+                -text    => 'Swap Terms',
+                -width   => 15
             )->pack(
                 -side   => 'left',
                 -padx   => 2,
                 -anchor => 'w'
             );
             my $hintbutton = $sf5->Button(
-                -activebackground => $::activecolor,
-                -command          => sub { reghint() },
-                -text             => 'Hint',
-                -width            => 5
+                -command => sub { reghint() },
+                -text    => 'Hint',
+                -width   => 5
             )->pack(
                 -side   => 'left',
                 -padx   => 2,
                 -anchor => 'w'
             );
             my $editbutton = $sf5->Button(
-                -activebackground => $::activecolor,
-                -command          => sub { regedit() },
-                -text             => 'Edit',
-                -width            => 5
+                -command => sub { regedit() },
+                -text    => 'Edit',
+                -width   => 5
             )->pack(
                 -side   => 'left',
                 -padx   => 2,
@@ -1514,8 +1494,7 @@ sub searchaddterms {
         push @$msref, $::lglobal{searchpop}->Frame;
         my $replaceentry = "replaceentry" . ( $_ + 1 );
         $msref->[$_]->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 update_sr_histories();
                 replaceall( $::lglobal{$replaceentry}->get );
             },
@@ -1527,8 +1506,7 @@ sub searchaddterms {
             -anchor => 'w'
         );
         my $rsbtn = $msref->[$_]->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 update_sr_histories();
                 replace( $::lglobal{$replaceentry}->get );
                 searchtext('');
@@ -1542,8 +1520,7 @@ sub searchaddterms {
         );
         search_shiftreverse($rsbtn);
         $msref->[$_]->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 update_sr_histories();
                 replace( $::lglobal{$replaceentry}->get );
             },
@@ -1555,8 +1532,7 @@ sub searchaddterms {
             -anchor => 'w'
         );
         $msref->[$_]->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 ::entry_history( $::lglobal{$replaceentry}, \@::replace_history );
             },
             -image  => $::lglobal{hist_img},
@@ -1875,15 +1851,13 @@ sub orphanedbrackets {
         $brkresult =
           $frame2->Label( -text => '', )->grid( -row => 0, -column => 1, -columnspan => 2 );
         my $brsearchbt = $frame2->Button(
-            -activebackground => $::activecolor,
-            -text             => 'Search',
-            -command          => sub { brsearch( $brkresult, $brnextbt ); },
-            -width            => 16,
+            -text    => 'Search',
+            -command => sub { brsearch( $brkresult, $brnextbt ); },
+            -width   => 16,
         )->grid( -row => 1, -column => 1, -padx => 4, -pady => 5 );
         $brnextbt = $frame2->Button(
-            -activebackground => $::activecolor,
-            -text             => 'Next',
-            -command          => sub {
+            -text    => 'Next',
+            -command => sub {
                 shift @{ $::lglobal{brbrackets} }
                   if @{ $::lglobal{brbrackets} };
                 shift @{ $::lglobal{brindices} }
@@ -2250,8 +2224,7 @@ sub quicksearchpopup {
     $::lglobal{quicksearchpop}->title('Quick Search');
 
     $::lglobal{quicksearchpop}->Button(
-        -activebackground => $::activecolor,
-        -command          => sub {
+        -command => sub {
             ::entry_history( $::lglobal{quicksearchentry}, \@::quicksearch_history );
         },
         -image  => $::lglobal{hist_img},
@@ -2278,8 +2251,7 @@ sub quicksearchpopup {
       $::lglobal{'quicksearchpop'}
       ->Frame->pack( -expand => 1, -fill => 'x', -padx => 0, -pady => 0, -side => 'top' );
     $::lglobal{quicksearchbutton} = $frame1->Button(
-        -activebackground => $::activecolor,
-        -command          => sub {
+        -command => sub {
             ::quicksearch( $::lglobal{searchreversetemp} );    # reverse variable set by Shift-Button-1 binding below
         },
         -text => 'Search',

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1023,7 +1023,6 @@ sub searchpopup {
             -height => 15,
         )->pack( -side => 'left', -anchor => 'w' );
         $::lglobal{searchentry} = $sf11->Entry(
-            -background => $::bkgcolor,
             -foreground => 'black',
             -validate   => 'all',
             -vcmd       => sub { reg_check(shift); }
@@ -1195,7 +1194,7 @@ sub searchpopup {
             -width  => 9,
             -height => 15,
         )->pack( -side => 'left', -anchor => 'w' );
-        $::lglobal{replaceentry} = $sf12->Entry( -background => $::bkgcolor, )->pack(
+        $::lglobal{replaceentry} = $sf12->Entry()->pack(
             -side   => 'left',
             -anchor => 'w',
             -padx   => 1,
@@ -1534,7 +1533,7 @@ sub searchaddterms {
             -width  => 9,
             -height => 15,
         )->pack( -side => 'left', -anchor => 'w' );
-        $::lglobal{$replaceentry} = $msref->[$_]->Entry( -background => $::bkgcolor, )->pack(
+        $::lglobal{$replaceentry} = $msref->[$_]->Entry()->pack(
             -side   => 'left',
             -anchor => 'w',
             -padx   => 1,
@@ -2020,7 +2019,6 @@ sub searchsize {    # Pop up a window where you can adjust the search history si
           $::lglobal{srchhistsizepop}->Frame->pack( -fill => 'x', -padx => 5, -pady => 5 );
         $frame->Label( -text => 'History Size: # of terms to save - ' )->pack( -side => 'left' );
         my $entry = $frame->Entry(
-            -background   => $::bkgcolor,
             -width        => 5,
             -textvariable => \$::history_size,
             -validate     => 'key',
@@ -2203,7 +2201,6 @@ sub quicksearchpopup {
     )->pack( -side => 'left', -anchor => 'nw' );
     $::lglobal{statussearchtext} = '' unless defined $::lglobal{statussearchtext};
     $::lglobal{quicksearchentry} = $::lglobal{'quicksearchpop'}->Entry(
-        -background   => $::bkgcolor,
         -width        => 12,
         -textvariable => \$::lglobal{statussearchtext},
     )->pack( -expand => 1, -fill => 'x', -side => 'top' );

--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -976,27 +976,23 @@ sub asciibox_popup {
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'n' );
         my $f1       = $::lglobal{asciiboxpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         my $leftjust = $f1->Radiobutton(
-            -text        => 'left justified',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{asciijustify},
-            -value       => 'left',
+            -text     => 'left justified',
+            -variable => \$::lglobal{asciijustify},
+            -value    => 'left',
         )->grid( -row => 2, -column => 1, -padx => 1, -pady => 2 );
         my $centerjust = $f1->Radiobutton(
-            -text        => 'centered',
-            -selectcolor => $::lglobal{checkcolor},
-            -variable    => \$::lglobal{asciijustify},
-            -value       => 'center',
+            -text     => 'centered',
+            -variable => \$::lglobal{asciijustify},
+            -value    => 'center',
         )->grid( -row => 2, -column => 2, -padx => 1, -pady => 2 );
         my $rightjust = $f1->Radiobutton(
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'right justified',
-            -variable    => \$::lglobal{asciijustify},
-            -value       => 'right',
+            -text     => 'right justified',
+            -variable => \$::lglobal{asciijustify},
+            -value    => 'right',
         )->grid( -row => 2, -column => 3, -padx => 1, -pady => 2 );
         my $asciiw = $f1->Checkbutton(
-            -variable    => \$::lglobal{asciinowrap},
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Don\'t Rewrap'
+            -variable => \$::lglobal{asciinowrap},
+            -text     => 'Don\'t Rewrap'
         )->grid( -row => 3, -column => 2, -padx => 1, -pady => 2 );
         my $gobut = $f1->Button(
             -command => sub {

--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -713,8 +713,7 @@ sub surround {
         );
         my $f2    = $::lglobal{surpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         my $gobut = $f2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 ::surroundit( $::lglobal{surstrt}, $::lglobal{surend}, $textwindow );
             },
             -text  => 'Surround',
@@ -791,10 +790,9 @@ sub flood {
         );
         my $f2    = $::lglobal{floodpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         my $gobut = $f2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { floodfill( $textwindow, $::lglobal{ffchar} ) },
-            -text             => 'Flood Fill',
-            -width            => 16
+            -command => sub { floodfill( $textwindow, $::lglobal{ffchar} ) },
+            -text    => 'Flood Fill',
+            -width   => 16
         )->pack( -side => 'top', -pady => 5, -padx => 2, -anchor => 'n' );
         ::initialize_popup_with_deletebinding('floodpop');
     }
@@ -913,8 +911,7 @@ sub alignpopup {
             -textvariable => \$::lglobal{alignstring},
         )->pack( -side => 'top', -pady => 5, -padx => 2, -anchor => 'n' );
         my $gobut = $f1->Button(
-            -activebackground => $::activecolor,
-            -command          => [
+            -command => [
                 sub {
                     aligntext( $textwindow, $::lglobal{alignstring} );
                 }
@@ -1002,8 +999,7 @@ sub asciibox_popup {
             -text        => 'Don\'t Rewrap'
         )->grid( -row => 3, -column => 2, -padx => 1, -pady => 2 );
         my $gobut = $f1->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 asciibox( $textwindow, $::lglobal{asciinowrap}, $::lglobal{asciiwidth},
                     $::lglobal{ascii}, $::lglobal{asciijustify} );
             },

--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -680,7 +680,6 @@ sub surround {
         my $surstrt = $f1->Entry(
             -textvariable => \$::lglobal{surstrt},
             -width        => 12,
-            -background   => $::bkgcolor,
             -relief       => 'sunken',
         )->pack(
             -side   => 'left',
@@ -697,7 +696,6 @@ sub surround {
         my $surend = $f1->Entry(
             -textvariable => \$::lglobal{surend},
             -width        => 12,
-            -background   => $::bkgcolor,
             -relief       => 'sunken',
         )->pack(
             -side   => 'left',
@@ -770,7 +768,6 @@ sub flood {
             -fill   => 'x'
         );
         my $floodch = $f1->Entry(
-            -background   => $::bkgcolor,
             -relief       => 'sunken',
             -textvariable => \$::lglobal{ffchar},
             -width        => 24,
@@ -906,7 +903,6 @@ sub alignpopup {
         my $f1 = $::lglobal{alignpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $f1->Entry(
             -width        => 8,
-            -background   => $::bkgcolor,
             -relief       => 'sunken',
             -textvariable => \$::lglobal{alignstring},
         )->pack( -side => 'top', -pady => 5, -padx => 2, -anchor => 'n' );
@@ -952,7 +948,6 @@ sub asciibox_popup {
             $col = $_ % 3;
             $f5->Entry(
                 -width        => 1,
-                -background   => $::bkgcolor,
                 -font         => 'proofing',
                 -relief       => 'sunken',
                 -textvariable => \${ $::lglobal{ascii} }[$_],
@@ -970,7 +965,6 @@ sub asciibox_popup {
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'n' );
         my $wmentry = $f0->Entry(
             -width        => 6,
-            -background   => $::bkgcolor,
             -relief       => 'sunken',
             -textvariable => \$::lglobal{asciiwidth},
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'n' );

--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -680,7 +680,6 @@ sub surround {
         my $surstrt = $f1->Entry(
             -textvariable => \$::lglobal{surstrt},
             -width        => 12,
-            -relief       => 'sunken',
         )->pack(
             -side   => 'left',
             -pady   => 5,
@@ -696,7 +695,6 @@ sub surround {
         my $surend = $f1->Entry(
             -textvariable => \$::lglobal{surend},
             -width        => 12,
-            -relief       => 'sunken',
         )->pack(
             -side   => 'left',
             -pady   => 5,
@@ -768,7 +766,6 @@ sub flood {
             -fill   => 'x'
         );
         my $floodch = $f1->Entry(
-            -relief       => 'sunken',
             -textvariable => \$::lglobal{ffchar},
             -width        => 24,
         )->pack(
@@ -903,7 +900,6 @@ sub alignpopup {
         my $f1 = $::lglobal{alignpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         $f1->Entry(
             -width        => 8,
-            -relief       => 'sunken',
             -textvariable => \$::lglobal{alignstring},
         )->pack( -side => 'top', -pady => 5, -padx => 2, -anchor => 'n' );
         my $gobut = $f1->Button(
@@ -949,7 +945,6 @@ sub asciibox_popup {
             $f5->Entry(
                 -width        => 1,
                 -font         => 'proofing',
-                -relief       => 'sunken',
                 -textvariable => \${ $::lglobal{ascii} }[$_],
             )->grid(
                 -row    => $row,
@@ -965,7 +960,6 @@ sub asciibox_popup {
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'n' );
         my $wmentry = $f0->Entry(
             -width        => 6,
-            -relief       => 'sunken',
             -textvariable => \$::lglobal{asciiwidth},
         )->pack( -side => 'left', -pady => 2, -padx => 2, -anchor => 'n' );
         my $f1       = $::lglobal{asciiboxpop}->Frame->pack( -side => 'top', -anchor => 'n' );

--- a/src/lib/Guiguts/SpellCheck.pm
+++ b/src/lib/Guiguts/SpellCheck.pm
@@ -493,17 +493,15 @@ sub spellchecker {    # Set up spell check window
           $spf1->Label( -text => 'Not in Dictionary:', )
           ->pack( -side => 'top', -anchor => 'n', -pady => 5 );
         $::lglobal{misspelledentry} = $spf1->Entry(
-            -background => $::bkgcolor,
-            -width      => 42,
-            -font       => 'proofing',
+            -width => 42,
+            -font  => 'proofing',
         )->pack( -side => 'top', -anchor => 'n', -pady => 1 );
         my $replacelabel =
           $spf1->Label( -text => 'Replacement Text:', )
           ->pack( -side => 'top', -anchor => 'n', -padx => 6 );
         $::lglobal{spreplaceentry} = $spf1->Entry(
-            -background => $::bkgcolor,
-            -width      => 42,
-            -font       => 'proofing',
+            -width => 42,
+            -font  => 'proofing',
         )->pack( -side => 'top', -anchor => 'n', -padx => 1 );
         $::lglobal{suggestionlabel} =
           $spf1->Label( -text => 'Suggestions:', )

--- a/src/lib/Guiguts/SpellCheck.pm
+++ b/src/lib/Guiguts/SpellCheck.pm
@@ -525,8 +525,7 @@ sub spellchecker {    # Set up spell check window
           $::lglobal{spellpopup}->Frame->pack( -side => 'top', -anchor => 'n', -padx => 5 );
 
         my $changebutton = $spf2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 ::busy();
                 spellreplace();
                 ::unbusy();
@@ -540,8 +539,7 @@ sub spellchecker {    # Set up spell check window
             -anchor => 'nw'
         );
         my $ignorebutton = $spf2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 ::busy();
                 shift @{ $::lglobal{misspelledlist} };
                 spellchecknext();
@@ -556,8 +554,7 @@ sub spellchecker {    # Set up spell check window
             -anchor => 'nw'
         );
         my $dictmyaddbutton = $spf2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 ::busy();
                 spellmyaddword( $::lglobal{misspelledentry}->get );
                 spellignoreall();
@@ -573,8 +570,7 @@ sub spellchecker {    # Set up spell check window
             -anchor => 'nw'
         );
         my $replaceallbutton = $spf3->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 ::busy();
                 spellreplaceall();
                 spellchecknext();
@@ -589,8 +585,7 @@ sub spellchecker {    # Set up spell check window
             -anchor => 'nw'
         );
         my $ignoreallbutton = $spf3->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 ::busy();
                 spellignoreall();
                 spellchecknext();
@@ -605,8 +600,7 @@ sub spellchecker {    # Set up spell check window
             -anchor => 'nw'
         );
         my $dictaddbutton = $spf3->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 ::busy();
                 spelladdword();
                 spellignoreall();
@@ -622,8 +616,7 @@ sub spellchecker {    # Set up spell check window
             -anchor => 'nw'
         );
         $spf4->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 $::spellindexbkmrk = $textwindow->index( $::lglobal{lastmatchindex} . '-1c' )
                   || '1.0';
                 $textwindow->markSet( 'spellbkmk', $::spellindexbkmrk );
@@ -638,8 +631,7 @@ sub spellchecker {    # Set up spell check window
             -anchor => 'nw'
         );
         $spf4->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 return unless $::spellindexbkmrk;
                 $textwindow->tagRemove( 'sel',       '1.0', 'end' );
                 $textwindow->tagRemove( 'highlight', '1.0', 'end' );
@@ -655,8 +647,7 @@ sub spellchecker {    # Set up spell check window
             -anchor => 'nw'
         );
         my $dictmybutton = $spf5->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 spelladdgoodwords();
             },
             -text  => 'Add Goodwords To Proj. Dic.',
@@ -668,10 +659,9 @@ sub spellchecker {    # Set up spell check window
             -anchor => 'nw'
         );
         my $spelloptionsbutton = $spf5->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { spelloptions() },
-            -text             => 'Options',
-            -width            => 12,
+            -command => sub { spelloptions() },
+            -text    => 'Options',
+            -width   => 12,
         )->pack(
             -side   => 'left',
             -pady   => 2,
@@ -679,10 +669,9 @@ sub spellchecker {    # Set up spell check window
             -anchor => 'nw'
         );
         my $closebutton = $spf5->Button(
-            -activebackground => $::activecolor,
-            -command          => \&endaspell,
-            -text             => 'Close',
-            -width            => 12,
+            -command => \&endaspell,
+            -text    => 'Close',
+            -width   => 12,
         )->pack(
             -side   => 'left',
             -pady   => 2,

--- a/src/lib/Guiguts/SpellCheck.pm
+++ b/src/lib/Guiguts/SpellCheck.pm
@@ -830,28 +830,24 @@ sub spelloptions {
     );
     my $spopframe = $spellop->Frame->pack;
     $spopframe->Radiobutton(
-        -selectcolor => $::lglobal{checkcolor},
-        -text        => 'Ultra Fast',
-        -variable    => \$::globalaspellmode,
-        -value       => 'ultra'
+        -text     => 'Ultra Fast',
+        -variable => \$::globalaspellmode,
+        -value    => 'ultra'
     )->grid( -row => 0, -sticky => 'w' );
     $spopframe->Radiobutton(
-        -selectcolor => $::lglobal{checkcolor},
-        -text        => 'Fast',
-        -variable    => \$::globalaspellmode,
-        -value       => 'fast'
+        -text     => 'Fast',
+        -variable => \$::globalaspellmode,
+        -value    => 'fast'
     )->grid( -row => 1, -sticky => 'w' );
     $spopframe->Radiobutton(
-        -selectcolor => $::lglobal{checkcolor},
-        -text        => 'Normal',
-        -variable    => \$::globalaspellmode,
-        -value       => 'normal'
+        -text     => 'Normal',
+        -variable => \$::globalaspellmode,
+        -value    => 'normal'
     )->grid( -row => 2, -sticky => 'w' );
     $spopframe->Radiobutton(
-        -selectcolor => $::lglobal{checkcolor},
-        -text        => 'Bad Spellers',
-        -variable    => \$::globalaspellmode,
-        -value       => 'bad-spellers'
+        -text     => 'Bad Spellers',
+        -variable => \$::globalaspellmode,
+        -value    => 'bad-spellers'
     )->grid( -row => 3, -sticky => 'w' );
     $spellop->Show;
     $spellop->focus;

--- a/src/lib/Guiguts/StatusBar.pm
+++ b/src/lib/Guiguts/StatusBar.pm
@@ -609,7 +609,6 @@ sub setlang {
         $frame->Label( -text => 'Language: ' )->pack( -side => 'left' );
         $::lglobal{booklang} = $::booklang;
         my $entry = $frame->Entry(
-            -background   => $::bkgcolor,
             -width        => 20,
             -textvariable => \$::lglobal{booklang},
         )->pack( -side => 'left', -fill => 'x' );
@@ -636,7 +635,6 @@ sub selection {
         my $frame = $::lglobal{selectionpop}->Frame->pack( -fill => 'x', -padx => 5, -pady => 5 );
         $frame->Label( -text => 'Start Line.Col' )->grid( -row => 1, -column => 1 );
         $::lglobal{selsentry} = $frame->Entry(
-            -background   => $::bkgcolor,
             -width        => 15,
             -textvariable => \$start,
             -validate     => 'focusout',
@@ -647,7 +645,6 @@ sub selection {
         )->grid( -row => 1, -column => 2 );
         $frame->Label( -text => 'End Line.Col' )->grid( -row => 2, -column => 1 );
         $::lglobal{seleentry} = $frame->Entry(
-            -background   => $::bkgcolor,
             -width        => 15,
             -textvariable => \$end,
             -validate     => 'focusout',

--- a/src/lib/Guiguts/TextProcessingMenu.pm
+++ b/src/lib/Guiguts/TextProcessingMenu.pm
@@ -296,24 +296,21 @@ sub fixpopup {
 
         for (@rbuttons) {
             $pframe1->Checkbutton(
-                -variable    => \${ $::lglobal{fixopt} }[$row],
-                -selectcolor => $::lglobal{checkcolor},
-                -text        => $_,
+                -variable => \${ $::lglobal{fixopt} }[$row],
+                -text     => $_,
             )->grid( -row => $row, -column => 1, -sticky => 'nw' );
             ++$row;
         }
         $pframe1->Radiobutton(
-            -variable    => \${ $::lglobal{fixopt} }[15],
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 1,
-            -text        => 'French style angle quotes «guillemets»',
+            -variable => \${ $::lglobal{fixopt} }[15],
+            -value    => 1,
+            -text     => 'French style angle quotes «guillemets»',
         )->grid( -row => $row, -column => 1 );
         ++$row;
         $pframe1->Radiobutton(
-            -variable    => \${ $::lglobal{fixopt} }[15],
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 0,
-            -text        => 'German style angle quotes »guillemets«',
+            -variable => \${ $::lglobal{fixopt} }[15],
+            -value    => 0,
+            -text     => 'German style angle quotes »guillemets«',
         )->grid( -row => $row, -column => 1 );
         my $tframe = $::lglobal{fixpop}->Frame->pack;
         $tframe->Button(

--- a/src/lib/Guiguts/TextProcessingMenu.pm
+++ b/src/lib/Guiguts/TextProcessingMenu.pm
@@ -317,8 +317,7 @@ sub fixpopup {
         )->grid( -row => $row, -column => 1 );
         my $tframe = $::lglobal{fixpop}->Frame->pack;
         $tframe->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 $::lglobal{fixpop}->UnmapWindow;
                 fixup();
                 ::killpopup('fixpop');

--- a/src/lib/Guiguts/TextProcessingMenu.pm
+++ b/src/lib/Guiguts/TextProcessingMenu.pm
@@ -65,7 +65,6 @@ sub text_convert_options {
     )->pack( -side => 'left' );
     my $italic_entry = $italic_frame->Entry(
         -width        => 6,
-        -background   => $::bkgcolor,
         -relief       => 'sunken',
         -textvariable => \$::italic_char,
     )->pack( -side => 'left' );
@@ -76,7 +75,6 @@ sub text_convert_options {
     )->pack( -side => 'left' );
     my $bold_entry = $bold_frame->Entry(
         -width        => 6,
-        -background   => $::bkgcolor,
         -relief       => 'sunken',
         -textvariable => \$::bold_char,
     )->pack( -side => 'left' );
@@ -107,7 +105,6 @@ sub txt_convert_palette {
         )->pack( -side => 'left' );
         my $italic_entry = $italic_frame->Entry(
             -width        => 6,
-            -background   => $::bkgcolor,
             -relief       => 'sunken',
             -textvariable => \$::italic_char,
         )->pack( -side => 'left' );
@@ -129,7 +126,6 @@ sub txt_convert_palette {
         )->pack( -side => 'left' );
         my $bold_entry = $bold_frame->Entry(
             -width        => 6,
-            -background   => $::bkgcolor,
             -relief       => 'sunken',
             -textvariable => \$::bold_char,
         )->pack( -side => 'left' );
@@ -150,7 +146,6 @@ sub txt_convert_palette {
         )->pack( -side => 'left' );
         my $g_entry = $g_frame->Entry(
             -width        => 6,
-            -background   => $::bkgcolor,
             -relief       => 'sunken',
             -textvariable => \$::gesperrt_char,
         )->pack( -side => 'left' );
@@ -171,7 +166,6 @@ sub txt_convert_palette {
         )->pack( -side => 'left' );
         my $f_entry = $f_frame->Entry(
             -width        => 6,
-            -background   => $::bkgcolor,
             -relief       => 'sunken',
             -textvariable => \$::font_char,
         )->pack( -side => 'left' );
@@ -206,7 +200,6 @@ sub txt_convert_palette {
         )->pack( -side => 'left' );
         my $sc_entry = $sc_frame->Entry(
             -width        => 6,
-            -background   => $::bkgcolor,
             -relief       => 'sunken',
             -textvariable => \$::sc_char,
         )->pack( -side => 'left' );

--- a/src/lib/Guiguts/TextProcessingMenu.pm
+++ b/src/lib/Guiguts/TextProcessingMenu.pm
@@ -65,7 +65,6 @@ sub text_convert_options {
     )->pack( -side => 'left' );
     my $italic_entry = $italic_frame->Entry(
         -width        => 6,
-        -relief       => 'sunken',
         -textvariable => \$::italic_char,
     )->pack( -side => 'left' );
     my $bold_frame = $options->add('Frame')->pack( -side => 'top', -padx => 5, -pady => 3 );
@@ -75,7 +74,6 @@ sub text_convert_options {
     )->pack( -side => 'left' );
     my $bold_entry = $bold_frame->Entry(
         -width        => 6,
-        -relief       => 'sunken',
         -textvariable => \$::bold_char,
     )->pack( -side => 'left' );
     $options->Show;
@@ -105,7 +103,6 @@ sub txt_convert_palette {
         )->pack( -side => 'left' );
         my $italic_entry = $italic_frame->Entry(
             -width        => 6,
-            -relief       => 'sunken',
             -textvariable => \$::italic_char,
         )->pack( -side => 'left' );
         my $italic_button = $italic_frame->Button(
@@ -126,7 +123,6 @@ sub txt_convert_palette {
         )->pack( -side => 'left' );
         my $bold_entry = $bold_frame->Entry(
             -width        => 6,
-            -relief       => 'sunken',
             -textvariable => \$::bold_char,
         )->pack( -side => 'left' );
         my $bold_button = $bold_frame->Button(
@@ -146,7 +142,6 @@ sub txt_convert_palette {
         )->pack( -side => 'left' );
         my $g_entry = $g_frame->Entry(
             -width        => 6,
-            -relief       => 'sunken',
             -textvariable => \$::gesperrt_char,
         )->pack( -side => 'left' );
         my $g_button = $g_frame->Button(
@@ -166,7 +161,6 @@ sub txt_convert_palette {
         )->pack( -side => 'left' );
         my $f_entry = $f_frame->Entry(
             -width        => 6,
-            -relief       => 'sunken',
             -textvariable => \$::font_char,
         )->pack( -side => 'left' );
         my $f_button = $f_frame->Button(
@@ -200,7 +194,6 @@ sub txt_convert_palette {
         )->pack( -side => 'left' );
         my $sc_entry = $sc_frame->Entry(
             -width        => 6,
-            -relief       => 'sunken',
             -textvariable => \$::sc_char,
         )->pack( -side => 'left' );
         my $tb_frame =

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1027,9 +1027,12 @@ sub initialize {
     );
     ::globalfontconfigure();       # may need to set to system default
 
-    # Use option database to set font for all widgets, then override for Entry fields
-    $top->optionAdd( '*font'       => 'global' );
-    $top->optionAdd( '*Entry*font' => 'textentry' );
+    # Use option database to set widget defaults - 'widgetDefault' priority means
+    # user can override, e.g. using .Xdefaults file
+    # Set font for all widgets, then override for Entry fields
+    $top->optionAdd( '*font'                    => 'global',       'widgetDefault' );
+    $top->optionAdd( '*Entry*font'              => 'textentry',    'widgetDefault' );
+    $top->optionAdd( '*Button*activeBackground' => $::activecolor, 'widgetDefault' );
 
     # Set up Main window size
     unless ($::geometry) {
@@ -2640,8 +2643,7 @@ sub externalpopup {    # Set up the external commands menu
         }
         my $f2    = $::lglobal{extoptpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         my $gobut = $f2->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
 
                 # save the settings and rebuild the menu
                 externalpopuptidy();
@@ -2994,10 +2996,9 @@ sub restorelinenumbers {
         ::initialize_popup_with_deletebinding('stoppop');
         my $frame      = $::lglobal{stoppop}->Frame->pack;
         my $stopbutton = $frame->Button(
-            -activebackground => $::activecolor,
-            -command          => sub { set_interrupt(); },
-            -text             => 'Interrupt Operation',
-            -width            => 16
+            -command => sub { set_interrupt(); },
+            -text    => 'Interrupt Operation',
+            -width   => 16
         )->grid( -row => 1, -column => 1, -padx => 10, -pady => 10 );
     }
 
@@ -3269,9 +3270,8 @@ sub printerror {
             $::lglobal{messagespop} = $top->Toplevel;
             $::lglobal{messagespop}->title('Message Log');
             my $button_ok = $::lglobal{messagespop}->Button(
-                -activebackground => $::activecolor,
-                -text             => 'Close',
-                -command          => sub { ::killpopup('messagespop'); }
+                -text    => 'Close',
+                -command => sub { ::killpopup('messagespop'); }
             )->pack( -side => 'bottom', -pady => 5 );
             my $frame = $::lglobal{messagespop}->Frame->pack(
                 -side   => 'top',

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1055,7 +1055,6 @@ sub initialize {
     $::textwindow = $::text_frame->LineNumberText(
         -exportselection => 'true',           # 'sel' tag is associated with selections
         -background      => $::bkgcolor,
-        -relief          => 'sunken',
         -font            => 'proofing',
         -wrap            => 'none',
         -curlinebg       => $::activecolor,
@@ -1767,7 +1766,11 @@ sub setwidgetdefaultoptions {
 
     # Various colors
     $top->optionAdd( '*Button*activeBackground' => $::activecolor, $priority );
-    $top->optionAdd( '*Entry*background'        => $::bkgcolor,    $priority );
+
+    $top->optionAdd( '*Entry*background'   => $::bkgcolor, $priority );
+    $top->optionAdd( '*Spinbox*background' => $::bkgcolor, $priority );
+    $top->optionAdd( '*ROText*background'  => $::bkgcolor, $priority );
+
     my $selectcolor = $::OS_WIN ? 'white' : $::activecolor;
     $top->optionAdd( '*Checkbutton*selectColor' => $selectcolor, $priority );
     $top->optionAdd( '*Radiobutton*selectColor' => $selectcolor, $priority );
@@ -2633,7 +2636,6 @@ sub externalpopup {    # Set up the external commands menu
         for my $menutempvar ( 0 .. ( $#::extops < 10 ? 10 : $#::extops ) + 1 ) {
             $f1->Entry(
                 -width        => 50,
-                -relief       => 'sunken',
                 -textvariable => \$::extops[$menutempvar]{label},
                 -state        => ( $menutempvar ? 'normal' : 'readonly' ),
             )->grid(
@@ -2644,7 +2646,6 @@ sub externalpopup {    # Set up the external commands menu
             );
             $f1->Entry(
                 -width        => 80,
-                -relief       => 'sunken',
                 -textvariable => \$::extops[$menutempvar]{command},
             )->grid(
                 -row    => "$menutempvar" + 1,

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -23,7 +23,7 @@ BEGIN {
       &enable_interrupt &disable_interrupt &set_interrupt &query_interrupt &soundbell &busy &unbusy
       &dieerror &warnerror &infoerror &poperror &BindMouseWheel &display_manual
       &path_settings &path_htmlheader &path_defaulthtmlheader &path_labels &path_defaultlabels &path_userdict &path_defaultdict
-      &path_userhtmlheader &processcommandline &copysettings &main_lang &list_lang);
+      &path_userhtmlheader &processcommandline &copysettings &main_lang &list_lang &setwidgetdefaultoptions);
 
 }
 
@@ -1027,12 +1027,7 @@ sub initialize {
     );
     ::globalfontconfigure();       # may need to set to system default
 
-    # Use option database to set widget defaults - 'widgetDefault' priority means
-    # user can override, e.g. using .Xdefaults file
-    # Set font for all widgets, then override for Entry fields
-    $top->optionAdd( '*font'                    => 'global',       'widgetDefault' );
-    $top->optionAdd( '*Entry*font'              => 'textentry',    'widgetDefault' );
-    $top->optionAdd( '*Button*activeBackground' => $::activecolor, 'widgetDefault' );
+    setwidgetdefaultoptions();
 
     # Set up Main window size
     unless ($::geometry) {
@@ -1750,13 +1745,31 @@ sub initialize {
           . "\x{2669}\x{266a}\x{266d}\x{266e}\x{266f}",
     );
 
-    $::lglobal{checkcolor} = ($::OS_WIN) ? 'white' : $::activecolor;
     my $scroll_gif =
       'R0lGODlhCAAQAIAAAAAAAP///yH5BAEAAAEALAAAAAAIABAAAAIUjAGmiMutopz0pPgwk7B6/3SZphQAOw==';
     $::lglobal{scrollgif} = $top->Photo(
         -data   => $scroll_gif,
         -format => 'gif',
     );
+}
+
+#
+# Use option database to set widget defaults
+sub setwidgetdefaultoptions {
+    my $top = $::top;
+
+    # 'widgetDefault' priority means user can override, e.g. using .Xdefaults file
+    my $priority = 'widgetDefault';
+
+    # Set font for all widgets, then override for Entry fields
+    $top->optionAdd( '*font'       => 'global',    $priority );
+    $top->optionAdd( '*Entry*font' => 'textentry', $priority );
+
+    # Active and select colors
+    $top->optionAdd( '*Button*activeBackground' => $::activecolor, $priority );
+    my $selectcolor = $::OS_WIN ? 'white' : $::activecolor;
+    $top->optionAdd( '*Checkbutton*selectColor' => $selectcolor, $priority );
+    $top->optionAdd( '*Radiobutton*selectColor' => $selectcolor, $priority );
 }
 
 sub scrolldismiss {

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1765,8 +1765,9 @@ sub setwidgetdefaultoptions {
     $top->optionAdd( '*font'       => 'global',    $priority );
     $top->optionAdd( '*Entry*font' => 'textentry', $priority );
 
-    # Active and select colors
+    # Various colors
     $top->optionAdd( '*Button*activeBackground' => $::activecolor, $priority );
+    $top->optionAdd( '*Entry*background'        => $::bkgcolor,    $priority );
     my $selectcolor = $::OS_WIN ? 'white' : $::activecolor;
     $top->optionAdd( '*Checkbutton*selectColor' => $selectcolor, $priority );
     $top->optionAdd( '*Radiobutton*selectColor' => $selectcolor, $priority );
@@ -2632,7 +2633,6 @@ sub externalpopup {    # Set up the external commands menu
         for my $menutempvar ( 0 .. ( $#::extops < 10 ? 10 : $#::extops ) + 1 ) {
             $f1->Entry(
                 -width        => 50,
-                -background   => $::bkgcolor,
                 -relief       => 'sunken',
                 -textvariable => \$::extops[$menutempvar]{label},
                 -state        => ( $menutempvar ? 'normal' : 'readonly' ),
@@ -2644,7 +2644,6 @@ sub externalpopup {    # Set up the external commands menu
             );
             $f1->Entry(
                 -width        => 80,
-                -background   => $::bkgcolor,
                 -relief       => 'sunken',
                 -textvariable => \$::extops[$menutempvar]{command},
             )->grid(
@@ -2898,7 +2897,6 @@ sub setprojectid {
     my $frame = $projectidpop->Frame->pack( -fill => 'x' );
     $frame->Label( -text => 'Project ID: ' )->pack( -side => 'left' );
     my $entry = $frame->Entry(
-        -background   => $::bkgcolor,
         -width        => 30,
         -textvariable => \$::projectid,
     )->pack( -side => 'left', -fill => 'x' );
@@ -3128,7 +3126,6 @@ sub textentrydialogpopup {
       $::lglobal{$key}->Frame->pack( -expand => 1, -fill => 'x', -padx => 5, -pady => 5 );
     $$varref = $defaulttext unless $$varref;
     my $entryw = $frame1->Entry(
-        -background   => $::bkgcolor,
         -width        => 12,
         -textvariable => $varref,
     )->pack( -expand => 1, -fill => 'x', -side => 'right' );
@@ -3173,7 +3170,6 @@ sub dialogboxcommonsetup {
     my $frame = $::lglobal{$dlg}->Frame->pack( -fill => 'x' );
     $frame->Label( -text => $prompt )->pack( -side => 'left' );
     my $entry = $frame->Entry(
-        -background   => $::bkgcolor,
         -width        => 25,
         -textvariable => $var,
     )->pack( -side => 'left', -fill => 'x' );

--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -88,32 +88,27 @@ sub wordfrequency {
         $::lglobal{wfpop}->title('Word Frequency');
         my $wordfreqseframe = $::lglobal{wfpop}->Frame->pack( -side => 'top', -anchor => 'n' );
         my $wcopt3          = $wordfreqseframe->Checkbutton(
-            -variable    => \$::lglobal{suspects_only},
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Suspects only'
+            -variable => \$::lglobal{suspects_only},
+            -text     => 'Suspects only'
         )->pack( -side => 'left', -anchor => 'w', -pady => 1 );
         my $wcopt1 = $wordfreqseframe->Checkbutton(
-            -variable    => \$::lglobal{wf_ignore_case},
-            -selectcolor => $::lglobal{checkcolor},
-            -text        => 'Ignore case',
+            -variable => \$::lglobal{wf_ignore_case},
+            -text     => 'Ignore case',
         )->pack( -side => 'left', -anchor => 'w', -pady => 1 );
         $wordfreqseframe->Radiobutton(
-            -variable    => \$::alpha_sort,
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'a',
-            -text        => 'Alph',
+            -variable => \$::alpha_sort,
+            -value    => 'a',
+            -text     => 'Alph',
         )->pack( -side => 'left', -anchor => 'w', -pady => 1 );
         $wordfreqseframe->Radiobutton(
-            -variable    => \$::alpha_sort,
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'f',
-            -text        => 'Frq',
+            -variable => \$::alpha_sort,
+            -value    => 'f',
+            -text     => 'Frq',
         )->pack( -side => 'left', -anchor => 'w', -pady => 1 );
         $wordfreqseframe->Radiobutton(
-            -variable    => \$::alpha_sort,
-            -selectcolor => $::lglobal{checkcolor},
-            -value       => 'l',
-            -text        => 'Len',
+            -variable => \$::alpha_sort,
+            -value    => 'l',
+            -text     => 'Len',
         )->pack( -side => 'left', -anchor => 'w', -pady => 1 );
         $wordfreqseframe->Button(
             -command => sub {

--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -765,7 +765,6 @@ sub ital_adjust {
     my $f1 = $::lglobal{markuppop}->Frame->pack( -side => 'top', -anchor => 'n' );
     $f1->Entry(
         -width        => 10,
-        -relief       => 'sunken',
         -textvariable => \$::markupthreshold,
         -validate     => 'key',
         -vcmd         => sub {

--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -205,15 +205,13 @@ sub wordfrequency {
                 );
                 $button->bind( '<3>' => $_->[2] ) if $_->[2];
             } else {
-                $::lglobal{regexpentry} = $wordfreqseframe1->Entry(
-                    -background   => $::bkgcolor,
-                    -textvariable => \$::regexpentry,
-                )->grid(
+                $::lglobal{regexpentry} =
+                  $wordfreqseframe1->Entry( -textvariable => \$::regexpentry, )->grid(
                     -row        => $row,
                     -column     => $col,
                     -columnspan => 3,
                     -sticky     => "nsew"
-                );
+                  );
             }
         }
         my $wcframe = $::lglobal{wfpop}->Frame->pack( -fill => 'both', -expand => 'both', );
@@ -767,7 +765,6 @@ sub ital_adjust {
     my $f1 = $::lglobal{markuppop}->Frame->pack( -side => 'top', -anchor => 'n' );
     $f1->Entry(
         -width        => 10,
-        -background   => $::bkgcolor,
         -relief       => 'sunken',
         -textvariable => \$::markupthreshold,
         -validate     => 'key',

--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -116,8 +116,7 @@ sub wordfrequency {
             -text        => 'Len',
         )->pack( -side => 'left', -anchor => 'w', -pady => 1 );
         $wordfreqseframe->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 return unless ( $::lglobal{wclistbox}->curselection );
                 $::lglobal{harmonics} = 1;
                 harmonicspop();
@@ -130,8 +129,7 @@ sub wordfrequency {
             -anchor => 'w'
         );
         $wordfreqseframe->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
                 return unless ( $::lglobal{wclistbox}->curselection );
                 $::lglobal{harmonics} = 2;
                 harmonicspop();
@@ -144,8 +142,7 @@ sub wordfrequency {
             -anchor => 'w'
         );
         $wordfreqseframe->Button(
-            -activebackground => $::activecolor,
-            -command          => sub {
+            -command => sub {
 
                 #return if $::lglobal{global_filename} =~ /No File Loaded/;
                 #savefile() unless ( $textwindow->numberChanges == 0 );
@@ -202,10 +199,9 @@ sub wordfrequency {
             ++$inc;
             if ( not( $_->[0] eq 'RegExpEntry' ) ) {
                 my $button = $wordfreqseframe1->Button(
-                    -activebackground => $::activecolor,
-                    -command          => $_->[1],
-                    -text             => $_->[0],
-                    -width            => 13
+                    -command => $_->[1],
+                    -text    => $_->[0],
+                    -width   => 13
                 )->grid(
                     -row    => $row,
                     -column => $col,
@@ -787,8 +783,7 @@ sub ital_adjust {
         },
     )->grid( -row => 1, -column => 1, -padx => 2, -pady => 4 );
     $::lglobal{markuppopok} = $f1->Button(
-        -activebackground => $::activecolor,
-        -command          => sub {
+        -command => sub {
             $::markupthreshold = 0 unless $::markupthreshold;    # User has cleared entry field
             ::savesettings();
             ::killpopup('markuppop');


### PR DESCRIPTION
Use option database to set defaults where appropriate, rather than setting for each widget individually. Also remove some settings which are the default anyway.

1. Primary goal is to reduce duplicate code (fixes #1094)
2. Also gives greater consistency across interface by catching a few places where individual setting wasn't done
3. Has the (unrequested) side effect that the user can specify settings in their `.Xdefaults` file, or other mechanisms for setting X resources depending on platform.

Affects:
1. Button active color (when cursor hovers over button before clicking)
2. Radio/checkbutton select color
3. Background color of Entry, ROText and Spinbox widgets
4. Sunken relief setting of Entry widgets
