### PR TITLE
Add unmatched item error checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 - `Quick Search` in Search menu (or Shift-Ctrl-f) pops a mini-dialog with
   basic search options and a history button. Clicking or Shift-clicking Search
-  button, or typing Return/Shift-Return, searches forwards or backwards.
+  button, or typing Return/Shift-Return, searches forwards or backwards
 - `Find Match` in the Search menu (or `Ctrl-[`) finds the matching bracket,
-  quote, block markup, or HTML tag to the one currently selected or indicated
-  by the cursor.
-- `Unclosed Tag Check` in the HTML menu reports unclosed HTML tags.
+  curly quote, block markup, or HTML tag to the one currently selected or
+  indicated by the cursor
+- `Unmatched Tag Check` in the HTML menu reports unclosed HTML tags
+- `Unmatched Curly Double Quote Check` added to the Txt menu
+- Separate `Unmatched Tag/Brackets/Block Markup Checks` added to Tools menu
 
 ### Bug Fixes
 - The column display (ruler) numbers could sometimes display wrongly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - `Find Match` in the Search menu (or `Ctrl-[`) finds the matching bracket,
   curly quote, block markup, or HTML tag to the one currently selected or
   indicated by the cursor
-- `Unmatched Tag Check` in the HTML menu reports unclosed HTML tags
+- `Unmatched Tag Check` in the HTML menu reports unmatched HTML tags
 - `Unmatched Curly Double Quote Check` added to the Txt menu
 - Separate `Unmatched Tag/Brackets/Block Markup Checks` added to Tools menu
 

--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -1727,7 +1727,8 @@ sub unmatcheddoublequotesrun {
 # Check that all block markups have matching pair
 sub unmatchedblockrun {
     my $errname = shift;
-    unmatcheditemsrun( $errname, "/[$::allblocktypes]|[$::allblocktypes]/", \&::hilitematchblock );
+    unmatcheditemsrun( $errname, "^/[$::allblocktypes]\$|^[$::allblocktypes]\$/",
+        \&::hilitematchblock );
 }
 
 #

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -300,7 +300,11 @@ sub menu_search {
         [ 'command',   'Find ~Orphaned DP Markup...', -command => \&::orphanedmarkup ],
         [ 'command',   'Find ~Asterisks w/o Slash',   -command => \&::find_asterisks ],
         menu_cascade( '~Find Block Markup', &menu_search_block ),
-        [ 'command',   'Find ~Match', -command => \&::hilitematch ],
+        [
+            'command', 'Find ~Match',
+            -accelerator => 'Ctrl+[',
+            -command     => \&::hilitematch,
+        ],
         [ 'separator', '' ],
         [
             'command', 'Highlight ~Double Quotes in Selection',

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -412,7 +412,7 @@ sub menu_tools {
     my ( $textwindow, $top ) = ( $::textwindow, $::top );
     [
         [
-            'command', '~Word Frequency...',
+            'command', 'Word Frequenc~y...',
             -accelerator => 'F5',
             -command     => \&::wordfrequency,
         ],
@@ -459,6 +459,27 @@ sub menu_tools {
         ],
         [
             'command',
+            'Unmatched Ta~g Check',
+            -command => sub {
+                ::errorcheckpop_up( $textwindow, $top, 'Unmatched Tags' );
+            }
+        ],
+        [
+            'command',
+            'Unmatche~d Brackets Check',
+            -command => sub {
+                ::errorcheckpop_up( $textwindow, $top, 'Unmatched Brackets' );
+            }
+        ],
+        [
+            'command',
+            'Unmatched ~Block Markup Check',
+            -command => sub {
+                ::errorcheckpop_up( $textwindow, $top, 'Unmatched Block Markup' );
+            }
+        ],
+        [
+            'command',
             'Load Checkf~ile...',
             -command => sub {
                 ::errorcheckpop_up( $textwindow, $top, 'Load Checkfile' );
@@ -469,7 +490,7 @@ sub menu_tools {
         [ 'command',   '~Sidenote Fixup...', -command => \&::sidenotes ],
         [
             'command',
-            'Replace [::] with I~ncremental Counter',
+            'Replace [::] ~with Incremental Counter',
             -command => \&::replace_incr_counter
         ],
         menu_cascade( 'Con~vert Fractions', &menu_tools_convertfractions ),
@@ -517,7 +538,7 @@ sub menu_tools {
         ],
         [
             'command',
-            '~Block Rewrap Selection',
+            'Block Rewrap Selectio~n',
             -accelerator => 'Ctrl+Shift+w',
             -command     => sub {
                 $textwindow->addGlobStart;
@@ -618,7 +639,14 @@ sub menu_txt {
         [
             'command', "Convert to Curly ~Quotes", -command => sub { ::text_quotes_convert(); }
         ],
-        menu_cascade( 'Curly Quote Corrections', &menu_txt_curlycorrections ),
+        menu_cascade( 'Curl~y Quote Corrections', &menu_txt_curlycorrections ),
+        [
+            'command',
+            '~Unmatched Curly Double Quote Check',
+            -command => sub {
+                ::errorcheckpop_up( $textwindow, $top, 'Unmatched Double Quotes' );
+            }
+        ],
         [ 'separator', '' ],
         [
             'command',
@@ -664,7 +692,7 @@ sub menu_txt {
         ],
         [ 'separator', '' ],
         [ 'command',   "~Center Selection",      -command => sub { ::rcaligntext( 'c', 0 ); } ],
-        [ 'command',   "~Right-Align Selection", -command => sub { ::rcaligntext( 'r', 0 ); } ],
+        [ 'command',   "Ri~ght-Align Selection", -command => sub { ::rcaligntext( 'r', 0 ); } ],
         [
             'command',
             "Right-Align ~Numbers in Selection",
@@ -816,9 +844,9 @@ sub menu_html {
         ],
         [
             'command',
-            'Unclo~sed Tag Check',
+            'Unm~atched Tag Check',
             -command => sub {
-                ::errorcheckpop_up( $textwindow, $top, 'HTML Tags' );
+                ::errorcheckpop_up( $textwindow, $top, 'Unmatched Tags' );
             }
         ],
         [

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -919,14 +919,21 @@ sub initialize {
     $::manualhash{'errorcheckpop+pphtml'}    = '/HTML_Menu#PPhtml';
     $::manualhash{'errorcheckpop+ppvimage'} =
       '/HTML_Menu#Check_for_image-related_errors_.28PPVimage.29';
-    $::manualhash{'extoptpop'}     = '/Custom_Menu';
-    $::manualhash{'filepathspop'}  = '/Preferences_Menu#File_Paths';
-    $::manualhash{'fixpop'}        = '/Tools_Menu#Basic_Fixup';
-    $::manualhash{'floodpop'}      = '/Edit_Menu#Flood_Fill';
-    $::manualhash{'fontpop'}       = '/Preferences_Menu#Appearance';
-    $::manualhash{'footcheckpop'}  = '/Tools_Menu#Footnote_Fixup';
-    $::manualhash{'footpop'}       = '/Tools_Menu#Footnote_Fixup';
-    $::manualhash{'gcviewoptspop'} = '/Tools_Menu#Bookloupe';
+    $::manualhash{'errorcheckpop+Spell Query'} = '/Tools_Menu#Spell_Query';
+    $::manualhash{'errorcheckpop+EPUBCheck'} =
+      '/HTML_Menu#Check_.EPUB_Files_for_Possible_Errors_.28EPUBCheck.29';
+    $::manualhash{'errorcheckpop+Unmatched Tags'}          = '/Tools_Menu#Unmatched_Tags';
+    $::manualhash{'errorcheckpop+Unmatched Brackets'}      = '/Tools_Menu#Unmatched_Brackets';
+    $::manualhash{'errorcheckpop+Unmatched Block Markup'}  = '/Tools_Menu#Unmatched_Block_Markup';
+    $::manualhash{'errorcheckpop+Unmatched Double Quotes'} = '/Text_Menu#Unmatched_Double_Quotes';
+    $::manualhash{'extoptpop'}                             = '/Custom_Menu';
+    $::manualhash{'filepathspop'}                          = '/Preferences_Menu#File_Paths';
+    $::manualhash{'fixpop'}                                = '/Tools_Menu#Basic_Fixup';
+    $::manualhash{'floodpop'}                              = '/Edit_Menu#Flood_Fill';
+    $::manualhash{'fontpop'}                               = '/Preferences_Menu#Appearance';
+    $::manualhash{'footcheckpop'}                          = '/Tools_Menu#Footnote_Fixup';
+    $::manualhash{'footpop'}                               = '/Tools_Menu#Footnote_Fixup';
+    $::manualhash{'gcviewoptspop'}                         = '/Tools_Menu#Bookloupe';
     $::manualhash{'gotolabpop'} =
       '/Navigation#Go_to_the_text_on_a_specific_page_number_of_the_original_Book';
     $::manualhash{'gotolinepop'} = '/Navigation#Go_to_a_specific_Line';


### PR DESCRIPTION
1. Add new menu options, including necessary reassignment of some keys used for keyboard navigation.
`Unclosed Tag Check` in HTML menu changed to `Unmatched Tag Check` since the tag is unmatched rather than unclosed. Quote check is with other curly quote options in Txt menu. Tag, Bracket and Block checks are in Tools menu.
2. Convert existing routine for checking tags to a general routine for checking matching items given regex and reference to match routine. Call it for each check type.
3.  Use existing global constant variable for possible block types
4. Updated changelog

Fixes #1100
Fixes #1105
Fixes #1106
Fixes #1107