### PR TITLE
Stop page markers within markup breaking rewrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Bug Fixes
 - The column display (ruler) numbers could sometimes display wrongly
+- When an internal page marker ended up in the middle of block markup,
+  rewrapping could fail. Page markers could also break the column
+  counting needed for `/R` and `/C` wrapping leading to misalignment
 
 
 ## Version 1.5.2


### PR DESCRIPTION
Temporary characters are inserted where page markers occur, so that after rewrapping, the page makers can be moved to the same location in the text that they were previously. This has been the case for many years. It was therefore necessary for many regexps used within rewrapping to allow for the temporary character appearing at the start of end of block markup lines.

Under two circumstances, these characters caused problems for rewrapping:

1. If, through manual editing of markup, e.g. when changing markup from the rounds to specific PPing markup, a page marker could end up in the middle of the markup, e.g. `/<123.png>*`. The regexps used didn't allow for this, so markup was missed, causing incorrect rewrapping.

2. Even when a page marker was within text as normal, the temporary character was being counted as part of the line length, and could cause center block or right-align block operations to be slightly misaligned. This has never been reported, since mis-centering by 1 character is unlikely to be noticed, and right-aligning to column 71 instead of 72 is also easily missed, unless two right-align blocks occur close to one another.

Fixes #1110