### PR TITLE
Fail more gracefully if Aspell not installed

### DIFF
--- a/src/lib/Guiguts/MultiLingual.pm
+++ b/src/lib/Guiguts/MultiLingual.pm
@@ -36,8 +36,8 @@ sub spellmultiplelanguages {
     ::hidepagenums();
 
     # find Aspell and base language if necessary
-    ::spelloptions() unless $::globalspellpath;
-    return           unless $::globalspellpath;
+    ::spelloptions() unless $::globalspellpath and -e $::globalspellpath;
+    return           unless $::globalspellpath and -e $::globalspellpath;
     ::spelloptions() unless $::globalspelldictopt;
     return           unless $::globalspelldictopt;
     multilangpopup( $textwindow, $top );


### PR DESCRIPTION
Now that Aspell is not required (since PPer can use Spell Query tool instead), using Help->Software Versions should not give an error about Aspell not being installed.

Also, a few places needed to extend the check that the Aspell path variable is set, to also check the executable actually exists.