### PR TITLE
Handle words with combining chars in WF

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -596,6 +596,7 @@ sub escape_regexmetacharacters {
 
 sub deaccentsort {
     my $phrase = shift;
+    $phrase =~ s/\p{Mark}//g;                              # First remove any combining marks from phrase
     if ( $phrase =~ /[$::convertcharssinglesearch]/ ) {    # do we need the slow tr?
         eval
           "\$phrase =~ tr/$::convertlatinsinglesearch$::convertcharssinglesearch/$::convertlatinsinglereplace$::convertcharssinglereplace/";

--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -41,11 +41,11 @@ sub wordfrequencybuildwordlist {
             $match = ( $::lglobal{wf_ignore_case} ) ? lc($word) : $word;
             $::lglobal{seenwordsdoublehyphen}->{$match}++;
         }
-        $line =~ s/[^'\.,\p{Alnum}\*-]/ /g;    # get rid of nonalphanumeric
-        $line =~ s/--/ /g;                     # get rid of --
-        $line =~ s/—/ /g;                      # trying to catch words with real em-dashes, from dp2rst
-        $line =~ s/(\D),/$1 /g;                # throw away comma after non-digit
-        $line =~ s/,(\D)/ $1/g;                # and before
+        $line =~ s/[^'\.,\p{Alnum}\p{Mark}\*-]/ /g;    # get rid of nonalphanumeric (retaining combining characters)
+        $line =~ s/--/ /g;                             # get rid of --
+        $line =~ s/—/ /g;                              # trying to catch words with real em-dashes, from dp2rst
+        $line =~ s/(\D),/$1 /g;                        # throw away comma after non-digit
+        $line =~ s/,(\D)/ $1/g;                        # and before
         @words = split( /\s+/, $line );
         for my $word (@words) {
             $word =~ s/ //g;

--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -617,7 +617,7 @@ sub accentcheck {
     my $wordwo = 0;
 
     foreach my $word ( keys %{ $::lglobal{seenwords} } ) {
-        if ( $word =~ /[$::convertlatinsinglesearch$::convertcharssinglesearch]/ ) {
+        if ( $word =~ /[\p{Mark}$::convertlatinsinglesearch$::convertcharssinglesearch]/ ) {
             $wordw++;
             my $wordtemp = $word;
             $display{$word} = $::lglobal{seenwords}->{$word}


### PR DESCRIPTION
Previously, combining characters were not considered part of a word, so words containing them were split into two at the location of the combining character.

By including combining characters in the permitted "word" characters, these words are now treated the same as other words.