### PR TITLE
Adjust which match checks permit nesting

### DIFF
--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -463,9 +463,9 @@ sub menu_tools {
         ],
         [
             'command',
-            'Unmatched Ta~g Check',
+            'Unmatched DP Ta~g Check',
             -command => sub {
-                ::errorcheckpop_up( $textwindow, $top, 'Unmatched Tags' );
+                ::errorcheckpop_up( $textwindow, $top, 'Unmatched DP Tags' );
             }
         ],
         [
@@ -848,9 +848,9 @@ sub menu_html {
         ],
         [
             'command',
-            'Unm~atched Tag Check',
+            'Unm~atched HTML Tag Check',
             -command => sub {
-                ::errorcheckpop_up( $textwindow, $top, 'Unmatched Tags' );
+                ::errorcheckpop_up( $textwindow, $top, 'Unmatched HTML Tags' );
             }
         ],
         [

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -922,7 +922,8 @@ sub initialize {
     $::manualhash{'errorcheckpop+Spell Query'} = '/Tools_Menu#Spell_Query';
     $::manualhash{'errorcheckpop+EPUBCheck'} =
       '/HTML_Menu#Check_.EPUB_Files_for_Possible_Errors_.28EPUBCheck.29';
-    $::manualhash{'errorcheckpop+Unmatched Tags'}          = '/Tools_Menu#Unmatched_Tags';
+    $::manualhash{'errorcheckpop+Unmatched HTML Tags'}     = '/HTML_Menu#Unmatched_Tags';
+    $::manualhash{'errorcheckpop+Unmatched DP Tags'}       = '/Tools_Menu#Unmatched_Tags';
     $::manualhash{'errorcheckpop+Unmatched Brackets'}      = '/Tools_Menu#Unmatched_Brackets';
     $::manualhash{'errorcheckpop+Unmatched Block Markup'}  = '/Tools_Menu#Unmatched_Block_Markup';
     $::manualhash{'errorcheckpop+Unmatched Double Quotes'} = '/Text_Menu#Unmatched_Double_Quotes';


### PR DESCRIPTION
The Unmatched item checks now report when some items are nested. "Nested" means contained within an item of the identical type, e.g. `/*` within `/*` would be reported, but not `/R` within `/*`. Although this could lead to occasional false positives, this is better than failing to detect badly formed items.
Specifically
1. Brackets may not be nested within their own type.
2. DP tags may not be nested
3. Only `/#` block markup may be nested
4. All non-void HTML tags may be nested. It may not be valid HTML but that is not the purpose of the check. Primarily it is to detect `<p>`, `<span>`, `<div>`, etc. that are not closed/nested correctly.
5. The tag check is now split for DP and HTML tags to be treated differently.