### PR TITLE
Avoid uninitialized var msg from `working` dialog

### DIFF
--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -762,23 +762,27 @@ sub readlabels {
 sub working {
     my $msg = shift;
     my $top = $::top;
-    if ( defined( $::lglobal{workpop} ) && ( defined $msg ) ) {
-        $::lglobal{worklabel}->configure( -text => "\n\n\nWorking....\n$msg\nPlease wait.\n\n\n" );
+
+    # Display "working" message
+    if ( defined $msg ) {
+        if ( defined $::lglobal{workpop} ) {    # dialog already showing, so just change message
+            $::lglobal{worklabel}
+              ->configure( -text => "\n\n\nWorking....\n$msg\nPlease wait.\n\n\n" );
+        } else {                                # create dialog from scratch
+            $::lglobal{workpop} = $top->Toplevel;
+            $::lglobal{workpop}->transient($top);
+            $::lglobal{workpop}->title('Working.....');
+            $::lglobal{worklabel} = $::lglobal{workpop}->Label(
+                -text       => "\n\n\nWorking....\n$msg\nPlease wait.\n\n\n",
+                -font       => '{helvetica} 20 bold',
+                -background => $::activecolor,
+            )->pack;
+            $::lglobal{workpop}->resizable( 'no', 'no' );
+            initialize_popup_with_deletebinding('workpop');
+        }
         $::lglobal{workpop}->update;
-    } elsif ( defined $::lglobal{workpop} ) {
+    } else {    # No message given means "no longer working" so kill dialog
         ::killpopup('workpop');
-    } else {
-        $::lglobal{workpop} = $top->Toplevel;
-        $::lglobal{workpop}->transient($top);
-        $::lglobal{workpop}->title('Working.....');
-        $::lglobal{worklabel} = $::lglobal{workpop}->Label(
-            -text       => "\n\n\nWorking....\n$msg\nPlease wait.\n\n\n",
-            -font       => '{helvetica} 20 bold',
-            -background => $::activecolor,
-        )->pack;
-        $::lglobal{workpop}->resizable( 'no', 'no' );
-        initialize_popup_with_deletebinding('workpop');
-        $::lglobal{workpop}->update;
     }
 }
 


### PR DESCRIPTION
If another dialog popped (e.g. to say file hadn't been saved yet) at the same time as the `working` dialog, the user could manually dismiss the `working` dialog. Then when the code tried to dismiss the dialog, by calling the routine with no arguments, a logic failure meant it tried to display the undefined `$msg` variable. Logic fixed.

Fixes #1123