### PR TITLE
Make SQ, WF, S/R cope better with combining characters

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -1472,7 +1472,7 @@ sub booklouperun {
             my $nextcol = 0;
 
             # Replace all non-alphanumeric (but not apostrophes) with space
-            $line =~ s/[^[:alnum:]'$APOS]/ /g;
+            $line =~ s/[^\p{Alnum}\p{Mark}'$APOS]/ /g;
 
             # Check each word individually
             my @words = split( /\s/, $line );    # Split on single spaces to aid column counting

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -187,7 +187,7 @@ sub searchtext {
         } else {    # not a search across line boundaries
             my $exactsearch = $searchterm;
             $exactsearch = ::escape_regexmetacharacters($exactsearch);
-            $searchterm  = '(?<!\p{Alnum})' . $exactsearch . '(?!\p{Alnum})'
+            $searchterm  = '(?<![\p{Alnum}\p{Mark}])' . $exactsearch . '(?![\p{Alnum}\p{Mark}])'
               if $::sopt[0];
             my ( $direction, $searchstart, $mode );
             if   ( $::sopt[2] ) { $searchstart = $::searchstartindex }
@@ -915,7 +915,7 @@ sub replaceall {
             # escape metacharacters and check before/after for non-alpha if whole word matching
             if ( $::sopt[0] ) {
                 my $exactsearch = ::escape_regexmetacharacters($searchterm);
-                $searchterm = '(?<!\p{Alnum})' . $exactsearch . '(?!\p{Alnum})';
+                $searchterm = '(?<![\p{Alnum}\p{Mark}])' . $exactsearch . '(?![\p{Alnum}\p{Mark}])';
             }
 
             # regex search is needed for whole word matching
@@ -2192,7 +2192,10 @@ sub quickcount {
     my $string = $textwindow->get( $start, $end );
 
     # Escape any regex metacharacters, and force whole-word searching
-    $string = '(?<!\p{Alnum})' . ::escape_regexmetacharacters($string) . '(?!\p{Alnum})';
+    $string =
+        '(?<![\p{Alnum}\p{Mark}])'
+      . ::escape_regexmetacharacters($string)
+      . '(?![\p{Alnum}\p{Mark}])';
 
     # Loop through whole file, counting number of occurrences
     my $length      = 0;

--- a/src/lib/Guiguts/SpellCheck.pm
+++ b/src/lib/Guiguts/SpellCheck.pm
@@ -91,9 +91,9 @@ sub spellchecknext {
             $textwindow->search(
                 -forwards, -regexp,
                 -count => \$::lglobal{matchlength},
-                '(?<!\p{Alpha})'
+                '(?<![\p{Alnum}\p{Mark}])'
                   . $::lglobal{misspelledlist}[ $::lglobal{nextmiss} ]
-                  . '(?!\p{Alnum})', $::lglobal{lastmatchindex}, 'end'
+                  . '(?![\p{Alnum}\p{Mark}])', $::lglobal{lastmatchindex}, 'end'
             )
         );
     }

--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -281,9 +281,9 @@ sub wordfrequency {
                     $sword =~ s/([^\w\s\\])/\\$1/g;
 
                     # Force whole word search via regex - can't use \b because underscore is a "word" character in Perl
-                    $sword .= '(?![[:alnum:]])'
+                    $sword .= '(?![\p{Alnum}\p{Mark}])'
                       if ( ( length $sword gt 1 ) && ( $sword =~ /\w$/ ) );
-                    $sword = '(?<![[:alnum:]])' . $sword
+                    $sword = '(?<![\p{Alnum}\p{Mark}])' . $sword
                       if ( ( length $sword gt 1 ) && ( $sword =~ /^\w/ ) );
                     ::searchoptset(qw/0 x x 1/);
                 }
@@ -321,9 +321,9 @@ sub wordfrequency {
                     $sword =~ s/([^\w\s\\])/\\$1/g;
 
                     # Force whole word search via regex - can't use \b because underscore is a "word" character in Perl
-                    $sword .= '(?![[:alnum:]])'
+                    $sword .= '(?![\p{Alnum}\p{Mark}])'
                       if ( ( length $sword gt 1 ) && ( $sword =~ /\w$/ ) );
-                    $sword = '(?<![[:alnum:]])' . $sword
+                    $sword = '(?<![\p{Alnum}\p{Mark}])' . $sword
                       if ( ( length $sword gt 1 ) && ( $sword =~ /^\w/ ) );
                     ::searchoptset(qw/0 0 x 1/);    # Case sensitive
                 }
@@ -446,7 +446,8 @@ sub bangmark {
     $::lglobal{wclistbox}->update;
     my $wholefile = slurpfile();
 
-    while ( $wholefile =~ m/(\p{Alnum}+\.['"]?\n*\s*['"]?\p{Lower}\p{Alnum}*)/g ) {
+    while (
+        $wholefile =~ m/([\p{Alnum}\p{Mark}]+\.['"]?\n*\s*['"]?\p{Lower}[\p{Alnum}\p{Mark}]*)/g ) {
         my $word = $1;
         $wordw++;
         $word =~ s/\n/\\n/g;
@@ -669,12 +670,12 @@ sub commark {
 
         # Skip if pattern is: . Hello, John
         $wholefile =~
-          s/([\.\?\!]['"]*[\n\s]['"]*\p{Upper}\p{Alnum}*),([\n\s]['"]*\p{Upper})/$1 $2/g;
+          s/([\.\?\!]['"]*[\n\s]['"]*\p{Upper}[\p{Alnum}\p{Mark}]*),([\n\s]['"]*\p{Upper})/$1 $2/g;
 
         # Skip if pattern is: \n\nHello, John
-        $wholefile =~ s/(\n\n *['"]*\p{Upper}\p{Alnum}*),( ['"]*\p{Upper})/$1 $2/g;
+        $wholefile =~ s/(\n\n *['"]*\p{Upper}[\p{Alnum}\p{Mark}]*),( ['"]*\p{Upper})/$1 $2/g;
     }
-    while ( $wholefile =~ m/,(['"]*\n*\s*['"]*\p{Upper}\p{Alnum}*)([\.\?\!]?)/g ) {
+    while ( $wholefile =~ m/,(['"]*\n*\s*['"]*\p{Upper}[\p{Alnum}\p{Mark}]*)([\.\?\!]?)/g ) {
         my $word = $1;
         next
           if $::intelligentWF


### PR DESCRIPTION
Several places in the code (now only some of the scanno highlighting code) considered a word to be made up of alphanumeric characters. The problem is, now that PPers use combining characters more e.g. to add unusual accents to a variety of letters, these combining characters were being treated as word-breaking characters.

Spell Check can't easily be fixed, since it relies on Aspell which, on Windows at least, scarcely copes with Unicode, never mind combining characters. However, this commit fixes Spell Query, and makes WF search and normal Search/Replace (with the whole word option checked) do a better job of finding whole words.

There's also a minor tidy-up in Multi-language Spellcheck code. It used to copy the whole file out to a temporary file a line at a time, then read it back in a line at a time to process the words in it. Now it just works directly from the loaded file.

Fixes #1118
Fixes #1122