### PR TITLE
Focus on main window after search/hilite ops

### DIFF
--- a/src/lib/Guiguts/Highlight.pm
+++ b/src/lib/Guiguts/Highlight.pm
@@ -204,6 +204,7 @@ sub hilite {
             else          { $lastindex = '' }
         }
     }
+    $textwindow->focus;
 }
 
 #
@@ -215,6 +216,7 @@ sub hiliteremove {
     hilite_alignment_stop();
     $::nohighlights = 0;
     ::highlight_quotbrac();
+    $textwindow->focus;
 }
 
 #
@@ -328,6 +330,7 @@ sub highlight_quotbrac {
         highlight_quotbrac_remove();
     }
     ::savesettings();
+    $textwindow->focus;
 }
 
 #
@@ -410,6 +413,7 @@ sub hilite_alignment_toggle {
     } else {
         ::hilite_alignment_start();
     }
+    $::textwindow->focus;
 }
 
 #
@@ -566,6 +570,7 @@ sub hilitematch {
         }
     }
     ::soundbell() unless $index;    # Match not found (or attempt to match unsupported string)
+    $textwindow->focus;
 }
 
 #

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -353,6 +353,7 @@ sub menu_search {
                 } else {
                     ::hilite_alignment_stop();
                 }
+                $textwindow->focus;
             }
         ],
         [

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -1682,6 +1682,7 @@ sub find_proofer_comment {
         ::operationadd('Found no more proofer comments')
           if $direction ne 'reverse';
     }
+    $textwindow->focus;
 }
 
 #
@@ -1696,6 +1697,7 @@ sub find_asterisks {
     } else {
         ::operationadd('Found no more asterisks without slash');
     }
+    $textwindow->focus;
 }
 
 #


### PR DESCRIPTION
If tear-off is used, using "find proofer comment", asterisk and highlight options from Search menu didn't return focus to main window, requiring user to click in main window to continue editing.

Fixes #1128