### PR TITLE
Save non-ASCII author name correctly

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -333,7 +333,7 @@ sub _bin_save {
         print $fh "\$::spellindexbkmrk = '$::spellindexbkmrk';\n\n";
         print $fh "\$::projectid = '$::projectid';\n\n";
         print $fh "\$::booklang = '$::booklang';\n\n";
-        print $fh "\$::bookauthor = '$::bookauthor';\n\n";
+        print $fh "\$::bookauthor = \"" . ::escapeforperlstring($::bookauthor) . "\";\n\n";
         print $fh
           "\$scannoslistpath = '@{[::escape_problems(::os_normal($::scannoslistpath))]}';\n\n";
         foreach ( sort keys %::charsuiteenabled ) {
@@ -984,7 +984,7 @@ EOM
         print $save_handle ("\@quicksearch_history = (\n");
         my @array = @::quicksearch_history;
         for my $index (@array) {
-            $index =~ s/([^A-Za-z0-9 ])/'\x{'.(sprintf "%x", ord $1).'}'/eg;
+            $index = ::escapeforperlstring($index);
             print $save_handle qq/\t"$index",\n/;
         }
         print $save_handle ");\n\n";
@@ -992,7 +992,7 @@ EOM
         print $save_handle ("\@search_history = (\n");
         @array = @::search_history;
         for my $index (@array) {
-            $index =~ s/([^A-Za-z0-9 ])/'\x{'.(sprintf "%x", ord $1).'}'/eg;
+            $index = ::escapeforperlstring($index);
             print $save_handle qq/\t"$index",\n/;
         }
         print $save_handle ");\n\n";
@@ -1000,7 +1000,7 @@ EOM
         print $save_handle ("\@replace_history = (\n");
         @array = @::replace_history;
         for my $index (@array) {
-            $index =~ s/([^A-Za-z0-9 ])/'\x{'.(sprintf "%x", ord $1).'}'/eg;
+            $index = ::escapeforperlstring($index);
             print $save_handle qq/\t"$index",\n/;
         }
         print $save_handle ");\n\n";

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -13,7 +13,7 @@ BEGIN {
     @EXPORT = qw(&openpng &get_image_file &arabic &roman &popscroll
       &cmdinterp &nofileloadedwarning &win32_cmdline &win32_start &dialogboxcommonsetup &textentrydialogpopup
       &win32_is_exe &win32_create_process &dos_path &runner &run &launchurl &escape_regexmetacharacters
-      &deaccentsort &deaccentdisplay &readlabels &working &initialize &initialize_popup_with_deletebinding
+      &deaccentsort &deaccentdisplay &escapeforperlstring &readlabels &working &initialize &initialize_popup_with_deletebinding
       &initialize_popup_without_deletebinding &titlecase &os_normal &escape_problems &natural_sort_alpha
       &natural_sort_length &natural_sort_freq &drag &cut &paste &entrypaste &textcopy &colcut &colcopy &colpaste &showversion
       &checkforupdates &checkforupdatesmonthly &gotobookmark &setbookmark &seeindex &ebookmaker
@@ -628,6 +628,19 @@ sub deaccentdisplay {
     eval
       "\$phrase =~ tr/$::convertlatinsinglesearch$::convertcharssinglesearch/$::convertlatinsinglereplace$::convertcharssinglereplace/";
     return $phrase;
+}
+
+#
+# Escape characters that are not alphanumeric or a space (for readability),
+# so returned string is suitable as a Perl string to be output enclosed in
+# double quotes to setting.rc, .bin file, etc.
+# Primarily to avoid outputing non-ASCII characters, backslashes or double
+# quotes that could cause errors when trying to read back in. It's fine
+# to be conservative though and escape all non-alphanumeric.
+sub escapeforperlstring {
+    my $string = shift;
+    $string =~ s/([^A-Za-z0-9 ])/'\x{'.(sprintf "%x", ord $1).'}'/eg;
+    return $string;
 }
 
 #


### PR DESCRIPTION
Specific example was a non-breaking space between initials, but would have failed on any non-ASCII characters in author's name. Problem arose because string is written out to `.bin` file as perl code to be executed back in on file load, so higher ordinal characters need escaping. Search/replace history strings already had a mechanism when written to `setting.rc`, so extracted and re-used that.

It would be fine to write every character out in hex, but it's more readable to let the alphanumeric and spaces be written out in native form, since they don't cause problems.

Fixes #1134