### PR TITLE
Avoid `bad index` error in HTML generate

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -419,7 +419,6 @@ sub html_convert_body {
             }
 
             # <p class="center"> if selection does not have /h, /d, <br>, </p>, or </div> (or last line closed markup)
-            #   print "int:$intitle:las:$last5[3]:sel:$selection\n";
             if (
                 (
                     length($selection)
@@ -1205,7 +1204,8 @@ sub html_convert_sidenotes {
         $textwindow->ntdelete( $thisblockstart, $thisblockstart . '+' . $length . 'c' );
         $textwindow->ntinsert( $thisblockstart, '<div class="sidenote">' );
         $thisnoteend = $textwindow->search( '--', ']', $thisblockstart, 'end' );
-        while ( $textwindow->compare( "$thisblockstart+1c", "<", $thisnoteend )
+        while ( $thisnoteend
+            and $textwindow->compare( "$thisblockstart+1c", "<", $thisnoteend )
             and $textwindow->get( "$thisblockstart+1c", $thisnoteend ) =~ /\[/ ) {
             $thisblockstart = $thisnoteend;
             $thisnoteend    = $textwindow->search( '--', ']</p>', $thisblockstart, 'end' );


### PR DESCRIPTION
Badly formed sidenotes, e.g. not surrounded by blank lines could sometimes give a bad index, since index was not checked for validity in loop attempting to skip past embedded square brackets