### PR TITLE
Three minor bugs

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -1627,7 +1627,7 @@ sub booklouperun {
     sub spellqueryloadglobaldict {
         my $dictname = shift;
         my $fh;
-        unless ( open $fh, "<:encoding(utf8)", $dictname ) {
+        unless ( open $fh, "<", $dictname ) {
             ::warnerror("Error opening Spell Query dictionary: $dictname");
             return 0;
         }

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -377,6 +377,7 @@ sub clearvars {
     $::lglobal{fntotal} = 0;
     undef $::lglobal{prepfile};
     $::bookauthor = '';
+    $::booklang   = 'en';
     return;
 }
 

--- a/src/lib/Guiguts/WordFrequency.pm
+++ b/src/lib/Guiguts/WordFrequency.pm
@@ -953,8 +953,8 @@ sub charsortcheck {
         if ( $_ =~ /\t/ ) { $display{'*tab*'} = $chars{$_}; next }
         $display{$_} = $chars{$_};
     }
-    $display{'*newline*'} = $last_line - 2;
-    $display{'*space*'}   = $chars{' '};
+    $display{'*newline*'} = $last_line - 2 if $last_line > 2;
+    $display{'*space*'}   = $chars{' '}    if $chars{' '};
     $display{'*nbsp*'}    = $chars{"\xA0"} if $chars{"\xA0"};
     delete $display{"\xA0"}  if $chars{"\xA0"};
     delete $display{"\x{d}"} if $chars{"\x{d}"};


### PR DESCRIPTION
1. Spaces are displayed in the WF Character Count list as `*space*`.
The number of occurrences was set to undef if the file contains
no spaces because of a missing check when space display was
handled specially. Check was there for non-breaking spaces,
but not regular ones. This caused an error when displaying the
character counts.
Also fixed similar (but more minor) error if file contains no
newline characters. Character count displayed a line saying
there were no newlines, instead of omitting mention of
newlines as happens with other characters that aren't in
the file.

2. Similar to loading text/HTML file, don't use `encoding(utf8)`
on file open of global dictionary, because if it isn't utf8, bad
things will happen.

3. If file has a `.bin` file, it may have language(s) set in it.
If it does not, the language(s) remained as for the previously
loaded file.