### PR TITLE
Use `nbsp` instead of `#160` for non-breaking space

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -122,8 +122,8 @@ sub html_convert_emdashes {
     # Use negative lookbehind for "<!" and negative lookahead for ">"
     ::named( '(?<!<!)--(?!>)', "\x{2014}" );
 
-    # Convert non-breaking space character to numeric entity, since character looks just like a regular space
-    ::named( "\x{A0}", '&#160;' );
+    # Convert non-breaking space character to named entity, since character looks just like a regular space
+    ::named( "\x{A0}", '&nbsp;' );
     return;
 }
 
@@ -852,17 +852,7 @@ sub html_convert_body {
         if ( $inblock || ( $selection =~ /^\s/ ) ) {
             if ($blkcenter) {
                 $selection =~ s/^\s+//;
-                $selection =~ s/  /&#160; /g;    # attempt to maintain multiple spaces
-                                                 # TODO - remove this commented section if not needed
-                                                 # if ($selection =~ /^$/) { # Blank line - replace with a paragraph break unless first/last line in block
-                                                 # my $stepm = $step - 1;
-                                                 # my $stepp = $step + 1;
-                                                 # unless ( $textwindow->get( "$stepm.0", "$stepm.end" ) =~ /^<p class="center">$/ or
-                                                 # $textwindow->get( "$stepp.0", "$stepp.end" ) =~ /^[Cc]\/$/ ) {
-                                                 # $selection =~ s/^$/<\/p><p class="center">/;
-                                                 # $addbr = 0;
-                                                 # }
-                                                 # }
+                $selection =~ s/  /&nbsp; /g;    # attempt to maintain multiple spaces
                 $textwindow->ntdelete( "$step.0", "$step.end" );
                 $textwindow->ntinsert( "$step.0", $selection );
 
@@ -877,7 +867,7 @@ sub html_convert_body {
                 # adjust length for conversions that have been done since the user did their alignment
                 # For each conversion, count the occurrences of the converted entity on the line
                 # then adjust for the number of characters that the conversion added or removed.
-                my $cnt = () = $selection =~ /&#160;/g;     # instead of non-breaking space
+                my $cnt = () = $selection =~ /&nbsp;/g;     # instead of non-breaking space
                 $len -= $cnt * 5;
                 $cnt = () = $selection =~ /&amp;/g;         # instead of ampersand
                 $len -= $cnt * 4;
@@ -893,7 +883,7 @@ sub html_convert_body {
                 $len -= $cnt * 6;
                 push( @blkrlens, $len );
                 $selection =~ s/^\s+//;
-                $selection =~ s/  /&#160; /g;               # attempt to maintain multiple spaces
+                $selection =~ s/  /&nbsp; /g;               # attempt to maintain multiple spaces
                 $textwindow->ntdelete( "$step.0", "$step.end" );
                 $textwindow->ntinsert( "$step.0", $selection );
 
@@ -903,7 +893,7 @@ sub html_convert_body {
             } elsif ( $selection =~ /^(\s+)/ ) {
                 $indent = ( length($1) / 2 );               # left margin of 1em for every 2 spaces
                 $selection =~ s/^\s+//;
-                $selection =~ s/  /&#160; /g;               # attempt to maintain multiple spaces
+                $selection =~ s/  /&nbsp; /g;               # attempt to maintain multiple spaces
                 $textwindow->ntdelete( "$step.0", "$step.end" );
                 $textwindow->ntinsert( "$step.0", $selection );
 
@@ -2834,15 +2824,15 @@ sub markup {
         ( $lsr, $lsc ) = split /\./, $thisblockstart;
         ( $ler, $lec ) = split /\./, $thisblockend;
         if ( $lsr eq $ler ) {
-            $textwindow->insert( 'insert', '&#160;' );
+            $textwindow->insert( 'insert', '&nbsp;' );
         } else {
             $step = $lsr;
             while ( $step <= $ler ) {
                 $selection = $textwindow->get( "$step.0", "$step.end" );
                 if ( $selection =~ /\s\s/ ) {
-                    $selection =~ s/^\s/&#160;/;
-                    $selection =~ s/  /&#160; /g;
-                    $selection =~ s/&#160; /&#160;&#160;/g;
+                    $selection =~ s/^\s/&nbsp;/;
+                    $selection =~ s/  /&nbsp; /g;
+                    $selection =~ s/&nbsp; /&nbsp;&nbsp;/g;
                     $textwindow->delete( "$step.0", "$step.end" );
                     $textwindow->insert( "$step.0", $selection );
                 }
@@ -3131,7 +3121,7 @@ sub clearmarkupinselection {
               if ( $selection =~ s/<span.*?margin-left: (\d+\.?\d?)em.*?>/' ' x ($1 *2)/e );
             $edited++ if ( $selection =~ s/<\/?span[^>]*?>//g );
             $edited++ if ( $selection =~ s/<\/?[hscalupt].*?>//g );
-            $edited++ if ( $selection =~ s/&#160;/ /g );
+            $edited++ if ( $selection =~ s/&nbsp;/ /g );
             $edited++ if ( $selection =~ s/<\/?blockquote>//g );
             $textwindow->delete( "$step.$lsc", "$step.$stepend" ) if $edited;
             $textwindow->insert( "$step.$lsc", $selection )       if $edited;
@@ -3463,7 +3453,7 @@ sub poetryhtml {
             $ler--;                                              # So there's one less line to process
             next;
         }
-        $selection =~ s/&#160;/ /g;
+        $selection =~ s/&nbsp;/ /g;
         my $indent = 0;
         $indent = length($1) if $selection =~ s/^(\s+)//;
         $textwindow->delete( "$step.0", "$step.$indent" ) if $indent;

--- a/tests/testhtml3baseline.html
+++ b/tests/testhtml3baseline.html
@@ -165,88 +165,88 @@ Richard Quarren, Esq<sup>r.</sup>{e.}</i></p>
 <span style="margin-left: 24em;">PAGES</span><br>
 <br>
 <span style="margin-left: 1em;">"She excused the witness and turned her back</span><br>
-<span style="margin-left: 1em;">to the looking-glass"&#160; &#160; &#160; <i>Frontispiece</i></span><br>
+<span style="margin-left: 1em;">to the looking-glass"&nbsp; &nbsp; &nbsp; <i>Frontispiece</i></span><br>
 <br>
 <span style="margin-left: 1em;">"Westguard, colossal in his armour, gazed</span><br>
-<span style="margin-left: 1em;">gloomily around at the gorgeous spectacle"&#160; &#160; &#160; 24-25</span><br>
+<span style="margin-left: 1em;">gloomily around at the gorgeous spectacle"&nbsp; &nbsp; &nbsp; 24-25</span><br>
 <br>
 <span style="margin-left: 1em;">"Jingling, fluttering, gems clashing musically,</span><br>
 <span style="margin-left: 1em;">the Byzantine dancer, besieged by adorers,</span><br>
-<span style="margin-left: 1em;">deftly evaded their pressing gallantries"&#160; &#160; &#160; 30-31</span><br>
+<span style="margin-left: 1em;">deftly evaded their pressing gallantries"&nbsp; &nbsp; &nbsp; 30-31</span><br>
 <br>
 <span style="margin-left: 1em;">"'To our new friendship, Monsieur Harlequin!'</span><br>
-<span style="margin-left: 1em;">she said lightly"&#160; &#160; &#160; 52-53</span><br>
+<span style="margin-left: 1em;">she said lightly"&nbsp; &nbsp; &nbsp; 52-53</span><br>
 <br>
 <span style="margin-left: 1em;">"Strelsa, propped on her pillows, was still intent</span><br>
-<span style="margin-left: 1em;">on her newspapers"&#160; &#160; &#160; 60-61</span><br>
+<span style="margin-left: 1em;">on her newspapers"&nbsp; &nbsp; &nbsp; 60-61</span><br>
 <br>
 <span style="margin-left: 1em;">"'A perfect scandal, child. The suppers those</span><br>
-<span style="margin-left: 1em;">young men give there!'"&#160; &#160; &#160; 78-79</span><br>
+<span style="margin-left: 1em;">young men give there!'"&nbsp; &nbsp; &nbsp; 78-79</span><br>
 <br>
 <span style="margin-left: 1em;">"'Is—Mrs. Leeds—well?' he ventured at length,</span><br>
-<span style="margin-left: 1em;">reddening again"&#160; &#160; &#160; 86-87</span><br>
+<span style="margin-left: 1em;">reddening again"&nbsp; &nbsp; &nbsp; 86-87</span><br>
 <br>
 <span style="margin-left: 1em;">"'I write,' said Westguard, furious, 'because</span><br>
-<span style="margin-left: 1em;">I have a message to deliver—'"&#160; &#160; &#160; 98-99</span><br>
+<span style="margin-left: 1em;">I have a message to deliver—'"&nbsp; &nbsp; &nbsp; 98-99</span><br>
 <br>
 <span style="margin-left: 1em;">"'Never mind geography, child; tell me about</span><br>
-<span style="margin-left: 1em;">the men!'"&#160; &#160; &#160; 116-117</span><br>
+<span style="margin-left: 1em;">the men!'"&nbsp; &nbsp; &nbsp; 116-117</span><br>
 <span class="pagenum" id="Page_11">[Pg 11]</span><br>
 <span style="margin-left: 1em;">"Strelsa, curled up on a divan ... listened to</span><br>
-<span style="margin-left: 1em;">his departure with quiet satisfaction"&#160; &#160; &#160; 126-127</span><br>
+<span style="margin-left: 1em;">his departure with quiet satisfaction"&nbsp; &nbsp; &nbsp; 126-127</span><br>
 <br>
 <span style="margin-left: 1em;">"'Do you remember our first toast?' he asked,</span><br>
-<span style="margin-left: 1em;">smiling"&#160; &#160; &#160; 128-129</span><br>
+<span style="margin-left: 1em;">smiling"&nbsp; &nbsp; &nbsp; 128-129</span><br>
 <br>
 <span style="margin-left: 1em;">"Once more, according to the newspapers, her</span><br>
 <span style="margin-left: 1em;">engagement to Sir Charles was expected</span><br>
-<span style="margin-left: 1em;">to be announced"&#160; &#160; &#160; 172-173</span><br>
+<span style="margin-left: 1em;">to be announced"&nbsp; &nbsp; &nbsp; 172-173</span><br>
 <br>
 <span style="margin-left: 1em;">"All stacked up pell-mell in the back yard and</span><br>
-<span style="margin-left: 1em;">regarded in amazement by the neighbors"&#160; &#160; &#160; 178-179</span><br>
+<span style="margin-left: 1em;">regarded in amazement by the neighbors"&nbsp; &nbsp; &nbsp; 178-179</span><br>
 <br>
 <span style="margin-left: 1em;">"A fortnight later Strelsa wrote to Quarren for</span><br>
-<span style="margin-left: 1em;">the first time in nearly two months"&#160; &#160; &#160; 190-191</span><br>
+<span style="margin-left: 1em;">the first time in nearly two months"&nbsp; &nbsp; &nbsp; 190-191</span><br>
 <br>
 <span style="margin-left: 1em;">"'I say, Quarren—does this old lady hang next</span><br>
-<span style="margin-left: 1em;">to the battered party in black?'"&#160; &#160; &#160; 194-195</span><br>
+<span style="margin-left: 1em;">to the battered party in black?'"&nbsp; &nbsp; &nbsp; 194-195</span><br>
 <br>
 <span style="margin-left: 1em;">"'I didn't tell Strelsa that you were coming,'</span><br>
-<span style="margin-left: 1em;">she whispered"&#160; &#160; &#160; 210-211</span><br>
+<span style="margin-left: 1em;">she whispered"&nbsp; &nbsp; &nbsp; 210-211</span><br>
 <br>
 <span style="margin-left: 1em;">"So he took the lake path and presently</span><br>
-<span style="margin-left: 1em;">rounded a sharp curve"&#160; &#160; &#160; 214-215</span><br>
+<span style="margin-left: 1em;">rounded a sharp curve"&nbsp; &nbsp; &nbsp; 214-215</span><br>
 <br>
-<span style="margin-left: 1em;">"'The old ones are the best,' she commented"&#160; &#160; &#160; 228-229</span><br>
+<span style="margin-left: 1em;">"'The old ones are the best,' she commented"&nbsp; &nbsp; &nbsp; 228-229</span><br>
 <br>
 <span style="margin-left: 1em;">"Strelsa in the library, pulling on her gloves,</span><br>
-<span style="margin-left: 1em;">was silent witness to a pantomime unmistakable"&#160; &#160; &#160; 246-247</span><br>
+<span style="margin-left: 1em;">was silent witness to a pantomime unmistakable"&nbsp; &nbsp; &nbsp; 246-247</span><br>
 <br>
 <span style="margin-left: 1em;">"A high and soulful tenor voice was singing</span><br>
-<span style="margin-left: 1em;">'Perfumes of Araby'"&#160; &#160; &#160; 272-273</span><br>
+<span style="margin-left: 1em;">'Perfumes of Araby'"&nbsp; &nbsp; &nbsp; 272-273</span><br>
 <br>
 <span style="margin-left: 1em;">"She came about noon—a pale young girl, very</span><br>
-<span style="margin-left: 1em;">slim in her limp black gown"&#160; &#160; &#160; 280-281</span><br>
+<span style="margin-left: 1em;">slim in her limp black gown"&nbsp; &nbsp; &nbsp; 280-281</span><br>
 <span class="pagenum" id="Page_12">[Pg 12]</span><br>
-<span style="margin-left: 1em;">Jessie Vining&#160; &#160; &#160; 290-291</span><br>
+<span style="margin-left: 1em;">Jessie Vining&nbsp; &nbsp; &nbsp; 290-291</span><br>
 <br>
 <span style="margin-left: 1em;">"'In the evenings sometimes Miss Vining remains</span><br>
 <span style="margin-left: 1em;">and dines with Dankmere and myself</span><br>
-<span style="margin-left: 1em;">at some near restaurant'"&#160; &#160; &#160; 302-303</span><br>
+<span style="margin-left: 1em;">at some near restaurant'"&nbsp; &nbsp; &nbsp; 302-303</span><br>
 <br>
-<span style="margin-left: 1em;">"'If you'll let me, I'll stand by you, darling'"&#160; &#160; &#160; 328-329</span><br>
+<span style="margin-left: 1em;">"'If you'll let me, I'll stand by you, darling'"&nbsp; &nbsp; &nbsp; 328-329</span><br>
 <br>
 <span style="margin-left: 1em;">"'Is it to be Sir Charles after all, darling?' she</span><br>
-<span style="margin-left: 1em;">asked caressingly"&#160; &#160; &#160; 346-347</span><br>
+<span style="margin-left: 1em;">asked caressingly"&nbsp; &nbsp; &nbsp; 346-347</span><br>
 <br>
-<span style="margin-left: 1em;">"'And it is to be your last breakfast'"&#160; &#160; &#160; 374-375</span><br>
+<span style="margin-left: 1em;">"'And it is to be your last breakfast'"&nbsp; &nbsp; &nbsp; 374-375</span><br>
 <br>
-<span style="margin-left: 1em;">Strelsa Leeds&#160; &#160; &#160; 380-381</span><br>
+<span style="margin-left: 1em;">Strelsa Leeds&nbsp; &nbsp; &nbsp; 380-381</span><br>
 <br>
-<span style="margin-left: 1em;">"'Let him loose, Quarren,' said Sprowl"&#160; &#160; &#160; 416-417</span><br>
+<span style="margin-left: 1em;">"'Let him loose, Quarren,' said Sprowl"&nbsp; &nbsp; &nbsp; 416-417</span><br>
 <br>
 <span style="margin-left: 1em;">"'I wanted to surprise you,' he explained</span><br>
-<span style="margin-left: 1em;">feebly"&#160; &#160; &#160; 424-425</span><br>
+<span style="margin-left: 1em;">feebly"&nbsp; &nbsp; &nbsp; 424-425</span><br>
 </p>
 
 <p><span class="pagenum" id="Page_13">[Pg 13]</span></p>


### PR DESCRIPTION
Named entity `&nbsp;` is more readable than `&#160;` and is permitted now that XML serialization is not used.