### PR TITLE
Quicksearch enhancements

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -2272,11 +2272,18 @@ sub quicksearchpopup {
         -height => 15,
     )->pack( -side => 'left', -anchor => 'nw' );
     $::lglobal{statussearchtext} = '' unless defined $::lglobal{statussearchtext};
+
+    # If some text is selected, put the first line only in the quick search entry field
+    my @ranges = $textwindow->tagRanges('sel');
+    $::lglobal{statussearchtext} = $textwindow->get( $ranges[0], $ranges[1] ) if @ranges;
+    $::lglobal{statussearchtext} =~ s/[\n\r].*//s;    # Trailing 's' makes '.' match newlines
+
     $::lglobal{quicksearchentry} = $::lglobal{'quicksearchpop'}->Entry(
         -width        => 12,
         -textvariable => \$::lglobal{statussearchtext},
     )->pack( -expand => 1, -fill => 'x', -side => 'top' );
-    $::lglobal{quicksearchentry}->bind( '<Return>',       sub { ::quicksearch(); } );
+    $::lglobal{quicksearchentry}->bind( '<Return>', sub { ::quicksearch(); } );
+    searchbind( $::lglobal{quicksearchpop}, '<Control-Shift-f>', sub { ::quicksearch(); } );    # Same shortcut as popping the dialog
     $::lglobal{quicksearchentry}->bind( '<Shift-Return>', sub { ::quicksearch('reverse'); } );
     $::lglobal{quicksearchentry}
       ->bind( '<Control-Return>', sub { ::quicksearch(); $::textwindow->focus; } );

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -2277,7 +2277,9 @@ sub quicksearchpopup {
     $::lglobal{statussearchtext} = '' unless defined $::lglobal{statussearchtext};
 
     # If some text is selected, put the first line only in the quick search entry field
+    # then clear the selection so it doesn't get in the way of the search
     my @ranges = $textwindow->tagRanges('sel');
+    $textwindow->tagRemove( 'sel', '1.0', 'end' );
     $::lglobal{statussearchtext} = $textwindow->get( $ranges[0], $ranges[1] ) if @ranges;
     $::lglobal{statussearchtext} =~ s/[\n\r].*//s;    # Trailing 's' makes '.' match newlines
 


### PR DESCRIPTION
Fixes #1130 with two small features:
1. If text is selected when QS is popped, the selected text appears as the search string (like main S/R dialog)
2. Small `#` button to count occurrences of search text in the selected region, or the whole file if nothing is selected.