### PR TITLE
Accept DP page sep lines with proofer names

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -476,7 +476,7 @@ sub file_mark_pages {
         my $pagemark = 'Pg' . $page;
 
         # Standardize page separator line format if necessary
-        unless ( $line =~ /^-----File: (\S+)\.(png|jpg)-----/ ) {
+        unless ( $line =~ /^-----File: (\S+)\.(png|jpg)---/ ) {
             $textwindow->ntdelete( $linestart, $lineend );
             my $stdline = ( '-' x 5 ) . "File: $page.$ext";
             $stdline .= '-' x ( 75 - length($stdline) );


### PR DESCRIPTION
Check in #1159 was slightly too strict. It allowed DP page sep files without proofer names, but not those with names, so ended up replacing the named line with an unnamed one.

Doesn't matter to most users, but some download CTF files from rounds with proofer names, giving link to images, etc.