### PR TITLE
Stop pphtml complaining about first-letter

### DIFF
--- a/src/lib/ppvchecks/pphtml.pl
+++ b/src/lib/ppvchecks/pphtml.pl
@@ -336,6 +336,7 @@ sub runProgram {
         foreach my $idx ( 0 .. $#css ) {
             my $cssdef = $css[$idx];
             $cssdef =~ s/^.*?\.?([^\. ]+)$/$1/;
+            $cssdef =~ s/:{1,2}first-letter//;
             if ( $cssdef =~ /\b(p|body)\b/ ) {
                 next;
             }
@@ -354,6 +355,7 @@ sub runProgram {
             my $found = 0;
             foreach my $cssdef (@css) {
                 $cssdef =~ s/^.*?\.?([^\. ]+)$/$1/;
+                $cssdef =~ s/:{1,2}first-letter//;
 
                 #        $cssdef =~ s/^.*?\.(.*)$/$1/;
                 if ( $cssdef =~ /\b(p)\b/ ) {    #/\b(p|body)\b/ ) {


### PR DESCRIPTION
The parsing of the CSS and class names is rudimentary, so it didn't cope with `:first-letter` or `::first-letter` which are commonly used to display drop-caps.

Fixes #1180