### PR TITLE
Fix blank line appearing after index rewrap

### DIFF
--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -96,7 +96,8 @@ sub indexwrapper {
 
         # if start and end of markup - just preserve - don't indent
         if ( $notpmline =~ /^([Ii]\/|\/[Ii])$/ ) {
-            $rewrapped .= $line . "\n";
+            $rewrapped .= $line;
+            $rewrapped .= "\n" if $notpmline =~ /^\/[Ii]$/;    # Open markup needs a newline, close doesn't
             next;
         }
 


### PR DESCRIPTION
An additional newline was added at the end during the index wrapping process.

Fixes #1187 