### PR TITLE
Fix S/R in selected range end-point failure

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -59,8 +59,10 @@ sub searchtext {
 
     # this is starting a search within a selection
     if ( $range_total > 0 ) {
-        $end                        = pop(@ranges);
-        $start                      = pop(@ranges);
+        $end   = pop(@ranges);
+        $start = pop(@ranges);
+        $textwindow->markSet( 'searchendmark', $end );      # Mark end of selection
+        $end                        = 'searchendmark';      # Use mark instead of line number in case replace adds/deletes lines
         $::lglobal{selectionsearch} = $end;
         $::searchstartindex         = $end if $::sopt[2];
 


### PR DESCRIPTION
When using Replace All in a selected range, if the replacement adds a new line, the replacing stopped part way through the range.

This was caused by the end point being stored as a line number. The extra line in the replace string caused the actual line number of the intended end point to increase, so the replacement stopped early. Fixed by using a mark instead of the line number to note the end point.

Fixes #1189