### PR TITLE
Add Illustration Fixup feature to Tools menu

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -391,6 +391,7 @@ sub clearpopups {
     ::killpopup('footcheckpop');
     ::killpopup('htmlgenpop');
     ::killpopup('pagelabelpop');
+    ::killpopup('errorcheckpop');
 }
 
 #

--- a/src/lib/Guiguts/KeyBindings.pm
+++ b/src/lib/Guiguts/KeyBindings.pm
@@ -273,6 +273,7 @@ sub keybindings {
     keybind( '<Control-KeyPress-3>',           sub { ::gotobookmark('3'); } );
     keybind( '<Control-KeyPress-4>',           sub { ::gotobookmark('4'); } );
     keybind( '<Control-KeyPress-5>',           sub { ::gotobookmark('5'); } );
+    keybind( '<Control-Shift-j>',              sub { ::gotobookmarksystem(); } );
 
     # Compose - define last since user could set the compose key to one of the above that they never use
     keybind( "<$::composepopbinding>", sub { ::composepopup(); } );

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -480,28 +480,28 @@ sub menu_tools {
         ],
         [
             'command',
-            'Unmatched DP Ta~g Check',
+            'Unmatched DP Ta~g Check...',
             -command => sub {
                 ::errorcheckpop_up( $textwindow, $top, 'Unmatched DP Tags' );
             }
         ],
         [
             'command',
-            'Unmatche~d Brackets Check',
+            'Unmatche~d Brackets Check...',
             -command => sub {
                 ::errorcheckpop_up( $textwindow, $top, 'Unmatched Brackets' );
             }
         ],
         [
             'command',
-            'Unmatched ~Block Markup Check',
+            'Unmatched ~Block Markup Check...',
             -command => sub {
                 ::errorcheckpop_up( $textwindow, $top, 'Unmatched Block Markup' );
             }
         ],
         [
             'command',
-            'Load Checkf~ile...',
+            'Load Checkfile~...',
             -command => sub {
                 ::errorcheckpop_up( $textwindow, $top, 'Load Checkfile' );
             }
@@ -509,6 +509,13 @@ sub menu_tools {
         [ 'separator', '' ],
         [ 'command',   '~Footnote Fixup...', -command => \&::footnotepop ],
         [ 'command',   '~Sidenote Fixup...', -command => \&::sidenotes ],
+        [
+            'command',
+            '~Illustration Fixup...',
+            -command => sub {
+                ::errorcheckpop_up( $textwindow, $top, 'Illustration Fixup' );
+            }
+        ],
         [
             'command',
             'Replace [::] ~with Incremental Counter',
@@ -923,6 +930,12 @@ sub menu_bookmarks {
                 -accelerator => "Ctrl+$_"
             ],
             ( 1 .. 5 ) ),
+        [ 'separator', '' ],
+        [
+            'command', 'Jump To Next System ~Bookmark',
+            -command     => [ \&::gotobookmarksystem ],
+            -accelerator => "Ctrl+Shift+j",
+        ],
     ];
 }
 

--- a/src/lib/Guiguts/TextUnicode.pm
+++ b/src/lib/Guiguts/TextUnicode.pm
@@ -857,4 +857,18 @@ sub AutoScan {
     $w->RepeatId( $w->after( 70, [ 'AutoScan', $w ] ) );
 }
 
+#
+# Override TextUndo::undo and redo so we can flag it to any routines that need to know
+sub undo {
+    my ($self) = @_;
+    $self->SUPER::undo();
+    ::errorcheckilloupdateneeded();
+}
+
+sub redo {
+    my ($self) = @_;
+    $self->SUPER::redo();
+    ::errorcheckilloupdateneeded();
+}
+
 1;

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -16,8 +16,9 @@ BEGIN {
       &deaccentsort &deaccentdisplay &escapeforperlstring &readlabels &working &initialize &initialize_popup_with_deletebinding
       &initialize_popup_without_deletebinding &titlecase &os_normal &escape_problems &natural_sort_alpha
       &natural_sort_length &natural_sort_freq &drag &cut &paste &entrypaste &textcopy &colcut &colcopy &colpaste &showversion
-      &checkforupdates &checkforupdatesmonthly &gotobookmark &setbookmark &seeindex &ebookmaker
-      &sidenotes &poetrynumbers &get_page_number &externalpopup &add_entry_history &entry_history
+      &checkforupdates &checkforupdatesmonthly &gotobookmark &setbookmark
+      &clearbookmarksystem &setbookmarksystem  &unsetbookmarksystem &gotobookmarksystem
+      &seeindex &ebookmaker &sidenotes &poetrynumbers &get_page_number &externalpopup &add_entry_history &entry_history
       &xtops &toolbar_toggle &killpopup &expandselection
       &getprojectid &setprojectid &viewprojectcomments &viewprojectdiscussion &viewprojectpage
       &scrolldismiss &updatedrecently &hidelinenumbers &restorelinenumbers &displaylinenumbers &displaycolnumbers
@@ -27,6 +28,8 @@ BEGIN {
       &path_userhtmlheader &processcommandline &copysettings &main_lang &list_lang &setwidgetdefaultoptions);
 
 }
+
+my $BKMKSYSTEM = "bkmksystem";    # String used at start of temporary system bookmarks
 
 #
 # Get name of scan file for given page number
@@ -2439,6 +2442,42 @@ sub gotobookmark {
         $textwindow->see("bkmk$bookmark");
         $textwindow->markSet( 'insert', "bkmk$bookmark" );
         $textwindow->tagAdd( 'bkmk', "bkmk$bookmark", "bkmk$bookmark+1c" );
+    } else {
+        ::soundbell();
+    }
+}
+
+#
+# Set a temporary system bookmark with given suffix
+sub setbookmarksystem {
+    my $suffix = shift;
+    my $index  = shift;
+    $::textwindow->markSet( "$BKMKSYSTEM$suffix", $index );
+}
+
+#
+# Unset the temporary system bookmark with given suffix
+sub unsetbookmarksystem {
+    my $suffix = shift;
+    $::textwindow->markUnset("$BKMKSYSTEM$suffix");
+}
+
+#
+# Go to next temporary system bookmark
+sub gotobookmarksystem {
+    my $textwindow = $::textwindow;
+
+    # Check marks from insert position to end of file, then from top back to insert position
+    my $mark  = 'insert+1c';
+    my $found = 0;
+    while ( $mark ne 'insert' and not $found ) {    # Keep looking until we return to insert position
+        $mark  = $textwindow->markNext($mark);
+        $mark  = '1.0' if not $mark;                # Start from beginning again if we hit end of file
+        $found = $mark =~ /^$BKMKSYSTEM/;
+    }
+    if ($found) {
+        $textwindow->see($mark);
+        $textwindow->markSet( 'insert', $mark );
     } else {
         ::soundbell();
     }


### PR DESCRIPTION
Check and report on all illustration markup in downloaded CTF. Allow user to move illos up/down a paragraph, either to ensure illo is not mid-paragraph or because illo fits better at the new location.

Ctrl-click to move illo down. Ctrl-shift-click to move illo up. Once an illo is moved, Ctrl+shift+j jumps between original and new locations for illo.  The "original" location is only stored for the most recently moved illo, so if you move one illo, then a different one, then go back to move the first again, the "original" position of the first is where you left it after its previous move, not its position when you first loaded the file. This is implemented with a general "system bookmark" feature, which could be useful in other places. Menu entry corresponding to Shift+Ctrl+j is in the Bookmarks menu.

Undo/redo have had to have a slight boost, so that undoing an illo move can refresh the list.
