### PR TITLE
Improve pphtml report of unused/undefined classes

### DIFF
--- a/src/lib/ppvchecks/pphtml.pl
+++ b/src/lib/ppvchecks/pphtml.pl
@@ -330,9 +330,10 @@ sub runProgram {
         my $class = shift;
         my @list  = shift;
         return (
-            grep      { $_ eq $class } @list                                                       # class is used/defined
-              or grep { $_ eq $class } qw(a blockquote body h1 h2 h3 h4 h5 h6 hr img ins p table)  # ignore these element names
-              or $class =~ /^x-ebookmaker/                                                         # special ebookmaker class
+            grep      { $_ eq $class } @list                                    # class is used/defined
+              or grep { $_ eq $class }
+              qw(a blockquote body div h1 h2 h3 h4 h5 h6 hr img ins p table)    # ignore these element names
+              or $class =~ /^x-ebookmaker/                                      # special ebookmaker class
         );
     }
 }

--- a/tests/pphtmlbaseline.txt
+++ b/tests/pphtmlbaseline.txt
@@ -4,7 +4,6 @@ Beginning check: pphtml
 6:0 The Streets Of Ascalon | Project Gutenberg
 7:0 </title>
 14:0 CSS possibly not used: unusedcss
-24:0 CSS possibly not defined: h1
 23:0 CSS possibly not defined: pagenum
 26:0 Unconverted illustration: <p>[Illustration: "She excused the witness and turned her back to the
 Check is complete: pphtml


### PR DESCRIPTION
Code was more complicated than necessary, and still reported things like `h1` possibly not defined.

Use common code for undefined/unused class check