### PR TITLE
Remove unwanted blank line after illo move

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -1932,6 +1932,12 @@ sub unmatchedblockrun {
         $textwindow->addGlobStart;
         my $end      = $illo->{end} . '+1l linestart';
         my $illotext = $textwindow->get( $illo->{start}, $end );
+
+        # If illo is mid-paragraph and it has a blank line after it, that should be deleted
+        if (    $illo->{error} == $ILLOERRORMIDPARA
+            and $textwindow->get( $end, "$end lineend" ) eq "" ) {
+            $end .= '+1l';
+        }
         $textwindow->delete( $illo->{start}, $end );
 
         # Use system bookmarks to aid user jumping between old & new locations


### PR DESCRIPTION
After using Illustration Fixup, if the illo is flagged as mid-paragraph, then when it is moved, the blank line after it (if present) needs to be deleted, or would leave behind a paragraph break.