### PR TITLE
Make `long ordinal label` setting persistent

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -160,6 +160,7 @@ our $jeebiesmode            = 'p';
 our $lastversioncheck       = time();
 our $lastversionrun         = $VERSION;
 our $lmargin                = 0;
+our $longordlabel           = 0;
 our $markupthreshold        = 4;
 our $multisearchsize        = 3;
 our $nobell                 = 0;

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -944,7 +944,8 @@ EOM
             font_char fontname fontsize fontweight gblfontname gblfontsize gblfontweight gblfontsystemuse
             geometry gesperrt_char globalaspellmode highlightcolor history_size xmlserialization
             htmlimageallowpixels htmlimagewidthtype ignoreversionnumber
-            intelligentWF ignoreversions italic_char jeebiesmode lastversioncheck lastversionrun lmargin markupthreshold
+            intelligentWF ignoreversions italic_char jeebiesmode lastversioncheck lastversionrun
+            lmargin longordlabel markupthreshold
             multisearchsize multiterm nobell nohighlights pagesepauto notoolbar poetrylmargin
             recentfile_size rmargin rmargindiff rwhyphenspace sc_char scannos_highlighted
             searchstickyoptions spellcheckwithenchant spellquerythreshold srstayontop stayontop toolside

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -1127,13 +1127,10 @@ sub menu_preferences_toolbar {
         [ 'separator', '' ],
         [
             Checkbutton => 'Display Character Names',
-            -variable   => \$::lglobal{longordlabel},
+            -variable   => \$::longordlabel,
             -command    => sub {
-                $::lglobal{longordlabel} = 1 - $::lglobal{longordlabel};
-                ::togglelongordlabel();
+                ::savesettings();
             },
-            -onvalue  => 1,
-            -offvalue => 0
         ],
     ];
 }

--- a/src/lib/Guiguts/StatusBar.pm
+++ b/src/lib/Guiguts/StatusBar.pm
@@ -6,7 +6,7 @@ BEGIN {
     use Exporter();
     our ( @ISA, @EXPORT );
     @ISA    = qw(Exporter);
-    @EXPORT = qw(&_updatesel &buildstatusbar &togglelongordlabel &seecurrentimage
+    @EXPORT = qw(&_updatesel &buildstatusbar &seecurrentimage
       &setlang &selection &gotoline &gotopage &gotolabel &set_auto_img);
 }
 
@@ -316,7 +316,8 @@ AAAAACH5BAAAAAAALAAAAAAMAAwAAwQfMMg5BaDYXiw178AlcJ6VhYFXoSoosm7KvrR8zfXHRQA7
         '<1>',
         sub {
             $::lglobal{ordinallabel}->configure( -relief => 'sunken' );
-            ::togglelongordlabel();
+            $::longordlabel = 1 - $::longordlabel;
+            ::savesettings();
         }
     );
 
@@ -416,7 +417,7 @@ sub update_ordinal_button {
     my $textwindow = $::textwindow;
     my $ordinal    = ord( $textwindow->get('insert') );
     my $hexi       = uc sprintf( "%04x", $ordinal );
-    if ( $::lglobal{longordlabel} ) {
+    if ($::longordlabel) {
         my $msg   = charnames::viacode($ordinal) || '';
         my $msgln = length(" Dec $ordinal : Hex $hexi : $msg ");
         $::lglobal{ordmaxlength} = $msgln
@@ -432,12 +433,6 @@ sub update_ordinal_button {
             -width => 18
         ) if ( $::lglobal{ordinallabel} );
     }
-}
-
-#
-# Toggle whether character name is shown in ordinal label
-sub togglelongordlabel {
-    $::lglobal{longordlabel} = 1 - $::lglobal{longordlabel};
 }
 
 #

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1152,7 +1152,6 @@ sub initialize {
     $::lglobal{wf_ignore_case}     = 0;
     $::lglobal{lastmatchindex}     = '1.0';
     $::lglobal{lastsearchterm}     = '';
-    $::lglobal{longordlabel}       = 0;
     $::lglobal{ordmaxlength}       = 1;
     $::lglobal{pageanch}           = 1;                           # HTML convert - add page anchors
     $::lglobal{pagecmt}            = 0;                           # HTML convert - page markers as comments


### PR DESCRIPTION
User can click on hex/dec ordinal label in status bar, or use Prefs, Toolbar to Display Character Names in ordinal label. This commit makes that setting persistent instead of resetting to "off" when GG is restarted.

Minor tidy up of unnecessary double toggling - clicking the menu option toggles the variable between the default values of 0 and 1.