### PR TITLE
Set `busy` flag while adding goodwords file

### DIFF
--- a/src/lib/Guiguts/SpellCheck.pm
+++ b/src/lib/Guiguts/SpellCheck.pm
@@ -490,6 +490,7 @@ sub spelladdgoodwords {
     }
 
     # Remove all newlines and/or carriage returns whatever the current OS
+    ::busy();
     my @raw_data = map { s/[\n\r]+$//g; $_ } <DAT>;
     close(DAT);
     chdir $pwd;
@@ -497,6 +498,7 @@ sub spelladdgoodwords {
     foreach my $word (@raw_data) {
         spellmyaddword($word);
     }
+    ::unbusy();
 }
 
 #


### PR DESCRIPTION
Since the busy flag wasn't set, it was possible to attempt to run spellcheck/query using F7/Shift+F7 while the goodwords file was being read. If this was done a couple of times during the "add goodwords" process, it generated errors.

Fixes #1200