### PR TITLE
Ring bell when illo can't be moved forward

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -1922,9 +1922,8 @@ sub unmatchedblockrun {
         $textwindow->markGravity( 'insertpointmark', 'left' );    # So illo gets inserted after mark
 
         # If new position doesn't move the illo, then nothing left to do
-        my $comparison = ( $direction eq 'forward' ? '>'   : '<' );
-        my $plus1      = ( $direction eq 'forward' ? '+1l' : '-1l' );
-        unless ( $textwindow->compare( $insertpoint, $comparison, $illo->{start} . $plus1 ) ) {
+        my $comparepoint = ( $direction eq 'forward' ? "$illo->{end} +1l" : "$illo->{start} -1l" );
+        if ( $textwindow->compare( $insertpoint, '==', $comparepoint ) ) {
             ::soundbell();
             return;
         }


### PR DESCRIPTION
Previous test only caught case of failing to move illo backward from Illo Fixup. Logic corrected.