### PR TITLE
Only strip trailing spaces when saving text file

### DIFF
--- a/src/lib/Guiguts/TextUnicode.pm
+++ b/src/lib/Guiguts/TextUnicode.pm
@@ -19,17 +19,19 @@ sub Load {
         $w->EmptyDocument;
         my $count = 1;
         my $progress;
-        my $line = <$fh>;
+        my $txtfile = $filename =~ /\.te?xt$/;
+        my $line    = <$fh>;
         if ($line) {
             utf8::decode($line);
             $line =~ s/^\x{FEFF}?//;
             $line =~ s/\cM\cJ|\cM|\cJ/\n/g;
+            $line =~ s/[\t \xA0]+$// if $txtfile;
             $w->ntinsert( 'end', $line );
         }
         while (<$fh>) {
             utf8::decode($_);
             $_ =~ s/\cM\cJ|\cM|\cJ/\n/g;
-            $_ =~ s/[\t \xA0]+$//;
+            $_ =~ s/[\t \xA0]+$// if $txtfile;
             $w->ntinsert( 'end', $_ );
             if ( ( $count++ % 1000 ) == 0 ) {
                 $progress = $w->TextUndoFileProgress(

--- a/src/lib/Guiguts/TextUnicode.pm
+++ b/src/lib/Guiguts/TextUnicode.pm
@@ -75,12 +75,13 @@ sub SaveUTF {
     my $progress;
     my $fileend = $w->index('end -1c');
     my ($lines) = $fileend =~ /^(\d+)\./;
+    my $txtfile = $filename =~ /\.te?xt$/;
 
     while ( $w->compare( $index, '<', $fileend ) ) {
         my $end  = $w->index("$index lineend +1c");
         my $line = $w->get( $index, $end );
-        $line =~ s/[\t \xA0]+$//;
-        $line =~ s/\cM\cJ|\cM|\cJ/\cM\cJ/g;    # Ensure DP-style (CRLF) line endings
+        $line =~ s/[\t \xA0]+$// if $txtfile;
+        $line =~ s/\cM\cJ|\cM|\cJ/\cM\cJ/g;     # Ensure DP-style (CRLF) line endings
         utf8::encode($line);
         $w->BackTrace("Cannot write to temp file:$!\n") and return
           unless print $tempfh $line;


### PR DESCRIPTION
Trailing spaces are harmless, and sometimes wanted, in HTML files.

Fixes #1213