### PR TITLE
Adjust test suite for new Nu validator

### DIFF
--- a/tests/errorcheck.html
+++ b/tests/errorcheck.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <title>
       The Streets Of Ascalon | Project Gutenberg
     </title>
-    <link rel="icon" href="images/cover.jpg" type="image/x-cover" />
+    <link rel="icon" href="images/cover.jpg" type="image/x-cover">
     <style> /* <![CDATA[ */
 
 body {
@@ -22,7 +22,7 @@ unusedcss {
 </p></p>
 <p><span class="pagenum"><a name="Page_3" id="Page_3">[Pg 3]</a></span></p>
 <h1>THE STREETS OF ASCALON</h1>
-<img src="images/t.jpg" width="90" height="78" alt="" title="" />
+<img src="images/t.jpg" width="90" height="78" alt="" title="">
 <p>[Illustration: "She excused the witness and turned her back to the
 looking-glass."]</p>
 <p>ÿ</p>

--- a/tests/xhtmlvalidatebaseline.txt
+++ b/tests/xhtmlvalidatebaseline.txt
@@ -1,5 +1,7 @@
 Beginning check: Nu XHTML Check
+5:4 error: Element “title” not allowed as child of element “meta” in this context. (Suppressing further errors from this subtree.)
+8:4 error: Element “link” not allowed as child of element “meta” in this context. (Suppressing further errors from this subtree.)
 12:18 error: CSS: “margin-left”: Parse Error.
-22:4 error fatal: required character (found “p”) (expected “b”)
+18:0 error fatal: required character (found “h”) (expected “l”)
 Check is complete: Nu XHTML Check
 Don't forget to do the final validation at https://validator.w3.org


### PR DESCRIPTION
New Nu validator reports trailing slashes on void elements. They needed removing from the test file anyway, since we don't use them any more. The XHTML test still runs, although it's not available via the menu interface - keep it for now.