### PR TITLE
Avoid bug when page marker is on closing markup

### DIFF
--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -439,8 +439,8 @@ sub selectrewrap {
                     $inblock      = 0;
                 }
             } else {
-                my $skipit = ( $selection =~ /^(\/#|#\/)$/ );    # Happens when /c or /r directly follows /# or blank line before #/
-                if ( $::blockwrap > 0 ) {                        # block wrap
+                my $skipit = ( $notpmselection =~ /^(\/#|#\/)$/ );    # Happens when /c or /r directly follows /# or blank line before #/
+                if ( $::blockwrap > 0 ) {                             # block wrap
                     if ($blockcenter) {
                         $rewrapped = centerblockwrapper( $leftmargin, $rightmargin, $selection );
                     } elsif ($blockright) {


### PR DESCRIPTION
If there is a blank line or other closing markup immediately before closing blockquote markup `#/`, the wrapping code has a special check to avoid accidentally indenting the closing markup itself.

However, in the previous work (#1111) to ensure the markup was detected, even if the line was polluted with temporary page markers, the above case was overlooked. Hence, if there was a page marker on the closing markup line, the markup was indented during rewrap.

Using the `notpmselection` variable instead fixes the issue as expected.