### PR TITLE
Generate valid code for italic superscripts

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -59,6 +59,11 @@ sub html_convert_superscripts {
         $textwindow->ntinsert( "$step.0", $selection );
     }
 
+    if ( $selection =~ s/\^(<([a-zA-Z]+)>.<\/\g2>)/<sup>$1<\/sup>/g ) {
+        $textwindow->ntdelete( "$step.0", "$step.end" );
+        $textwindow->ntinsert( "$step.0", $selection );
+    }
+
     if ( $selection =~ s/\^(.)/<sup>$1<\/sup>/g ) {
         $textwindow->ntdelete( "$step.0", "$step.end" );
         $textwindow->ntinsert( "$step.0", $selection );


### PR DESCRIPTION
Since the "rule" is that single character superscripts do not require enclosing braces, that is what Guiguts did.

However, where a single character superscript is italicised, the rule is a little ambiguous and can therefore lead to markup such as `a^<i>x</i>` instead of
`a^{<i>x</i>}`
Handle this case by allowing a single character which is surrounded by "markup" to be superscripted without the enclosing braces. The chances of the reverse case of a book containing a single superscripted angle bracket immediately followed by apparently valid markup around a single character are vanishing small, so this seems a safe edit.