### PR TITLE
Use `insertit` function for all unicode insertions

### DIFF
--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -527,7 +527,7 @@ sub utfchar_bind {
         '<ButtonPress-1>',
         sub {
             $widget->configure( -relief => 'sunken' );
-            $::lglobal{hasfocus}->insert( 'insert', $widget->cget('-text') );
+            insertit( $widget->cget('-text') );
         }
     );
     $widget->bind(
@@ -616,7 +616,7 @@ sub utfcharentrypopup {
             -text    => 'Insert',
             -width   => 8,
             -command => sub {
-                $::lglobal{hasfocus}->insert( 'insert', $outentry->get( '1.0', 'end -1c' ) );
+                insertit( $outentry->get( '1.0', 'end -1c' ) );
             },
         )->grid( -row => 1, -column => 1 );
         $inentry->Tk::bind( '<Return>', sub { $insertbtn->invoke(); } );


### PR DESCRIPTION
The `insertit` function behaves like normal typing of a character would, i.e. deleting any selected text and replacing it with the inserted character. There were a couple of cases which used a plain insert instead of `insertit`

Fixes #1233