### PR TITLE
Really final fix for Mac nonexistent dir bug

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -2228,6 +2228,7 @@ sub htmlautoconvert {
 sub thumbnailbrowse {
     my $name = shift;
     unless ($name) {
+        $::globalimagepath = ::getsafelastpath() unless ( -d $::globalimagepath );
         my $types = [ [ 'Image Files', [ '.gif', '.jpg', '.png' ] ], [ 'All Files', ['*'] ], ];
         $name = $::lglobal{htmlimpop}->getOpenFile(
             -filetypes  => $types,

--- a/src/lib/Guiguts/Highlight.pm
+++ b/src/lib/Guiguts/Highlight.pm
@@ -19,7 +19,8 @@ my $TAGCH = "[a-z0-9]";    # Permissible characters in HTML tag name
 sub scannosfile {
     my $top = $::top;
     $::scannoslistpath = ::os_normal($::scannoslistpath);
-    my $types       = [ [ 'Text file', [ '.txt', ] ], [ 'All Files', ['*'] ], ];
+    my $types = [ [ 'Text file', [ '.txt', ] ], [ 'All Files', ['*'] ], ];
+    $::scannoslistpath = ::getsafelastpath() unless ( -d $::scannoslistpath );
     my $scannosfile = $top->getOpenFile(
         -title      => 'List of words to highlight?',
         -filetypes  => $types,

--- a/src/lib/Guiguts/Preferences.pm
+++ b/src/lib/Guiguts/Preferences.pm
@@ -417,10 +417,11 @@ sub setpngspath {
     my $textwindow = $::textwindow;
     my $top        = $::top;
 
-    #print $pagenum.'';
+    my $initialdir = "$::globallastpath" . "pngs";
+    $initialdir = ::getsafelastpath() unless ( -d $initialdir );
     my $path = $textwindow->chooseDirectory(
         -title      => 'Choose the PNGs file directory',
-        -initialdir => "$::globallastpath" . "pngs",
+        -initialdir => $initialdir,
     );
     return unless defined $path and -e $path;
     $path .= '/';
@@ -597,9 +598,11 @@ sub locateExecutable {
 sub locateDirectory {
     my ( $dirname, $dirpathref ) = @_;
     my $textwindow = $::textwindow;
+    my $initialdir = ::dirname( ${$dirpathref} );
+    $initialdir = ::getsafelastpath() unless ( -d $initialdir );
     $::lglobal{pathtemp} = $textwindow->chooseDirectory(
         -title      => "Where is your $dirname folder?",
-        -initialdir => ::dirname( ${$dirpathref} ),
+        -initialdir => $initialdir,
     );
     return unless $::lglobal{pathtemp};    # User cancelled
 

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -2124,6 +2124,7 @@ sub loadscannos {
     @{ $::lglobal{scannosarray} } = ();
     $::lglobal{scannosindex} = 0;
     my $types = [ [ 'Scannos', ['.rc'] ], [ 'All Files', ['*'] ], ];
+    $::scannospath = ::getsafelastpath() unless ( -d $::scannospath );
     $::lglobal{scannosfilename} = $top->getOpenFile(
         -filetypes  => $types,
         -title      => 'Scannos list?',


### PR DESCRIPTION
Searching for `initialdir` found all places that construct was used, which on Mac causes error if dir doesn't exist.
Replaced with default safe last path if dir doesn't exist.

Embarrassingly the third(?) time of fixing the last occurrence :)