### PR TITLE
Don't pop Page Marker Adjust when using next page

### DIFF
--- a/src/lib/Guiguts/StatusBar.pm
+++ b/src/lib/Guiguts/StatusBar.pm
@@ -357,7 +357,7 @@ sub update_img_button {
             -width      => 7,
             -background => 'gray',
             -relief     => 'ridge',
-        )->grid( -row => 1, -column => 3, -sticky => 'nw' );
+        )->grid( -row => 1, -column => 2, -sticky => 'nw' );
         $::lglobal{img_num_label}->bind(
             '<1>',
             sub {
@@ -445,7 +445,7 @@ sub update_prev_img_button {
             -width      => 2,
             -relief     => 'ridge',
             -background => 'gray',
-        )->grid( -row => 1, -column => 2 );
+        )->grid( -row => 1, -column => 3 );
         $::lglobal{previmagebutton}->bind(
             '<1>',
             sub {
@@ -469,7 +469,7 @@ sub update_see_img_button {
             -width      => 7,
             -relief     => 'ridge',
             -background => 'gray',
-        )->grid( -row => 1, -column => 5 );
+        )->grid( -row => 1, -column => 4 );
         $::lglobal{pagebutton}->bind( '<1>', \&seecurrentimage );
         $::lglobal{pagebutton}->bind( '<3>', sub { ::setpngspath() } );
         _butbind( $::lglobal{pagebutton} );
@@ -501,7 +501,7 @@ sub update_next_img_button {
             -width      => 2,
             -relief     => 'ridge',
             -background => 'gray',
-        )->grid( -row => 1, -column => 4 );
+        )->grid( -row => 1, -column => 5 );
         $::lglobal{nextimagebutton}->bind(
             '<1>',
             sub {

--- a/src/lib/Guiguts/StatusBar.pm
+++ b/src/lib/Guiguts/StatusBar.pm
@@ -357,7 +357,7 @@ sub update_img_button {
             -width      => 7,
             -background => 'gray',
             -relief     => 'ridge',
-        )->grid( -row => 1, -column => 2, -sticky => 'nw' );
+        )->grid( -row => 1, -column => 3, -sticky => 'nw' );
         $::lglobal{img_num_label}->bind(
             '<1>',
             sub {
@@ -445,7 +445,7 @@ sub update_prev_img_button {
             -width      => 2,
             -relief     => 'ridge',
             -background => 'gray',
-        )->grid( -row => 1, -column => 3 );
+        )->grid( -row => 1, -column => 2 );
         $::lglobal{previmagebutton}->bind(
             '<1>',
             sub {
@@ -469,7 +469,7 @@ sub update_see_img_button {
             -width      => 7,
             -relief     => 'ridge',
             -background => 'gray',
-        )->grid( -row => 1, -column => 4 );
+        )->grid( -row => 1, -column => 5 );
         $::lglobal{pagebutton}->bind( '<1>', \&seecurrentimage );
         $::lglobal{pagebutton}->bind( '<3>', sub { ::setpngspath() } );
         _butbind( $::lglobal{pagebutton} );
@@ -501,7 +501,7 @@ sub update_next_img_button {
             -width      => 2,
             -relief     => 'ridge',
             -background => 'gray',
-        )->grid( -row => 1, -column => 5 );
+        )->grid( -row => 1, -column => 4 );
         $::lglobal{nextimagebutton}->bind(
             '<1>',
             sub {

--- a/src/lib/Guiguts/StatusBar.pm
+++ b/src/lib/Guiguts/StatusBar.pm
@@ -450,15 +450,12 @@ sub update_prev_img_button {
             '<1>',
             sub {
                 $::lglobal{previmagebutton}->configure( -relief => 'sunken' );
-                ::displaypagenums();
-                ::pgfocus( -1, 'show' );
+                ::pgfocus(-1);
             }
         );
         _butbind( $::lglobal{previmagebutton} );
         $::lglobal{statushelp}->attach( $::lglobal{previmagebutton},
-            -balloonmsg =>
-              "Move to previous page in text and open image corresponding to previous current page in an external viewer."
-        );
+            -balloonmsg => "Move to previous start of page in text." );
     }
 }
 
@@ -509,15 +506,12 @@ sub update_next_img_button {
             '<1>',
             sub {
                 $::lglobal{nextimagebutton}->configure( -relief => 'sunken' );
-                ::displaypagenums();
-                ::pgfocus( +1, 'show' );
+                ::pgfocus(1);
             }
         );
         _butbind( $::lglobal{nextimagebutton} );
         $::lglobal{statushelp}->attach( $::lglobal{nextimagebutton},
-            -balloonmsg =>
-              "Move to next page in text and open image corresponding to next current page in an external viewer."
-        );
+            -balloonmsg => "Move to next start of page in text." );
     }
 }
 


### PR DESCRIPTION
When using the next/previous page icons on the status bar (`<` and `>`) it used to pop the Page Marker Adjust dialog, and turn off Auto Img if that was enabled. It would then move to the previous/next page marker and show the image, although it left the cursor just before the page marker, so in the status bar said you were on the page before the one that was shown.

Now more consistent. The two buttons move to the previous or next page marker as before, but only automatically show the image if Auto Img is enabled; using the buttons does not turn Auto Img off; the cursor is positioned 1 character into the correct page, i.e. the earliest point that counts as being on that page; it also briefly shows the yellow page marker labels, but doesn't pop the Marker Adjustment dialog.

Unused argument also removed from `togglepagenums()`