### PR TITLE
Clarify which count dialog is which

### DIFF
--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -2219,7 +2219,7 @@ sub quickcount {
 
     # Inform user
     my $dlg = $::top->Dialog(
-        -text    => "Count: $count        ",    # Extra space needed to force dialog wide enough for title
+        -text    => "Word Count: $count",
         -bitmap  => "info",
         -title   => "Word Count",
         -buttons => ['Ok']

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -2219,9 +2219,9 @@ sub quickcount {
 
     # Inform user
     my $dlg = $::top->Dialog(
-        -text    => "Count: $count",
+        -text    => "Count: $count        ",    # Extra space needed to force dialog wide enough for title
         -bitmap  => "info",
-        -title   => "Count",
+        -title   => "Word Count",
         -buttons => ['Ok']
     );
     $dlg->Tk::bind( '<Escape>' => sub { $dlg->Subwidget('B_Ok')->invoke; } );
@@ -2392,7 +2392,7 @@ sub quicksearchcountmatches {
     my $dlg = $::top->Dialog(
         -text    => searchnumtext($count),
         -bitmap  => "info",
-        -title   => "Count",
+        -title   => "QS Count",
         -buttons => ['Ok']
     );
     $dlg->Tk::bind( '<Escape>' => sub { $dlg->Subwidget('B_Ok')->invoke; } );


### PR DESCRIPTION
Show in the title of the two count dialogs which one is which. The one invoked from the main window on the selected text does a "whole word" search.
The other is from the "Quick Search" (QS) dialog.