### PR TITLE
Remove `Change All` button from Spell Check

### DIFF
--- a/src/lib/Guiguts/SpellCheck.pm
+++ b/src/lib/Guiguts/SpellCheck.pm
@@ -196,19 +196,6 @@ sub spellreplace {
 }
 
 #
-# Replace all instances of bad spelling with correction
-sub spellreplaceall {
-    my $textwindow = $::textwindow;
-    ::hidepagenums();
-    my $lastindex   = '1.0';
-    my $misspelled  = $::lglobal{misspelledentry}->get;
-    my $replacement = $::lglobal{spreplaceentry}->get;
-    my $repmatchindex;
-    $textwindow->FindAndReplaceAll( '-exact', '-nocase', $misspelled, $replacement );
-    spellignoreall();
-}
-
-#
 # Replace the replacement word with one from the guess list
 sub spellmisspelled_replace {
     ::hidepagenums();
@@ -585,7 +572,22 @@ sub spellchecker {
             -padx   => 3,
             -anchor => 'nw'
         );
-        my $dictmyaddbutton = $spf2->Button(
+        my $ignoreallbutton = $spf2->Button(
+            -command => sub {
+                ::busy();
+                spellignoreall();
+                spellchecknext();
+                ::unbusy();
+            },
+            -text  => 'Skip All <Ctrl+i>',
+            -width => 14,
+        )->pack(
+            -side   => 'left',
+            -pady   => 2,
+            -padx   => 3,
+            -anchor => 'nw'
+        );
+        my $dictmyaddbutton = $spf3->Button(
             -command => sub {
                 ::busy();
                 spellmyaddword( $::lglobal{misspelledentry}->get );
@@ -595,36 +597,6 @@ sub spellchecker {
             },
             -text  => 'Add To Project Dic. <Ctrl+p>',
             -width => 22,
-        )->pack(
-            -side   => 'left',
-            -pady   => 2,
-            -padx   => 3,
-            -anchor => 'nw'
-        );
-        my $replaceallbutton = $spf3->Button(
-            -command => sub {
-                ::busy();
-                spellreplaceall();
-                spellchecknext();
-                ::unbusy();
-            },
-            -text  => 'Change All',
-            -width => 14,
-        )->pack(
-            -side   => 'left',
-            -pady   => 2,
-            -padx   => 3,
-            -anchor => 'nw'
-        );
-        my $ignoreallbutton = $spf3->Button(
-            -command => sub {
-                ::busy();
-                spellignoreall();
-                spellchecknext();
-                ::unbusy();
-            },
-            -text  => 'Skip All <Ctrl+i>',
-            -width => 14,
         )->pack(
             -side   => 'left',
             -pady   => 2,


### PR DESCRIPTION
Several reasons have led to this:
1. PPers shouldn't really be doing a Change All because if there are lots of "wrong" spellings, they shouldn't be correcting them, imho.
2. The code as it stood changed not only words but parts of words, and ignored case, so if `ebu` was reported as a bad spelling, and the PPer did a Change All to `emu`, then the word `debug` would silently become `demug`, and `EBU` would be changed to `emu`
3. An alternative of making `Change All` respect word boundaries foundered on the known bug in Perl/Tk's `FindAndReplaceAll()`. The work-around for that (as has to be done in the S&R dialog code) then made the job too large, and it would also have relied on knowing Aspell's exact algorithm for considering something a "word". The question of case would also still remain - it's not obvious if it should be case sensitive or not, and we don't want to add a checkbox just for that.
4. The PPer reporting the issue thought removing the button was the best and safest option and I agreed.

Although it's not that clear from the diffs, the `spellreplaceall` function has been removed, the `Change All` button has been removed, and the other buttons have just been re-ordered so they appear in a sensible arrangement in the dialog.