### PR TITLE
Add history to Highlight Char/Regex entry field

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -236,6 +236,7 @@ our @recentfile;
 our @replace_history;
 our @search_history;
 our @quicksearch_history;
+our @highlight_history;
 our @sopt = ( 0, 0, 0, 0, 0 );                       # default is not whole word search
 our @wfsearchopt;
 our @userchars;                                      # user defined chars for common characters dialog

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -1024,6 +1024,14 @@ EOM
         }
         print $save_handle ");\n\n";
 
+        print $save_handle ("\@highlight_history = (\n");
+        @array = @::highlight_history;
+        for my $index (@array) {
+            $index = ::escapeforperlstring($index);
+            print $save_handle qq/\t"$index",\n/;
+        }
+        print $save_handle ");\n\n";
+
         print $save_handle ("\@multidicts = (\n");
         for my $index (@::multidicts) {
             print $save_handle qq/\t"$index",\n/;

--- a/src/lib/Guiguts/Highlight.pm
+++ b/src/lib/Guiguts/Highlight.pm
@@ -247,13 +247,20 @@ sub hilitepopup {
         $::lglobal{hilitepop}->title('Character Highlight');
         ::initialize_popup_with_deletebinding('hilitepop');
         my $hilitemode = 'exact';
-        my $f          = $::lglobal{hilitepop}->Frame->pack( -side => 'top', -anchor => 'n' );
+        my $f = $::lglobal{hilitepop}->Frame->pack( -side => 'top', -anchor => 'n', -padx => 3 );
         $f->Label( -text => 'Highlight Character(s) or Regex', )
           ->pack( -side => 'top', -pady => 2, -padx => 2, -anchor => 'n' );
-        my $entry = $f->Entry( -width => 40, )->pack(
+        $f->Button(
+            -command => sub {
+                ::entry_history( $::lglobal{highlightentry}, \@::highlight_history );
+            },
+            -image  => $::lglobal{hist_img},
+            -width  => 9,
+            -height => 15,
+        )->pack( -side => 'left', -anchor => 'w' );
+        $::lglobal{highlightentry} = $f->Entry( -width => 40, )->pack(
             -expand => 1,
             -fill   => 'x',
-            -padx   => 3,
             -pady   => 3,
             -anchor => 'n'
         );
@@ -285,9 +292,12 @@ sub hilitepopup {
             -width   => 16,
         )->grid( -row => 1, -column => 2, -padx => 2, -pady => 2 );
         $f3->Button(
-            -command => sub { hilite( $entry->get, $hilitemode ) },
-            -text    => 'Apply Highlights',
-            -width   => 16,
+            -command => sub {
+                hilite( $::lglobal{highlightentry}->get, $hilitemode );
+                ::add_entry_history( $::lglobal{highlightentry}->get, \@::highlight_history );
+            },
+            -text  => 'Apply Highlights',
+            -width => 16,
         )->grid( -row => 2, -column => 1, -padx => 2, -pady => 2 );
         $f3->Button(
             -command => \&::hiliteremove,
@@ -295,6 +305,7 @@ sub hilitepopup {
             -width   => 16,
         )->grid( -row => 2, -column => 2, -padx => 2, -pady => 2 );
     }
+    $::lglobal{highlightentry}->focus;
 }
 
 #

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -3218,6 +3218,7 @@ sub add_entry_history {
         push @$history_array_ref, $_;
         last if @$history_array_ref >= $::history_size;    # don't exceed maximum history size
     }
+    ::savesettings();
 }
 
 #


### PR DESCRIPTION
1. Use generic routines to add history pulldown (thanks past windy :)
2. Save highlight history to `setting.rc`
3. Add `savesettings` call to generic routine when history is altered (boo! past windy :)
3. Set focus to entry field when dialog is popped to improve UX