### PR TITLE
Ignore `@media` when open brace is on next line

### DIFF
--- a/src/lib/ppvchecks/pphtml.pl
+++ b/src/lib/ppvchecks/pphtml.pl
@@ -274,7 +274,7 @@ sub runProgram {
 
             # Either "{" on same line as class name, or on its own on next line
             if ( $incss and $line =~ /{/ or $count < $#book and $book[$count] =~ /^\s*{\s*$/ ) {
-                $line =~ s/\@media\s+[^\{]+\{//;      # Remove any @media query
+                $line =~ s/\@media\s+[^\{]+\{?//;     # Remove any @media query (including if brace is on next line)
                 $line =~ s/^(.*?)\{.*$/$1/;           # Remove any declaration block
                 $line =~ s/:{1,2}$validpattern//g;    # Remove any pseudo-classes/pseudo-elements (e.g. ::first-letter)
                 $line =~ s/#$validpattern//g;         # Remove any ids (e.g. #table1)


### PR DESCRIPTION
Previously, the code only stripped `@media` and any media types when there was a brace on the same line as the `@media`. If brace was on next line, then `media`, `print`, `screen`, etc. would be reported as "unused" classes.
Now, make the brace optional - strip it if it's there. If it's on the next line, it will be dealt with (ignored) there.