### PR TITLE
Improve regex checking

### DIFF
--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -173,7 +173,6 @@ our $defaultpngspath        = ::os_normal('pngs/');
 our $pngspath               = q{};
 our $projectid              = q{};
 our $recentfile_size        = 9;
-our $regexpentry            = q();
 our $rmargin                = 72;
 our $rmargindiff            = 1;
 our $rwhyphenspace          = 1;

--- a/src/lib/Guiguts/SearchReplaceMenu.pm
+++ b/src/lib/Guiguts/SearchReplaceMenu.pm
@@ -324,7 +324,7 @@ sub countmatches {
     my $count = 0;
     ++$count while searchtext( $searchterm, 2 );    # search very silently, counting matches
     $::lglobal{searchnumlabel}->configure( -text => searchnumtext($count) )
-      if defined $::lglobal{quicksearchpop};
+      if defined $::lglobal{searchpop};
 
     # restore saved globals
     $::searchstartindex         = $savesearchstartindex;


### PR DESCRIPTION
User can type regexes in 4 places: Search/Replace, Quick Search, Word Frequency, Search->Highlight Character, String or Regex.

Only the first had regex checking, changing the text color to red if the regex gave an error on compilation, and a weak error message if the user tried to actually search with the bad regex.

This commit improves the error message to report a sanitized version of the error or warning message for Search/Replace. It also applies the same color changing, error messages, and checks for switching between exact/regex as appropriate for the other 3 cases.

Validating doesn't always work well with having a variable bound to the text widget, so that has been removed if present, and the necessary functionality coded separately.