### PR TITLE
Replace not sign with hyphen in CP Char Subs

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -1400,6 +1400,7 @@ sub cpcharactersubs {
     $textwindow->addGlobStart;
     $textwindow->FindAndReplaceAll( '-exact', '-nocase', "\x{0009}", " " );     # tab --> space
     $textwindow->FindAndReplaceAll( '-exact', '-nocase', "\x{2014}", "--" );    # emdash --> double hyphen
+    $textwindow->FindAndReplaceAll( '-exact', '-nocase', "\x{00ac}", "-" );     # not sign --> hyphen
     $textwindow->FindAndReplaceAll( '-exact', '-nocase', "\x{2018}", "'" );     # left single quote --> straight
     $textwindow->FindAndReplaceAll( '-exact', '-nocase', "\x{2019}", "'" );     # right single quote --> straight
     $textwindow->FindAndReplaceAll( '-exact', '-nocase', "\x{201c}", "\"" );    # left double quote --> straight


### PR DESCRIPTION
Hyphens with specks are sometimes mis-OCRed as Not signs `¬`. Add to the list of replacements made in File->Content Providing-> CP Character Substitutions.

Fixes #1256