### PR TITLE
Various LaTeX-->HTML/SVG support features

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -7,7 +7,7 @@ BEGIN {
     our ( @ISA, @EXPORT );
     @ISA    = qw(Exporter);
     @EXPORT = qw(&errorcheckpop_up &spellquerycleardict &spellqueryinitialize &spellquerywfwordok
-      errorcheckillosnupdateneeded);
+      &errorcheckillosnupdateneeded &savetoerrortmpfile);
 }
 
 my @errorchecklines;

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -648,9 +648,10 @@ sub menu_tools_latextools {
     [
         [ 'command', 'Replace LaTeX quotes with curlies', -command => \&::latex_quotes_convert ],
         [ 'command', 'Create preview of selected LaTeX',  -command => \&::latex_preview_select ],
-        [ 'command', 'View preview in browser',      -command => \&::latex_preview_select_view ],
-        [ 'command', 'Convert file (m2svg)',         -command => \&::latex_svg_convert ],
-        [ 'command', 'View convert file in browser', -command => \&::latex_svg_convert_view ],
+        [ 'command', 'View preview in browser',        -command => \&::latex_preview_select_view ],
+        [ 'command', 'Convert file (m2svg)',           -command => \&::latex_svg_convert ],
+        [ 'command', 'View convert file in browser',   -command => \&::latex_svg_convert_view ],
+        [ 'command', 'Undo some HTML autogen changes', -command => \&::latex_undo_autogen ],
     ];
 }
 

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -432,7 +432,6 @@ sub menu_search_block {
 sub menu_tools {
     my ( $textwindow, $top ) = ( $::textwindow, $::top );
     [
-        menu_cascade( 'LaTeX Tools', &menu_tools_latextools ),
         [
             'command', 'Word Frequenc~y...',
             -accelerator => 'F5',
@@ -585,13 +584,8 @@ sub menu_tools {
                 $textwindow->addGlobEnd;
             }
         ],
+        menu_cascade( 'LaTeX Tools', &menu_tools_latextools ),
     ];
-}
-
-#
-# Create the Tools, LaTeX Tools submenu
-sub menu_tools_latextools {
-    [ [ 'command', 'Replace LaTeX quotes with curlies', -command => \&::latex_quotes_convert ], ];
 }
 
 #
@@ -645,6 +639,18 @@ sub menu_tools_convertfractions {
             'All to superscript/subscript',
             -command => sub { ::fractionconvert('supsub'); }
         ],
+    ];
+}
+
+#
+# Create the Tools, LaTeX Tools submenu
+sub menu_tools_latextools {
+    [
+        [ 'command', 'Replace LaTeX quotes with curlies', -command => \&::latex_quotes_convert ],
+        [ 'command', 'Create preview of selected LaTeX',  -command => \&::latex_preview_select ],
+        [ 'command', 'View preview in browser',      -command => \&::latex_preview_select_view ],
+        [ 'command', 'Convert file (m2svg)',         -command => \&::latex_svg_convert ],
+        [ 'command', 'View convert file in browser', -command => \&::latex_svg_convert_view ],
     ];
 }
 

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -71,6 +71,8 @@ sub menu_file {
 
         menu_cascade( 'Co~ntent Providing', &menu_file_content_providing ),
 
+        menu_cascade( '~LaTeX Tools', &menu_file_latextools ),
+
         [ 'separator', '' ],
         [ 'command',   '~Quit', -command => \&::_exit ],
     ];
@@ -151,6 +153,20 @@ sub menu_file_content_providing {
         [
             'command', 'CP Character S~ubstitutions', -command => sub { ::cpcharactersubs(); },
         ],
+    ];
+}
+
+#
+# Create the File, LaTeX Tools submenu
+sub menu_file_latextools {
+    [
+        [ 'command', 'Convert LaTeX ~page separators',     -command => \&::latex_pagesep_convert ],
+        [ 'command', 'Replace LaTeX ~quotes with curlies', -command => \&::latex_quotes_convert ],
+        [ 'command', 'Create preview of ~selected LaTeX',  -command => \&::latex_preview_select ],
+        [ 'command', '~View preview in browser',        -command => \&::latex_preview_select_view ],
+        [ 'command', '~Convert file (m2svg)',           -command => \&::latex_svg_convert ],
+        [ 'command', 'View converted file in ~browser', -command => \&::latex_svg_convert_view ],
+        [ 'command', 'Undo some HTML ~autogen changes', -command => \&::latex_undo_autogen ],
     ];
 }
 
@@ -584,7 +600,6 @@ sub menu_tools {
                 $textwindow->addGlobEnd;
             }
         ],
-        menu_cascade( 'LaTeX Tools', &menu_tools_latextools ),
     ];
 }
 
@@ -639,19 +654,6 @@ sub menu_tools_convertfractions {
             'All to superscript/subscript',
             -command => sub { ::fractionconvert('supsub'); }
         ],
-    ];
-}
-
-#
-# Create the Tools, LaTeX Tools submenu
-sub menu_tools_latextools {
-    [
-        [ 'command', 'Replace LaTeX quotes with curlies', -command => \&::latex_quotes_convert ],
-        [ 'command', 'Create preview of selected LaTeX',  -command => \&::latex_preview_select ],
-        [ 'command', 'View preview in browser',        -command => \&::latex_preview_select_view ],
-        [ 'command', 'Convert file (m2svg)',           -command => \&::latex_svg_convert ],
-        [ 'command', 'View convert file in browser',   -command => \&::latex_svg_convert_view ],
-        [ 'command', 'Undo some HTML autogen changes', -command => \&::latex_undo_autogen ],
     ];
 }
 

--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -432,6 +432,7 @@ sub menu_search_block {
 sub menu_tools {
     my ( $textwindow, $top ) = ( $::textwindow, $::top );
     [
+        menu_cascade( 'LaTeX Tools', &menu_tools_latextools ),
         [
             'command', 'Word Frequenc~y...',
             -accelerator => 'F5',
@@ -585,6 +586,12 @@ sub menu_tools {
             }
         ],
     ];
+}
+
+#
+# Create the Tools, LaTeX Tools submenu
+sub menu_tools_latextools {
+    [ [ 'command', 'Replace LaTeX quotes with curlies', -command => \&::latex_quotes_convert ], ];
 }
 
 #

--- a/src/lib/Guiguts/StatusBar.pm
+++ b/src/lib/Guiguts/StatusBar.pm
@@ -6,18 +6,20 @@ BEGIN {
     use Exporter();
     our ( @ISA, @EXPORT );
     @ISA    = qw(Exporter);
-    @EXPORT = qw(&_updatesel &buildstatusbar &seecurrentimage
+    @EXPORT = qw(&_updatesel &buildstatusbar &seecurrentimage &update_indicators
       &setlang &selection &gotoline &gotopage &gotolabel &set_auto_img);
 }
 
 #
 # Routine to update the status bar when something has changed.
+# Optional argument to force page number update even if cursor location hasn't changed
 {    # Start of block to localise persistent variables
     my $prev_line   = -1;
     my $prev_column = -1;
     my $pnum        = 0;
 
     sub update_indicators {
+        my $force      = shift;
         my $textwindow = $::textwindow;
         my $top        = $::top;
         my ( $last_line, $last_col ) = split( /\./, $textwindow->index('end') );
@@ -27,6 +29,7 @@ BEGIN {
           if ( $::lglobal{current_line_label} );
         my $mode             = $textwindow->OverstrikeMode;
         my $overstrke_insert = ' I ';
+
         if ($mode) {
             $overstrke_insert = ' O ';
         }
@@ -58,7 +61,7 @@ BEGIN {
 
         # get_page_number() can take a significant time to execute, so check if line/column
         # have changed since previous call - if not, page number is also unchanged.
-        $pnum        = ::get_page_number() if $line != $prev_line or $column != $prev_column;
+        $pnum = ::get_page_number() if $force or $line != $prev_line or $column != $prev_column;
         $prev_line   = $line;
         $prev_column = $column;
 

--- a/src/lib/Guiguts/TextProcessingMenu.pm
+++ b/src/lib/Guiguts/TextProcessingMenu.pm
@@ -500,7 +500,6 @@ sub text_quotes_convert {
     $top->Busy( -recurse => 1 );
     $textwindow->addGlobStart;
 
-    $::lglobal{quotesflagcount} = 0;
     text_quotes_double();
     text_quotes_single();
 
@@ -530,7 +529,6 @@ sub text_quotes_double {
                 and $linenum + 1 < $lineend
                 and $textwindow->get("$linenum.0 +1l") ne '"' ) {
                 $textwindow->insert( "$linenum.0 - 1l lineend", $FLAG );
-                $::lglobal{quotesflagcount}++;
             }
             $dqlevel = 0;
             next;
@@ -545,7 +543,6 @@ sub text_quotes_double {
             $edited = 1;
             if ( $dqlevel != 0 ) {                          # flag previous line if open not expected
                 $textwindow->insert( "$linenum.0 - 1l lineend", $FLAG );
-                $::lglobal{quotesflagcount}++;
             }
             $dqlevel = 1;
         }
@@ -575,24 +572,19 @@ sub text_quotes_double {
         # Check for various errors and flag/correct them
         if ( $line =~ s/$LDQ$/$RDQ/ ) {    # open quote end of line - change to close quote
             $line .= $FLAG;
-            $::lglobal{quotesflagcount}++;
             $dqlevel = 0;
         }
         if ( $line =~ /\w$LDQ/ ) {         # open quote preceded by word char
             $line .= $FLAG;
-            $::lglobal{quotesflagcount}++;
         }
         if ( $line =~ /$RDQ\w/ ) {         # close quote followed by word char
             $line .= $FLAG;
-            $::lglobal{quotesflagcount}++;
         }
         if ( $line =~ /$LDQ / ) {          # floating open quote
             $line .= $FLAG;
-            $::lglobal{quotesflagcount}++;
         }
         if ( $line =~ / $RDQ(?!(  |$))/ ) {    # floating close quote
             $line .= $FLAG;
-            $::lglobal{quotesflagcount}++;
         }
 
         $textwindow->replacewith( "$linenum.0", "$linenum.end", $line );


### PR DESCRIPTION
Tools support conversion of existing LaTeX file (one taken from PG for reprocessing & reposting as an HTML/SVG project) or a project that has been through the rounds with HTML/SVG as the target format.
1. Add `LaTeX Tools` submenu to the File menu
2. Convert LaTeX page separators (comment format used commonly by PG submitters) to Guiguts format to link pngs (if available) to the correct page, and also to allow setting of printed page numbers for HTML format.
3. Convert LaTeX-style curly quote markup to standard curly quotes
4. Preview selected piece of LaTeX from an HTML/SVG file (for use while checking/adjusting the chunks of LaTeX in the HTML file as it comes out of the rounds)
5. Preview whole file by converting HTML/SVG file using `m2svg` tool
6. HTML autogen is a bit overenthusiastic, e.g. changing ampersands to HTML entity codes everywhere, which would break LaTeX code that contains ampersands. Add option to undo such changes.