### PR TITLE
Stop misconversion of fractions like 1/100,000

### DIFF
--- a/src/lib/Guiguts/CharacterTools.pm
+++ b/src/lib/Guiguts/CharacterTools.pm
@@ -1157,7 +1157,7 @@ sub fractionconvert {
         $start = $textwindow->search(
             '-regexp',
             '-count' => \$length,
-            '--', '-?\d+' . $anyslash . '\d+(?!,\d)', $start, 'tempselend'    # Negative lookahead to avoid converting 1/2 in 1/2,000
+            '--', '-?\d+' . $anyslash . '\d+(?!\d*,\d)', $start, 'tempselend'    # Negative lookahead to avoid converting 1/2 in 1/2,000
         )
     ) {
         my $end        = "$start+${length}c";


### PR DESCRIPTION
GG is supposed to convert fractions that don't contain commas, to use super/subscript or Unicode characters.
E.g. 1/2000 will be converted, but 1/2,000 or 1/100,000 should not be. Previous negative lookahead caught 1/2,000 case, but converted the 1/10 in 1/100,000, since there was another digit before the comma.
Fixed by adding optional digits to the negative lookahead.

Fixes #1265 