### PR TITLE
Position coincident page marks in the correct order

### DIFF
--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -1283,7 +1283,7 @@ sub file_import_markup {
 sub interpretbinfile {
     my $textwindow = $::textwindow;
     my $markindex;
-    foreach my $mark ( sort keys %::pagenumbers ) {
+    foreach my $mark ( reverse sort keys %::pagenumbers ) {
         $markindex = $::pagenumbers{$mark}{offset};
         unless ($markindex) {
             delete $::pagenumbers{$mark};

--- a/src/lib/Guiguts/FileMenu.pm
+++ b/src/lib/Guiguts/FileMenu.pm
@@ -1283,7 +1283,7 @@ sub file_import_markup {
 sub interpretbinfile {
     my $textwindow = $::textwindow;
     my $markindex;
-    foreach my $mark ( reverse sort keys %::pagenumbers ) {
+    foreach my $mark ( sort keys %::pagenumbers ) {
         $markindex = $::pagenumbers{$mark}{offset};
         unless ($markindex) {
             delete $::pagenumbers{$mark};


### PR DESCRIPTION
If Pg123 and Pg124 were at the same location in the file, usually because Pg123 is blank, then when the page locations are loaded from the bin file and positioned in the text widget using "marks", the mark for Pg124 was inserted at the location where Pg123's mark was, and ended up before it in the text widget's internal list of marks.

Loading the marks in reverse order means that coincident marks appear in alphanumeric order,  which is preferable.

This was assumed to be the case by the HTML generation code when set to skip coincident pagenum spans. So this fixes #1272