### PR TITLE
Trap AutoIndex bug when no lines to process

### DIFF
--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -3289,8 +3289,11 @@ sub autoindex {
     my $first  = 1;
     my $indent = 0;
 
+    my $endstep = $textwindow->index('end');
+    $endstep =~ s/\..*//;
     while ( $textwindow->get( "$step.0", "$step.end" ) eq '' ) {
         $step++;
+        return if $step >= $endstep;
     }
     while ( $step <= $ler ) {
         my $selection = $textwindow->get( "$step.0", "$step.end" );


### PR DESCRIPTION
Attempting to run HTML -> AutoIndex when there are no non-blank lines before the end of file, e.g. on empty file, caused an infinite loop