### PR TITLE
Support bold/italic page numbers in AutoIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 
 ## Version 1.6.1
 
-- New 'Add Index Cross-references' feature links "See"/"Also see" references
-  to the relevant location in the index. References that cannot be linked
-  automatically are listed for manual linking
+- New 'Add Index Cross-references' feature links "See"/"Also see"/"See also"
+  references to the relevant location in the index. References that cannot be
+  linked automatically are listed for manual linking
 - Several tools added to support LaTeX/HTML/SVG workflow
 - CP Character Substitutions now include `¬` -> `-`
 - Bad words are loaded when good words file is loaded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
   selected text in the way other insertions do
 - HTML AutoIndex could sometimes loop forever if it didn't find suitable
   lines to convert to an index
+- HTML index generation did not recognise page numbers that were marked
+  up as bold or italic
 
 
 ## Version 1.6.0

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -4248,7 +4248,7 @@ sub indexxref {
     $textwindow->markSet( 'indexendmark', $indexend );    # Since row/col of indexend will change during insertions
     my $indexstart = pop(@ranges);
 
-    my $SEESTR     = '(also )*see';                       # Change this if needed for different languages
+    my $SEESTR     = '(also )?see( also)?';               # Change this if needed for different languages
     my $SEESTRLEN  = length($SEESTR);                     # Approx length just used for advancing search position
     my $seepos     = $indexstart;
     my $seesawnum  = 1;

--- a/src/lib/Guiguts/HTMLConvert.pm
+++ b/src/lib/Guiguts/HTMLConvert.pm
@@ -4216,14 +4216,14 @@ sub fracconv {
 # The rules are as follows:
 # 1. Number must be preceded by a comma (optionally close quote) then one or more spaces
 # 2. Number must be no more than 3 digits (word boundary \b used to avoid partial matches with 4 digit numbers)
-# 3. Page range may be specified by hyphen or ndash between two numbers
+# 3. Page range may be specified by hyphen/ndash and second number following the first
+# 4. Number or range may be marked up italic or bold, e.g. <b>123</b> or <i>123-124</i>
 sub addpagelinks {
     my $selection = shift;
     my $ndash     = "\x{2013}";
     my $rquot     = q(["'\x{201d}\x{2019}]);
     $selection =~
-      s/(,$rquot?) +(\d{1,3})([-$ndash])\b(\d{1,3})\b/$1 <a href="#$::htmllabels{pglabel}$2">$2$3$4<\/a>/g;
-    $selection =~ s/(,$rquot?) +\b(\d{1,3})\b/$1 <a href="#$::htmllabels{pglabel}$2">$2<\/a>/g;
+      s/(,$rquot?) +((<[ib]>)?\b(\d{1,3})([-$ndash]\d{1,3})?\b(<\/[ib]>)?)/$1 <a href="#$::htmllabels{pglabel}$4">$2<\/a>/g;
     return $selection;
 }
 


### PR DESCRIPTION
If page number was marked bold or italic, the autoindexing code did not convert it to a hyperlink.

Also, after using a capture group to capture the whole page number including any bold/italic markup, it was easier to combine the single page and page range cases into one regex.