### PR TITLE
Output context with "unmatched `#/`" message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   behavior
 - Basic Fixup options are now persistent across different runs of Guiguts
 - The Word Count and QuickSearch Count dialogs have clearer titles
+- "Unmatched `#/`" message when rewrapping now includes two lines of
+  context to help user track down which blockquote is failing
 - Included latest version of ebookmaker (0.12.36)
 - Included latest version of Epubcheck (5.1.0)
 - New TROUBLESHOOTING.md guide included with release

--- a/src/guiguts.pl
+++ b/src/guiguts.pl
@@ -322,6 +322,10 @@ BEGIN { *CORE::GLOBAL::die = \&::dieerror }
 # Redirect warn by overriding signal handler
 local $SIG{__WARN__} = \&::warnerror;
 
+# Ensure stdout & stderr accept utf8 characters
+binmode( STDOUT, ":utf8" );
+binmode( STDERR, ":utf8" );
+
 # An alternative for catching Tk background errors,
 # but they are caught by the warn override above
 # sub Tk::Error {

--- a/src/lib/Guiguts/SelectionMenu.pm
+++ b/src/lib/Guiguts/SelectionMenu.pm
@@ -504,6 +504,16 @@ sub selectrewrap {
                         ( $leftmargin, $firstmargin, $rightmargin ) = setblockmargins($::blockwrap);
                     } else {
                         ::warnerror("Close blockquote (#/) found with no matching open markup");
+
+                        # Last line in block is the closing markup, and output up to
+                        # two more context lines before that
+                        my @splitsel = split( /\n/, $notpmselection );
+                        my $ncontext = scalar @splitsel;
+                        $ncontext = 3 if $ncontext > 3;
+                        ::infoerror("Context:");
+                        for my $ln ( 1 .. $ncontext ) {
+                            ::infoerror("    $splitsel[$ln-$ncontext-1]");
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
Output up to two lines before the closing `#/` to give the user context if they have unmatched blockquote markup when rewrapping.

Also, set stdout & stderr to utf8 to avoid "wide character" errors when printing utf8 characters.