### PR TITLE
Add page marker flags feature

### DIFF
--- a/src/lib/Guiguts/MenuStructure.pm
+++ b/src/lib/Guiguts/MenuStructure.pm
@@ -97,10 +97,12 @@ sub menu_file_project {
         [ 'command',   'Set Pro~ject ID...',       -command => \&::setprojectid ],
         [ 'command',   'Set I~mage Directory...',  -command => \&::setpngspath ],
         [ 'separator', '' ],
-        [ 'command',   'Display/~Adjust Page Markers...', -command => \&::togglepagenums ],
-        [ 'command',   '~Guess Page Markers...',          -command => \&::file_guess_page_marks ],
-        [ 'command',   '~Set Page Markers',               -command => \&::file_mark_pages ],
-        [ 'command',   'Configure Page La~bels...',       -command => \&::pageadjust ],
+        [ 'command', 'Display/~Adjust Page Markers...', -command => \&::togglepagenums ],
+        [ 'command', '~Guess Page Markers...',          -command => \&::file_guess_page_marks ],
+        [ 'command', '~Set Page Markers',               -command => \&::file_mark_pages ],
+        [ 'command', '~Add Page Marker Flags',          -command => \&::add_page_marker_flags ],
+        [ 'command', '~Remove Page Marker Flags',       -command => \&::remove_page_marker_flags ],
+        [ 'command', 'Configure Page La~bels...',       -command => \&::pageadjust ],
     ];
 }
 

--- a/src/lib/Guiguts/Utilities.pm
+++ b/src/lib/Guiguts/Utilities.pm
@@ -1320,7 +1320,11 @@ sub initialize {
         -foreground => 'black',
         -background => 'grey'
     );    # From TextEdit.pm
-
+    $textwindow->tagConfigure(
+        'pageflag',
+        -foreground => 'black',
+        -background => 'gold',
+    );
     $textwindow->tagConfigure(
         'pagenum',
         -background  => 'yellow',


### PR DESCRIPTION
This feature is in GG2, and allows editing in a different editor without losing the page break positions.

In particular, swapping between GG1 & GG2 should be easy, but any other editor is OK too.

Linked with GG2 PR: https://github.com/DistributedProofreaders/guiguts-py/pull/272