### PR TITLE
Fix block markup check bug

### DIFF
--- a/src/lib/Guiguts/ErrorCheck.pm
+++ b/src/lib/Guiguts/ErrorCheck.pm
@@ -1822,7 +1822,8 @@ sub unmatcheditemsrun {
             if ($matchstr) {                            # Should always be true, since we're only passing valid items to matching subroutine
                 my $nest = ( defined $nestreg and $item =~ $nestreg );
                 my $matchidx =
-                  ::hilitematchfind( $index, $endidx, $item, $matchstr, $reverse, $nest );
+                  ::hilitematchfind( $index, $endidx, $item, $matchstr, $reverse, $nest,
+                    substr( $regexp, 0, 1 ) eq '^' );
                 unless ($matchidx) {                    # Failed to find a match
                     my ( $row, $col ) = split( /\./, $index );
                     my $error = sprintf( "%d:%d - %s not matched", $row, $col, $item );

--- a/src/lib/Guiguts/Highlight.pm
+++ b/src/lib/Guiguts/Highlight.pm
@@ -618,11 +618,12 @@ sub hilitematchfind {
     my $match      = shift;
     my $reverse    = shift;
     my $nest       = shift;
+    my $anchor     = shift;           # True for strings to only match if at start of line
     my $textwindow = $::textwindow;
 
     # Regex searches for either the tag or its match, since if nested you may find the tag
     # several times before finding the matches.
-    my $regexp = "(\Q$match\E|\Q$selection\E)";
+    my $regexp = ( $anchor ? "^" : "" ) . "(\Q$match\E|\Q$selection\E)";
 
     # If an HTML tag, don't want "<b" to match "</blockquote...", for example,
     # so use negative lookahead to ensure there's not an alphanumeric character


### PR DESCRIPTION
If the regex to match the markup being checked is
anchored at the start of a line (`^...etc`), then also anchor the regex that finds the match.

Fixes #1293 

Not attempting to fix other bugs that no-one has found, but are improved in GG2.