### PR TITLE
Fix clang on macOS

### DIFF
--- a/src/install_cpan_modules.pl
+++ b/src/install_cpan_modules.pl
@@ -38,6 +38,10 @@ $cpanm = "cpanm";
 # pointing to which might be the one that came with macOS.
 if ( $^O eq 'darwin' ) {
 
+    # https://xkcd.com/927/
+    $ENV{"CFLAGS"}   = "-std=c89";
+    $ENV{"CPPFLAGS"} = "-std=c89";
+
     # Intel
     if ( -e "/usr/local/bin/cpanm" ) {
         $cpanm = "perl /usr/local/bin/cpanm";


### PR DESCRIPTION
Adds clang/cpp arguments to fix build problem that has cropped up in more recent versions of clang/Xcode when users install Guiguts. In particular, compiling the Perl Tk module (installed via `install_cpan_modules.pl`) has been an issue recently, as reported by some Mac PPers.

Fixes #1312