### PR TITLE
Improve check for PPGEN commands inside paragraph

### DIFF
--- a/src/lib/ppvchecks/pphtml.pl
+++ b/src/lib/ppvchecks/pphtml.pl
@@ -117,8 +117,8 @@ sub runProgram {
             if ( $line =~ /&amp;amp/ ) {
                 printf LOGFILE ( "%d:0 Ampersand: %s\n", $count, $line );
             }
-            if ( $line =~ /<p>\./ ) {
-                printf LOGFILE ( "%d:0 Possible PPG command: %s\n", $count, $line );
+            if ( $line =~ /<p>\.[a-z]{2}/ ) {
+                printf LOGFILE ( "%d:0 Possible PPGEN command: %s\n", $count, $line );
             }
             if ( $line =~ /\`/ ) {
                 printf LOGFILE ( "%d:0 Tick-mark check: %s\n", $count, $line );


### PR DESCRIPTION
Rather than only check for a line beginning with a dot (inside a `<p>` tag), check for a more PPGEN-like pattern, to avoid false-positives such as a paragraph beginning with an ellipsis.

Should complain about this:
```html
<p>.pn +1</p>
```

But not about this:
```html
<p>... and they rode off into the sunset</p>
```
